### PR TITLE
Retail Demo Windows 10.

### DIFF
--- a/Winapp2.ini (for CCleaner)
+++ b/Winapp2.ini (for CCleaner)
@@ -20301,6 +20301,14 @@ Detect=HKLM\Software\Microsoft\ESENT
 Default=False
 RegKey1=HKLM\Software\Microsoft\ESENT\Process
 
+[Windows Retail Demo*]
+DetectOS=10.0|
+Section=3031
+Default=False
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft
+Default=False
+FileKey1=%CommonAppData%\Microsoft\Windows\RetailDemo|.*.|REMOVESELF
+
 [Windows Feedback*]
 DetectOS=10.0|
 Section=3031


### PR DESCRIPTION
This will delete the retail demo of Windows 10.
Warning seems to be not so important. Upon it's deletion, there's no problem with the OS.
But you won't be able to start the Retail Demo Mode, which is pretty useless for nomal users anyway.
For more benefit:
http://www.askvg.com/tip-hidden-secret-retail-demo-mode-in-windows-10/