### PR TITLE
Battle.Net rename

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -2856,7 +2856,7 @@ FileKey4=%LocalAppData%\Blizzard Entertainment\System Survey|*.log|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Client\Blizzard Launcher.*\Logs|*.*|RECURSE
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Client\Logs|*.*|RECURSE
 
-[Battle.net*]
+[Battle.Net*]
 Section=Games
 Detect=HKCU\Software\Blizzard Entertainment\Battle.net
 Default=False


### PR DESCRIPTION
only Optical Change from
Battle.net to Battle.Net
now all Entries are same written.