### PR TITLE
Refactor Winapp2.ini

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
-; Version: 171113
-; # of entries: 2,503
+; Version: 171115
+; # of entries: 2,376
 ; You can get the latest Winapp2 here: https://github.com/MoscaDotTo/Winapp2
 ; Any contributions are appreciated. Please send them to the link above.
 ; Is CCleaner taking too long to load with Winapp2? Please head to this link and follow the instructions: http://www.winapp2.com/howto.html
@@ -253,7 +253,7 @@ Detect1=HKCU\Software\Vivaldi
 Default=False
 FileKey1=%LocalAppData%\Google\Chrome*\Application\*\Installer|*.*|RECURSE
 FileKey2=%LocalAppData%\Google\Update\*\*\Installer|*.*|RECURSE
-FileKey3=%ProgramFiles%|GUT*tmp
+FileKey3=%ProgramFiles%\|GUT*tmp
 FileKey4=%ProgramFiles%\Google\Chrome*\Application\*\Installer|*.*|RECURSE
 FileKey5=%ProgramFiles%\Google\Update\*\*\Installer|*.*|RECURSE
 FileKey6=%LocalAppData%\Vivaldi\Application\*\Installer|*.*|RECURSE
@@ -790,8 +790,7 @@ FileKey1=%AppData%\Thunderbird\Profiles\*|webappsstore.sqlite
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\.NETFramework
 Default=False
-FileKey1=%WinDir%\Microsoft.NET\Framework\v4.0.30319\SetupCache|*.*|RECURSE
-FileKey2=%WinDir%\Microsoft.NET\Framework64\v4.0.30319\SetupCache|*.*|RECURSE
+FileKey1=%WinDir%\Microsoft.NET\Framework*\v4.0.30319\SetupCache|*.*|RECURSE
 
 [.NET Framework*]
 LangSecRef=3025
@@ -799,13 +798,10 @@ Detect=HKLM\Software\Microsoft\.NETFramework
 Default=False
 FileKey1=%LocalAppData%\IsolatedStorage|*.*|RECURSE
 FileKey2=%WinDir%\assembly\NativeImages_*\Temp|*.*|RECURSE
-FileKey3=%WinDir%\assembly\temp|*.*|REMOVESELF
-FileKey4=%WinDir%\assembly\tmp|*.*|REMOVESELF
-FileKey5=%WinDir%\Microsoft.NET\Framework\*\*\Logs|*.*|RECURSE
-FileKey6=%WinDir%\Microsoft.NET\Framework64\*\*\Logs|*.*|RECURSE
-FileKey7=%WinDir%\Microsoft.NET\Framework\*\Temporary ASP.NET Files|*.*|REMOVESELF
-FileKey8=%WinDir%\Microsoft.NET\Framework64\*\Temporary ASP.NET Files|*.*|REMOVESELF
-FileKey9=%WinDir%\System32\URTTemp|*.*|RECURSE
+FileKey3=%WinDir%\assembly\t*mp|*.*|REMOVESELF
+FileKey4=%WinDir%\Microsoft.NET\Framework*\*\*\Logs|*.*|RECURSE
+FileKey5=%WinDir%\Microsoft.NET\Framework*\*\Temporary ASP.NET Files|*.*|REMOVESELF
+FileKey6=%WinDir%\System32\URTTemp|*.*|RECURSE
 RegKey1=HKCU\Software\Microsoft\.NETFramework\SQM\Apps
 
 [.NET Reflector*]
@@ -854,10 +850,7 @@ FileKey2=%ProgramFiles%\Steam\SteamApps\common\140\140_Data|output_log.txt
 Section=Games
 Detect=HKCU\Software\ValuSoft
 Default=False
-FileKey1=%Documents%\18 WoS American Long Haul|*.log;*.crash
-FileKey2=%Documents%\18 WoS Extreme Trucker|*.log;*.crash
-FileKey3=%Documents%\18 WoS Extreme Trucker 2|*.log;*.crash
-FileKey4=%Documents%\18 WoS Haulin|*.log;*.crash
+FileKey1=%Documents%\18 WoS*|*.log;*.crash
 
 [1954 Alcatraz*]
 Section=Games
@@ -908,12 +901,7 @@ FileKey1=%LocalAppData%\360Browser\Browser\User Data\Default|Cookies
 LangSecRef=3029
 Detect=HKCU\Software\360Browser\Browser
 Default=False
-FileKey1=%LocalAppData%\360Browser\Browser\User Data\Default|Archived History
-FileKey2=%LocalAppData%\360Browser\Browser\User Data\Default|Current Tabs
-FileKey3=%LocalAppData%\360Browser\Browser\User Data\Default|History Provider Cache
-FileKey4=%LocalAppData%\360Browser\Browser\User Data\Default|Network Action Predictor
-FileKey5=%LocalAppData%\360Browser\Browser\User Data\Default|Top Sites
-FileKey6=%LocalAppData%\360Browser\Browser\User Data\Default|Visited Links
+FileKey1=%LocalAppData%\360Browser\Browser\User Data\Default|Archived History;Current Tabs;History Provider Cache;Network Action Predictor;Top Sites;Visited Links
 
 [360 Browser - Session*]
 LangSecRef=3029
@@ -936,20 +924,20 @@ DetectOS=10.0|
 Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.3DBuilder_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.3DBuilder_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.3DBuilder_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.3DBuilder_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.3DBuilder_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.3DBuilder_*\LocalCache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.3DBuilder_*\LocalState\Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.3DBuilder_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.3DBuilder_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.3DBuilder_*\AC\Temp|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.3DBuilder_*\LocalCache|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.3DBuilder_*\LocalState\Cache|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.3DBuilder_*\TempState|*.*|RECURSE
 
 [3DMark Logs*]
 Section=Games
 DetectFile=%Documents%\3DMark
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\3DMark|*.log|RECURSE
-FileKey2=%ProgramFiles%\Steam\SteamApps\common\3DMark|*.log|RECURSE
+FileKey1=%Documents%\3DMark|*.log
+FileKey2=%Documents%\3DMark\Log|*.*|REMOVESELF
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\3DMark|*.log|RECURSE
+FileKey4=%ProgramFiles%\Steam\SteamApps\common\3DMark|*.log|RECURSE
 
 [3DMark Saved Benchmarks*]
 Section=Games
@@ -1151,16 +1139,13 @@ Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.AccountsControl_cw5n1h2txyewy
 FileKey1=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.AccountsControl_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.AccountsControl_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.AccountsControl_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.AccountsControl_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.AccountsControl_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.AccountsControl_*\TempState|*.*|RECURSE
 
 [AccurateRip Cache*]
 LangSecRef=3023
@@ -1175,13 +1160,11 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\AccuWeather.AccuWeatherforWindows8_8zz2pj9h1h1d8
 DetectFile=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_8zz2pj9h1h1d8
 Default=False
-FileKey1=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.log|RECURSE
-FileKey5=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\AC\Temp|*.*
-FileKey6=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\LocalState|*.tmp
-FileKey7=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\TempState\Bing.Maps\Cache|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.log|RECURSE
+FileKey3=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\AC\Temp|*.*
+FileKey4=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\LocalState|*.tmp
+FileKey5=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\TempState\Bing.Maps\Cache|*.*|RECURSE
 
 [ACDSee 6.0 Standard Database*]
 LangSecRef=3021
@@ -1255,7 +1238,7 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData\Acebyte\Acebyte Utilities*\Log|
 Section=Games
 DetectFile=%LocalAppData%\Acer Arcade Deluxe
 Default=False
-FileKey1=%CommonAppData%|ArcadeDexluxe2.log
+FileKey1=%CommonAppData%\|ArcadeDexluxe2.log
 FileKey2=%LocalAppData%\Acer Arcade Deluxe|*.log
 FileKey3=%LocalAppData%\VirtualStore\ProgramData|ArcadeDexluxe2.log
 
@@ -1270,13 +1253,11 @@ RegKey2=HKCU\Software\AcooBrowser\Acoo Browser\Search\History
 LangSecRef=3024
 Detect=HKCU\Software\Acoustica\CD Label Maker
 Default=False
-FileKey1=%AppData%\Acoustica\CD Label Maker\backgrounds\cache|*.*|RECURSE
+FileKey1=%AppData%\Acoustica\CD Label Maker\*\cache|*.*|RECURSE
 FileKey2=%AppData%\Acoustica\CD Label Maker\cache|*.*|RECURSE
-FileKey3=%AppData%\Acoustica\CD Label Maker\layouts\cache|*.*|RECURSE
-FileKey4=%AppData%\Acoustica\CD Label Maker\shapes|*.*
-FileKey5=%AppData%\Acoustica\CD Label Maker\themes\cache|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Acoustica CD Label Maker\thumbs|*.*|RECURSE
-FileKey7=%ProgramFiles%\Acoustica CD Label Maker\thumbs|*.*|RECURSE
+FileKey3=%AppData%\Acoustica\CD Label Maker\shapes|*.*
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\Acoustica CD Label Maker\thumbs|*.*|RECURSE
+FileKey5=%ProgramFiles%\Acoustica CD Label Maker\thumbs|*.*|RECURSE
 
 [Acoustica Premium Edition 6*]
 LangSecRef=3023
@@ -1497,7 +1478,7 @@ FileKey2=%AppData%\Adobe\Elements Organizer\*\Organizer|*.txt;status.dat
 FileKey3=%AppData%\Adobe\Elements Smart Tag Agent\*\Logs|*.log
 FileKey4=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog\Watch Folder|*.txt;*.xml
 FileKey5=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog|face.thumb.9.cache;thumb.5.cache
-FileKey6=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog|WaldoData\waldo.cache
+FileKey6=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog\WaldoData\waldo.cache
 RegKey1=HKCU\Software\Adobe\Elements Organizer\11.0\CurrentMediaFilePath
 RegKey2=HKCU\Software\Adobe\Elements Organizer\12.0\CurrentMediaFilePath
 RegKey3=HKCU\Software\Adobe\Elements Organizer\13.0\CurrentMediaFilePath
@@ -1509,20 +1490,15 @@ LangSecRef=3023
 Detect=HKCU\Software\Macromedia\FlashPlayer
 DetectFile=%AppData%\Adobe\Flash Player
 Default=False
-FileKey1=%AppData%\Adobe\Flash Player\AFCache|*.*|RECURSE
-FileKey2=%AppData%\Adobe\Flash Player\AssetCache|*.*|RECURSE
-FileKey3=%AppData%\Adobe\Flash Player\Icon Cache|*.*|RECURSE
-FileKey4=%AppData%\Adobe\Flash Player\NativeCache|*.*|RECURSE
-FileKey5=%WinDir%\System32\Macromed\Flash|FlashInstall*.log;install.log
-FileKey6=%WinDir%\SysWOW64\Macromed\Flash|FlashInstall*.log;install.log
+FileKey1=%AppData%\Adobe\Flash Player\*Cache|*.*|RECURSE
+FileKey2=%WinDir%\System32\Macromed\Flash|FlashInstall*.log;install.log
+FileKey3=%WinDir%\SysWOW64\Macromed\Flash|FlashInstall*.log;install.log
 
 [Adobe Media Cache*]
 LangSecRef=3023
 DetectFile=%AppData%\Adobe\Common\Media Cache
 Default=False
-FileKey1=%AppData%\Adobe\Common\Media Cache|*.*|RECURSE
-FileKey2=%AppData%\Adobe\Common\Media Cache Files|*.*|RECURSE
-FileKey3=%AppData%\Adobe\Common\Thumbnail Cache|*.*|RECURSE
+FileKey1=%AppData%\Adobe\Common\*Cache*|*.*|RECURSE
 
 [Adobe Media Encoder*]
 LangSecRef=3023
@@ -1559,8 +1535,7 @@ FileKey1=%AppData%\Adobe\Photoshop Album\*.*|Logse*.txt
 [Adobe Photoshop CS2 More*]
 LangSecRef=3021
 Detect=HKCU\Software\Adobe\Photoshop\9.0
-DetectFile1=%AppData%\Adobe\CameraRaw\Cache
-DetectFile2=%AppData%\Adobe\Bridge\Cache
+DetectFile1=%AppData%\Adobe\*\Cache
 Default=False
 FileKey1=%AppData%\Adobe\CameraRaw\Cache|*.*|RECURSE
 FileKey2=%AppData%\Adobe\Bridge\Cache\Thumbnails|*.*|RECURSE
@@ -1591,7 +1566,7 @@ RegKey15=HKCU\Software\Adobe\Photoshop Elements\15.0\VisitedDirs|STARTUPIMAGEDIR
 LangSecRef=3023
 Detect=HKCU\Software\Adobe\Premiere Elements
 Default=False
-FileKey1=%CommonAppData%|StreamingMediaTechnologyLog.txt
+FileKey1=%CommonAppData%\|StreamingMediaTechnologyLog.txt
 FileKey2=%AppData%\Adobe\Premiere Elements\*\logs|*.*|RECURSE
 FileKey3=%AppData%\Adobe\Premiere Elements\*|Plugin Loading.log
 FileKey4=%Documents%\Adobe\Premiere Elements\*|*.log
@@ -1658,9 +1633,7 @@ RegKey6=HKCU\Software\Adobe\Adobe Synchronizer\11.0
 
 [Adobe Service Manager*]
 LangSecRef=3024
-DetectFile1=%AppData%\Adobe\Cs5servicemanager
-DetectFile2=%AppData%\Adobe\CS5.5ServiceManager
-DetectFile3=%AppData%\Adobe\CS6ServiceManager
+DetectFile=%AppData%\Adobe\Cs*servicemanager
 Default=False
 FileKey1=%AppData%\Adobe\CS*ServiceManager\Cache|*.*|RECURSE
 FileKey2=%AppData%\Adobe\CS*ServiceManager\Logs|*.*|RECURSE
@@ -1724,6 +1697,14 @@ RegKey2=HKLM\Software\AdwCleaner|SearchCount
 RegKey3=HKLM\Software\Wow6432node\AdwCleaner|DeleteCount
 RegKey4=HKLM\Software\Wow6432node\AdwCleaner|SearchCount
 
+[Aegisub Backups*]
+LangSecRef=3023
+Detect=HKLM\Software\Aegisub
+Default=False
+Warning=Aegisub automatically saves a backup copy of each script you open. This will delete them.
+FileKey1=%AppData%\Aegisub\autoback|*.*|REMOVESELF
+FileKey2=%AppData%\Aegisub\autosave|*.*|REMOVESELF
+
 [Aegisub*]
 LangSecRef=3023
 Detect=HKLM\Software\Aegisub
@@ -1734,14 +1715,6 @@ FileKey3=%AppData%\Aegisub\recovered|*.*|REMOVESELF
 FileKey4=%LocalAppData%\Aegisub\ffms2cache|*.*|REMOVESELF
 FileKey5=%LocalAppData%\VirtualStore\Program Files*\Aegisub|*.txt
 FileKey6=%ProgramFiles%\Aegisub|*.txt
-
-[Aegisub Backups*]
-LangSecRef=3023
-Detect=HKLM\Software\Aegisub
-Default=False
-Warning=Aegisub automatically saves a backup copy of each script you open. This will delete them.
-FileKey1=%AppData%\Aegisub\autoback|*.*|REMOVESELF
-FileKey2=%AppData%\Aegisub\autosave|*.*|REMOVESELF
 
 [Age of Conan*]
 Section=Games
@@ -1824,16 +1797,11 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Agomo\tmp_update|*.*
 FileKey2=%ProgramFiles%\Agomo\tmp_update|*.*
 
-[Ahead Nero 8 Logs*]
+[Ahead Nero 8*]
 LangSecRef=3021
 Detect=HKCU\Software\Nero\Nero8
 Default=False
 FileKey1=%AppData%\Nero\Nero8\Nero Burning ROM|*.log
-
-[Ahead Nero 8 MRU*]
-LangSecRef=3021
-Detect=HKCU\Software\Nero\Nero8
-Default=False
 RegKey1=HKCU\Software\Nero\Nero8\Cover Designer\Recent File List
 RegKey2=HKCU\Software\Nero\Nero8\Nero - Burning Rom\Recent File List
 
@@ -1897,17 +1865,12 @@ FileKey2=%AppData%\aignes\website-watcher\config\log|*.*
 FileKey3=%AppData%\aignes\WebSite-Watcher\config\settings|*.cfg_bak*
 FileKey4=%AppData%\aignes\website-watcher\config\temp|*.*
 
-[AIM Cache*]
-LangSecRef=3022
-DetectFile=%LocalAppData%\AOL\AIM
-Default=False
-FileKey1=%LocalAppData%\AOL\AIM\cache|*.*|REMOVESELF
-
-[AIM Logs*]
+[AIM*]
 LangSecRef=3022
 DetectFile=%LocalAppData%\AOL\AIM
 Default=False
 FileKey1=%LocalAppData%\AOL\AIM|*.log|RECURSE
+FileKey2=%LocalAppData%\AOL\AIM\cache|*.*|REMOVESELF
 
 [Aimersoft DRM Media Converter*]
 LangSecRef=3023
@@ -1941,9 +1904,8 @@ FileKey4=%ProgramFiles%\Aimersoft\Video Converter Ultimate\TempThumbDir|*.*|RECU
 
 [AIMP*]
 LangSecRef=3023
-DetectFile1=%ProgramFiles%\AIMP2\AIMP2.exe
-DetectFile2=%ProgramFiles%\AIMP\AIMP.exe
-DetectFile3=%ProgramFiles%\AIMP Classic\cAIMP.exe
+DetectFile1=%ProgramFiles%\AIMP*\AIMP*.exe
+DetectFile2=%ProgramFiles%\AIMP Classic\cAIMP.exe
 Default=False
 FileKey1=%AppData%\AIMP|*.bak
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\AIMP2\Data|*.bak|RECURSE
@@ -2021,12 +1983,6 @@ Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Aliens: Colonial
 Default=False
 FileKey1=%Documents%\My Games\Aliens Colonial Marines\PecanGame\Logs|*.*
 
-[AllDup Logs*]
-LangSecRef=3024
-DetectFile=%AppData%\AllDup
-Default=False
-FileKey1=%AppData%\AllDup|*.log
-
 [All In One Runtimes*]
 LangSecRef=3024
 DetectFile1=%SystemDrive%\AiO-Files
@@ -2054,6 +2010,12 @@ Section=Games
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\All Zombies Must Die!_is1
 Default=False
 FileKey1=%Documents%\My Games\UnrealEngine3\Bzb2Game\Logs|*.*
+
+[AllDup Logs*]
+LangSecRef=3024
+DetectFile=%AppData%\AllDup
+Default=False
+FileKey1=%AppData%\AllDup|*.log
 
 [Alternate File Shredder Logs*]
 LangSecRef=3024
@@ -2104,6 +2066,12 @@ DetectFile=%LocalAppData%\Amazon Cloud Player
 Default=False
 FileKey1=%LocalAppData%\Amazon Cloud Player\Logs|*.*
 
+[Amazon Downloader Logs*]
+LangSecRef=3024
+DetectFile=%Documents%\Amazon Downloader Logs
+Default=False
+FileKey1=%Documents%\Amazon Downloader Logs|*.*|RECURSE
+
 [Amazon Kindle for PC Session*]
 LangSecRef=3023
 Detect=HKCU\Software\Amazon\Kindle
@@ -2140,12 +2108,6 @@ LangSecRef=3024
 Detect=HKCU\Software\Amazon\Amazon Music
 Default=False
 FileKey1=%LocalAppData%\Amazon Music\Logs|*.*
-
-[Amazon Downloader Logs*]
-LangSecRef=3024
-DetectFile=%Documents%\Amazon Downloader Logs
-Default=False
-FileKey1=%Documents%\Amazon Downloader Logs|*.*|RECURSE
 
 [AMD/ATI*]
 LangSecRef=3024
@@ -2232,22 +2194,16 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\1ED5AEA5.AngryBirdsSpace_p2gbknwb5d8r2
 DetectFile=%LocalAppData%\Packages\1ED5AEA5.AngryBirdsSpace_p2gbknwb5d8r2
 Default=False
-FileKey1=%LocalAppData%\Packages\*.AngryBirdsSpace_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\*.AngryBirdsSpace_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\*.AngryBirdsSpace_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\*.AngryBirdsSpace_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey5=%LocalAppData%\Packages\*.AngryBirdsSpace_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
+FileKey1=%LocalAppData%\Packages\*.AngryBirdsSpace_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\*.AngryBirdsSpace_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 
 [Angry Birds Star Wars*]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\1ED5AEA5.AngryBirdsBlack_p2gbknwb5d8r2
 DetectFile=%LocalAppData%\Packages\1ED5AEA5.AngryBirdsBlack_p2gbknwb5d8r2
 Default=False
-FileKey1=%LocalAppData%\Packages\*.AngryBirdsBlack_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\*.AngryBirdsBlack_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\*.AngryBirdsBlack_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\*.AngryBirdsBlack_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey5=%LocalAppData%\Packages\*.AngryBirdsBlack_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
+FileKey1=%LocalAppData%\Packages\*.AngryBirdsBlack_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\*.AngryBirdsBlack_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 
 [Anim8or*]
 LangSecRef=3021
@@ -2275,13 +2231,8 @@ Section=Games
 DetectFile=%AppData%\Ubisoft\ANNO 2070
 Default=False
 FileKey1=%AppData%\Ubisoft\ANNO 2070\Cache|*.*|REMOVESELF
-
-[ANNO 2070 Logs*]
-Section=Games
-DetectFile=%AppData%\Ubisoft\ANNO 2070
-Default=False
-FileKey1=%AppData%\Ubisoft\ANNO 2070\Logs|*.log;*.dmp
-FileKey2=%AppData%\Ubisoft\ANNO 2070\Logs\netlogs|*.log
+FileKey2=%AppData%\Ubisoft\ANNO 2070\Logs|*.log;*.dmp
+FileKey3=%AppData%\Ubisoft\ANNO 2070\Logs\netlogs|*.log
 
 [Anvisoft Cloud System Booster Backups*]
 LangSecRef=3024
@@ -2404,7 +2355,7 @@ FileKey1=%LocalAppData%\ApplicationHistory|*.*|RECURSE
 [Apps CrashDumps*]
 DetectOS=6.2|
 Section=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\WinStore_cw5n1h2txyewy
+Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\WinStore_cw5n1h2txyewy
 Detect2=HKCU\SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsStore_8wekyb3d8bbwe
 Default=False
 Warning=This deletes crash dumps from Windows Store Apps.
@@ -2418,36 +2369,25 @@ FileKey1=%AppData%\Appupdater|appupdaterw.log
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Appupdater|*.log
 FileKey3=%CommonAppData%\Appupdater|*.log
 
-[AQQ Cache*]
-LangSecRef=3022
-Detect1=HKCU\Software\MyPortal\AQQ
-Detect2=HKCU\Software\Wapster\AQQ
-Default=False
-FileKey1=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\Avatars|*.*
-FileKey2=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\Cache|*.*
-FileKey3=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\LocalAvatars|*.*
-FileKey4=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\PrivateCache|*.*
-FileKey5=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\Avatars|*.*
-FileKey6=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\Cache|*.*
-FileKey7=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\LocalAvatars|*.*
-FileKey8=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\PrivateCache|*.*
-
 [AQQ Chat History*]
 LangSecRef=3022
 Detect1=HKCU\Software\MyPortal\AQQ
 Detect2=HKCU\Software\Wapster\AQQ
 Default=False
-FileKey1=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\Archive|*.DC2
-FileKey2=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\Archive|*.DC2
+FileKey1=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\Archive|*.DC2
+FileKey2=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\Temp|*.*
+FileKey3=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\Archive|*.DC2
+FileKey4=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\Temp|*.*
 
-[AQQ Temps*]
+[AQQ*]
 LangSecRef=3022
-Warning=This will delete your chat history.
 Detect1=HKCU\Software\MyPortal\AQQ
 Detect2=HKCU\Software\Wapster\AQQ
 Default=False
-FileKey1=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\Temp|*.*
-FileKey2=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\Temp|*.*
+FileKey1=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\*Avatars|*.*
+FileKey2=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\*Cache|*.*
+FileKey3=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\*Avatars|*.*
+FileKey4=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\*Cache|*.*
 
 [Arasan Chess*]
 Section=Games
@@ -2472,9 +2412,9 @@ FileKey2=%AppData%\ArcSoft\log|*.log
 LangSecRef=3024
 Detect=HKCU\Software\Argotronic\Argus Monitor
 Default=False
-FileKey1=%Documents%|ArgusMonitor_EventLog.txt;ArgusMonitor_CSVLog.csv
+FileKey1=%Documents%\|ArgusMonitor_EventLog.txt;ArgusMonitor_CSVLog.csv
 FileKey2=%LocalAppData%\VirtualStore\Program Files*|ArgusMonitor_EventLog.txt;ArgusMonitor_CSVLog.csv
-FileKey3=%ProgramFiles%|ArgusMonitor_EventLog.txt;ArgusMonitor_CSVLog.csv
+FileKey3=%ProgramFiles%\|ArgusMonitor_EventLog.txt;ArgusMonitor_CSVLog.csv
 
 [ARO 2011/2013*]
 LangSecRef=3024
@@ -2583,6 +2523,15 @@ RegKey79=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\VCD Project\SaveDia
 RegKey80=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\VIDEO_TS Disc Project\DumpImage|ImagePath
 RegKey81=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\VIDEO_TS Disc Project\SelectVideoTSFolder|VideoTSPath
 
+[Ashampoo Snap AutoSave*]
+LangSecRef=3024
+Detect1=HKCU\Software\Ashampoo\Ashampoo Snap 7
+Detect2=HKCU\Software\Ashampoo\Ashampoo Snap 8
+Detect3=HKCU\Software\Ashampoo\Ashampoo Snap 9
+Detect4=HKCU\Software\Ashampoo\Ashampoo Snap 10
+Default=False
+FileKey1=%Pictures%\Ashampoo Snap *\_SNAPDOC|*.*|RECURSE
+
 [Ashampoo Snap*]
 LangSecRef=3024
 Detect1=HKCU\Software\Ashampoo\Ashampoo Snap 7
@@ -2595,15 +2544,6 @@ FileKey2=%LocalAppData%\ashampoo\BaNT\product|*.*|RECURSE
 FileKey3=%LocalAppData%\CrashRpt\UnsentCrashReports|*.*|RECURSE
 FileKey4=%LocalAppData%\VirtualStore\Program Files*\Ashampoo\Ashampoo Snap *|_NLogMsg.txt
 FileKey5=%ProgramFiles%\Ashampoo\Ashampoo Snap *|_NLogMsg.txt
-
-[Ashampoo Snap AutoSave*]
-LangSecRef=3024
-Detect1=HKCU\Software\Ashampoo\Ashampoo Snap 7
-Detect2=HKCU\Software\Ashampoo\Ashampoo Snap 8
-Detect3=HKCU\Software\Ashampoo\Ashampoo Snap 9
-Detect4=HKCU\Software\Ashampoo\Ashampoo Snap 10
-Default=False
-FileKey1=%Pictures%\Ashampoo Snap *\_SNAPDOC|*.*|RECURSE
 
 [Ashley Jones - The Heart Of Egypt*]
 Section=Games
@@ -2618,33 +2558,18 @@ Default=False
 FileKey1=%AppData%\AstroGrep|AstroGrep.general.config
 FileKey2=%AppData%\AstroGrep\Log|*.log
 
-[ASUS AI Suite*]
+[ASUS Logs*]
 LangSecRef=3024
-DetectFile=%ProgramFiles%\ASUS\AI Suite*
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ASUS\AI Suite*|*.log;*log*.txt|RECURSE
-FileKey2=%ProgramFiles%\ASUS\AI Suite*|*.log;*log*.txt|RECURSE
-FileKey3=%SystemDrive%|wifi.log
-
-[ASUS AppStore*]
-LangSecRef=3021
-DetectFile=%CommonAppData%\Asus\AsusAppStore
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\ProgramData\Asus\AsusAppStore|*.log|RECURSE
-FileKey2=%CommonAppData%\Asus\AsusAppStore|*.log|RECURSE
-
-[ASUS Cool & Quiet*]
-LangSecRef=3024
-DetectFile=%ProgramFiles%\ASUS\Cool & Quiet
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ASUS\Cool & Quiet|*.log
-FileKey2=%ProgramFiles%\ASUS\Cool & Quiet|*.log
-
-[ASUS WebStorage Logs*]
-LangSecRef=3022
-DetectFile=%AppData%\ASUS WebStorage
+DetectFile1=%ProgramFiles%\ASUS\AI Suite
+DetectFile2=%CommonAppData%\Asus
+DetectFile3=%AppData%\ASUS WebStorage
 Default=False
 FileKey1=%AppData%\ASUS WebStorage\Logs|*.*
+FileKey2=%CommonAppData%\Asus\AsusAppStore|*.log|RECURSE
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\ASUS\*|*.log;*log*.txt|RECURSE
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\Asus\AsusAppStore|*.log|RECURSE
+FileKey5=%ProgramFiles%\ASUS\*|*.log;*log*.txt|RECURSE
+FileKey6=%SystemDrive%\|wifi.log
 
 [Atheros Driver Log*]
 LangSecRef=3021
@@ -2676,7 +2601,7 @@ FileKey2=%ProgramFiles%\Audio Sliders|*.log
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%LocalAppData%|DCBC2A71-70D8-4DAN-EHR8-E0D61DEA3FDF.ini
+FileKey1=%LocalAppData%\|DCBC2A71-70D8-4DAN-EHR8-E0D61DEA3FDF.ini
 
 [AudioGrail*]
 LangSecRef=3023
@@ -2689,7 +2614,7 @@ LangSecRef=3024
 Detect=HKCU\Software\Auslogics\BoostSpeed
 Default=False
 FileKey1=%AppData%\Auslogics|*.htm;*.html;*.log;*.rsc;*.sta;*.xml|RECURSE
-FileKey2=%CommonAppData%\Auslogics\BoostSpeed\7.x|*.err;*.htm;*.html;*.log;*.rsc;*.sta;*.xml|RECURSE
+FileKey2=%CommonAppData%\Auslogics\BoostSpeed\*.x|*.err;*.htm;*.html;*.log;*.rsc;*.sta;*.xml|RECURSE
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\Auslogics\Auslogics BoostSpeed|rdboot.log
 FileKey4=%ProgramFiles%\Auslogics\Auslogics BoostSpeed|rdboot.log
 RegKey1=HKCU\Software\Auslogics\BoostSpeed\5.x\Settings|DiskCleaner.AppLogic.ErrorsFailed
@@ -2726,28 +2651,16 @@ RegKey31=HKLM\SOFTWARE\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.
 
 [Auslogics Disk Defrag*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\Auslogics\DiskDefrag
+Detect1=HKLM\SOFTWARE\Auslogics\DiskDefrag
+Detect2=HKCU\Software\Auslogics\Disk Defrag Portable
+Detect3=HKLM\Software\Auslogics\DiskDefrag Portable
+Detect4=HKLM\Software\Auslogics\Disk Defrag Portable
+Detect5=HKLM\SOFTWARE\Auslogics\Disk Defrag Professional
 Default=False
-FileKey1=%CommonAppData%\Auslogics\DiskDefrag\*\Logs|*.*|RECURSE
-FileKey2=%CommonAppData%\Auslogics\DiskDefrag\*\Reports|*.*|RECURSE
-
-[Auslogics Disk Defrag Portable*]
-LangSecRef=3024
-Detect1=HKCU\Software\Auslogics\Disk Defrag Portable
-Detect2=HKLM\Software\Auslogics\DiskDefrag Portable
-Detect3=HKLM\Software\Auslogics\Disk Defrag Portable
-Default=False
-FileKey1=%AppData%\Auslogics\Disk Defrag\Reports|*.*
-FileKey2=%AppData%\Auslogics\Disk Defrag\Logs|*.*
-FileKey3=%CommonAppData%\Auslogics\Disk*Defrag Portable\*\Reports|*.*
-
-[Auslogics Disk Defrag Professional*]
-LangSecRef=3024
-Detect=HKLM\SOFTWARE\Auslogics\Disk Defrag Professional
-Default=False
-FileKey1=%CommonAppData%\Auslogics\Disk Defrag Professional\*\Logs|*.*|RECURSE
-FileKey2=%CommonAppData%\Auslogics\Disk Defrag Professional\*\Reports|*.*|RECURSE
-FileKey3=%ProgramFiles%\Auslogics\Disk Defrag Professional|ndefrg.log
+FileKey1=%AppData%\Auslogics\Disk*Defrag*\Reports|*.*|RECURSE
+FileKey2=%AppData%\Auslogics\Disk*Defrag*\Logs|*.*RECURSE
+FileKey3=%CommonAppData%\Auslogics\Disk*Defrag*\*\Reports|*.*
+FileKey4=%ProgramFiles%\Auslogics\Disk Defrag Professional|ndefrg.log
 
 [Auslogics Registry Cleaner*]
 LangSecRef=3024
@@ -2758,12 +2671,8 @@ Detect4=HKLM\Software\Auslogics\Registry Cleaner\5.X
 Default=False
 Warning=This will reset your scan results.
 FileKey1=%AppData%\Auslogics|*.htm;*.html;*.log;*.rsc;*.sta;*.xml|RECURSE
-FileKey2=%CommonAppData%\Auslogics\Registry Cleaner\3.x|*.htm;*.html;*.log|RECURSE
-FileKey3=%CommonAppData%\Auslogics\Registry Cleaner\4.x|*.htm;*.html;*.log|RECURSE
-FileKey4=%CommonAppData%\Auslogics\Registry Cleaner\5.X\Rescue\Auslogics Registry Cleaner|*.htm;*.html;*.log|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Auslogics\Registry Cleaner\3.x|*.htm;*.html;*.log|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Auslogics\Registry Cleaner\4.x|*.htm;*.html;*.log|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Auslogics\Registry Cleaner\5.X\Rescue\Auslogics Registry Cleaner|*.htm;*.html;*.log|RECURSE
+FileKey2=%CommonAppData%\Auslogics\Registry Cleaner\*.x|*.htm;*.html;*.log|RECURSE
+FileKey3=%LocalAppData%\VirtualStore\ProgramData\Auslogics\Registry Cleaner\3.x|*.htm;*.html;*.log|RECURSE
 RegKey1=HKCU\Software\Auslogics\Registry Cleaner\2.x\Settings|RegCleaner.AppLogic.ErrorsFailed
 RegKey2=HKCU\Software\Auslogics\Registry Cleaner\2.x\Settings|RegCleaner.AppLogic.ErrorsFound
 RegKey3=HKCU\Software\Auslogics\Registry Cleaner\2.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
@@ -2818,18 +2727,15 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\microsoft.windows.authhost.sso_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey7=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey8=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\PRICache|*.*
-FileKey10=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Temp|*.*
-FileKey11=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\PRICache|*.*
+FileKey7=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Temp|*.*
+FileKey8=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\TempState|*.*|RECURSE
 
 [Auto BCC For MS Outlook*]
 LangSecRef=3021
@@ -2859,7 +2765,7 @@ RegKey1=HKCU\Software\AutoDesk\DWF Common\Preferences\MRUList
 LangSecRef=3021
 Detect=HKCU\Software\AutoIt v3
 Default=False
-FileKey1=%UserProfile%|SciTE.*
+FileKey1=%UserProfile%\|SciTE.*
 RegKey1=HKCU\Software\AutoIt v3\Aut2Exe|LastExeDir
 RegKey2=HKCU\Software\AutoIt v3\Aut2Exe|LastIcon
 RegKey3=HKCU\Software\AutoIt v3\Aut2Exe|LastIconDir
@@ -2902,35 +2808,6 @@ FileKey11=%LocalAppData%\VirtualStore\ProgramData\AVAST Software\Browser|*.*|REC
 FileKey12=%LocalAppData%\VirtualStore\ProgramData\AVAST Software\Persistent Data\Avast\Logs|*.log
 RegKey1=HKCU\Software\AVAST Software\Avast Browser Cleanup
 
-[AVG*]
-LangSecRef=3024
-Detect=HKLM\SOFTWARE\AVG
-Default=False
-FileKey1=%CommonAppData%\Avg\AV\Antispam|*.tmp;*.tmp1;*.tmp2;*.gz
-FileKey2=%CommonAppData%\Avg\AV\SetupBackup|*.*|REMOVESELF
-FileKey3=%CommonAppData%\Avg\log\AV16|history.xml;*.log;*.log.*;*.log.lock
-FileKey4=%CommonAppData%\Avg\log\fmw1|*.log;*.log.*;*.log.lock
-FileKey5=%CommonAppData%\MFAData|msistorg.dat.bkp;public_installation_log.xml
-FileKey6=%CommonAppData%\MFAData\logs|*.*
-FileKey7=%CommonAppData%\MFAData\pack|*.*
-FileKey8=%LocalAppData%\Avg\log\av16|history.xml;*.log;*.log.*;*.log.lock
-FileKey9=%LocalAppData%\Avg\log\fmw1|*.log;*.log.*;*.log.lock
-FileKey10=%LocalAppData%\AvgSetupLog|*.*|REMOVESELF
-FileKey11=%LocalAppData%\MFAData\logs|*.*
-FileKey12=%ProgramFiles%\AVG\Av|updatecomps.bak;*.old
-FileKey13=%WinDir%\System32\config\systemprofile\AppData\Local\Avg\av16\temp|*.*
-FileKey14=%WinDir%\System32\config\systemprofile\AppData\Local\Avg\log\av16|history.xml;*.log;*.log.*;*.log.lock
-FileKey15=%WinDir%\System32\config\systemprofile\AppData\Local\Avg\log\fmw1|*.log;*.log.*;*.log.lock
-FileKey16=%WinDir%\System32\config\systemprofile\AppData\Local\AvgSetupLog|*.*|REMOVESELF
-FileKey17=%WinDir%\System32\config\systemprofile\Local Settings\Application Data\Avg\av16\temp|*.*
-FileKey18=%WinDir%\System32\config\systemprofile\Local Settings\Application Data\Avg\log\av16|history.xml;*.log;*.log.*;*.log.lock
-FileKey19=%WinDir%\System32\config\systemprofile\Local Settings\Application Data\Avg\log\fmw1|*.log;*.log.*;*.log.lock
-FileKey20=%WinDir%\System32\config\systemprofile\Local Settings\Application Data\AvgSetupLog|*.*|REMOVESELF
-FileKey21=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Avg\av16\temp|*.*
-FileKey22=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Avg\log\av16|history.xml;*.log;*.log.*;*.log.lock
-FileKey23=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Avg\log\fmw1|*.log;*.log.*;*.log.lock
-FileKey24=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\AvgSetupLog|*.*|REMOVESELF
-
 [AVG PC TuneUp & Utilities CrashDumps*]
 LangSecRef=3024
 Detect1=HKCU\Software\TuneUp
@@ -2964,20 +2841,43 @@ Detect3=HKCU\Software\TuneUp\Utilities\12.0
 Detect4=HKCU\Software\TuneUp\Utilities\13.0
 Detect5=HKCU\Software\TuneUp\Utilities\14.0
 Default=False
-FileKey1=%CommonAppData%|NTUSER.DAT_tureg_new.LOG1;NTUSER.DAT_tureg_new.LOG2;NTUSER.DAT_tureg_old
+FileKey1=%CommonAppData%\|NTUSER.DAT_tureg_new.LOG1;NTUSER.DAT_tureg_new.LOG2;NTUSER.DAT_tureg_old
 FileKey2=%LocalAppData%\Microsoft\Windows|USRCLASS.DAT_tureg_new.LOG*;USRCLASS.DAT_tureg_old
 FileKey3=%SystemDrive%\Boot|BCD_tureg_new.LOG*;BCD_tureg_old
-FileKey4=%SystemDrive%\Documents and Settings\LocalService|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey5=%SystemDrive%\Documents and Settings\LocalService.NT*|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey6=%SystemDrive%\Documents and Settings\NetworkService|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey7=%SystemDrive%\Documents and Settings\NetworkService.NT*|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey8=%SystemDrive%\Users\Public|NTUSER.DAT_tureg_new.LOG1;NTUSER.DAT_tureg_new.LOG2;NTUSER.DAT_tureg_old
-FileKey9=%UserProfile%|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey10=%WinDir%\ServiceProfiles\LocalService|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey11=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows|USRCLASS.DAT_tureg_old;USRCLASS.DAT_tureg_new.LOG*
-FileKey12=%WinDir%\ServiceProfiles\NetworkService|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey13=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows|USRCLASS.DAT_tureg_old;USRCLASS.DAT_tureg_new.LOG*
-FileKey14=%WinDir%\System32\config|COMPONENTS_tureg_new.LOG*;COMPONENTS_tureg_old;DEFAULT_tureg_new.LOG*;DEFAULT_tureg_old;SAM_tureg_new.LOG*;SAM_tureg_old;SECURITY_tureg_new.LOG*;SECURITY_tureg_old;SOFTWARE_tureg_new.LOG*;SOFTWARE_tureg_old;SYSTEM_tureg_new.LOG*;SYSTEM_tureg_old;DRIVERS_tureg_new.LOG*;DRIVERS_tureg_old;SOFTWARE_tureg_new;SYSTEM_tureg_new
+FileKey4=%SystemDrive%\Documents and Settings\LocalService*|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
+FileKey5=%SystemDrive%\Documents and Settings\NetworkService*|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
+FileKey6=%SystemDrive%\Users\Public|NTUSER.DAT_tureg_new.LOG1;NTUSER.DAT_tureg_new.LOG2;NTUSER.DAT_tureg_old
+FileKey7=%UserProfile%\|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
+FileKey8=%WinDir%\ServiceProfiles\LocalService|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
+FileKey9=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows|USRCLASS.DAT_tureg_old;USRCLASS.DAT_tureg_new.LOG*
+FileKey10=%WinDir%\ServiceProfiles\NetworkService|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
+FileKey11=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows|USRCLASS.DAT_tureg_old;USRCLASS.DAT_tureg_new.LOG*
+FileKey12=%WinDir%\System32\config|COMPONENTS_tureg_new.LOG*;COMPONENTS_tureg_old;DEFAULT_tureg_new.LOG*;DEFAULT_tureg_old;SAM_tureg_new.LOG*;SAM_tureg_old;SECURITY_tureg_new.LOG*;SECURITY_tureg_old;SOFTWARE_tureg_new.LOG*;SOFTWARE_tureg_old;SYSTEM_tureg_new.LOG*;SYSTEM_tureg_old;DRIVERS_tureg_new.LOG*;DRIVERS_tureg_old;SOFTWARE_tureg_new;SYSTEM_tureg_new
+
+[AVG*]
+LangSecRef=3024
+Detect=HKLM\SOFTWARE\AVG
+Default=False
+FileKey1=%CommonAppData%\Avg\AV\Antispam|*.tmp;*.tmp1;*.tmp2;*.gz
+FileKey2=%CommonAppData%\Avg\AV\SetupBackup|*.*|REMOVESELF
+FileKey3=%CommonAppData%\Avg\log\AV16|history.xml;*.log;*.log.*;*.log.lock
+FileKey4=%CommonAppData%\Avg\log\fmw1|*.log;*.log.*;*.log.lock
+FileKey5=%CommonAppData%\MFAData|msistorg.dat.bkp;public_installation_log.xml
+FileKey6=%CommonAppData%\MFAData\logs|*.*
+FileKey7=%CommonAppData%\MFAData\pack|*.*
+FileKey8=%LocalAppData%\Avg\log\av16|history.xml;*.log;*.log.*;*.log.lock
+FileKey9=%LocalAppData%\Avg\log\fmw1|*.log;*.log.*;*.log.lock
+FileKey10=%LocalAppData%\AvgSetupLog|*.*|REMOVESELF
+FileKey11=%LocalAppData%\MFAData\logs|*.*
+FileKey12=%ProgramFiles%\AVG\Av|updatecomps.bak;*.old
+FileKey13=%WinDir%\System32\config\systemprofile\*\*\Avg\av16\temp|*.*
+FileKey14=%WinDir%\System32\config\systemprofile\*\*\Avg\log\av16|history.xml;*.log;*.log.*;*.log.lock
+FileKey15=%WinDir%\System32\config\systemprofile\*\*\Avg\log\fmw1|*.log;*.log.*;*.log.lock
+FileKey16=%WinDir%\System32\config\systemprofile\*\*\AvgSetupLog|*.*|REMOVESELF
+FileKey17=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Avg\av16\temp|*.*
+FileKey18=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Avg\log\av16|history.xml;*.log;*.log.*;*.log.lock
+FileKey19=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Avg\log\fmw1|*.log;*.log.*;*.log.lock
+FileKey20=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\AvgSetupLog|*.*|REMOVESELF
 
 [Avi-Mux GUI*]
 LangSecRef=3023
@@ -2998,16 +2898,12 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_6hb943tstq5q8
 Default=False
 FileKey1=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey6=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0_32|*.log|RECURSE
-FileKey8=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0_32\NativeImages\Temp|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Temp|*.*
-FileKey10=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\LocalState|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
+FileKey4=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Temp|*.*
+FileKey6=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\LocalState|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\TempState|*.*|RECURSE
 
 [Avidemux log*]
 LangSecRef=3023
@@ -3047,21 +2943,15 @@ DetectFile=%CommonAppData%\Avira\VPN
 Default=False
 FileKey1=%CommonAppData%\Avira\VPN|*.log
 
-[Avira System Speedup Error Reports*]
+[Avira System Speedup*]
 LangSecRef=3024
 Detect1=HKLM\Software\AviraSpeedup
 Detect2=HKLM\Software\Avira\Speedup
 Default=False
 FileKey1=%CommonAppData%\Avira\SystemSpeedup\Errors|*.*
-
-[Avira System Speedup Logs*]
-LangSecRef=3024
-Detect1=HKLM\Software\AviraSpeedup
-Detect2=HKLM\Software\Avira\Speedup
-Default=False
-FileKey1=%CommonAppData%\Avira\SystemSpeedup\Logs|*.*
-FileKey2=%LocalAppData%\AviraSpeedup\logs|*.*
-FileKey3=%CommonAppData%\Avira\Launcher\Logfiles|*.log
+FileKey2=%CommonAppData%\Avira\SystemSpeedup\Logs|*.*
+FileKey3=%LocalAppData%\AviraSpeedup\logs|*.*
+FileKey4=%CommonAppData%\Avira\Launcher\Logfiles|*.log
 
 [AVS Audio Converter 6*]
 LangSecRef=3023
@@ -3073,7 +2963,7 @@ FileKey1=%AppData%\AVS4YOU\AVSAudioConverter6|recentfiles.*
 LangSecRef=3024
 Detect=HKLM\Software\AVS\DiscCreator
 Default=False
-FileKey1=%WinDir%|coredw.log;datawriter.log
+FileKey1=%WinDir%\|coredw.log;datawriter.log
 
 [Awesomium Cache*]
 LangSecRef=3021
@@ -3087,12 +2977,6 @@ DetectFile=%AppData%\Awesomium
 Default=False
 FileKey1=%AppData%\Awesomium\*|Cookies
 
-[Awesomium Logs*]
-LangSecRef=3021
-DetectFile=%AppData%\Awesomium
-Default=False
-FileKey1=%AppData%\Awesomium|*.log
-
 [Awesomium History*]
 LangSecRef=3021
 DetectFile=%AppData%\Awesomium
@@ -3104,6 +2988,12 @@ LangSecRef=3021
 DetectFile=%AppData%\Awesomium
 Default=False
 FileKey1=%AppData%\Awesomium\*\Local Storage|*.*|REMOVESELF
+
+[Awesomium Logs*]
+LangSecRef=3021
+DetectFile=%AppData%\Awesomium
+Default=False
+FileKey1=%AppData%\Awesomium|*.log
 
 [Axialis IconWorkshop More*]
 LangSecRef=3023
@@ -3163,25 +3053,15 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Rovio\Bad Piggies\BadPiggies_Data|output_log.txt
 FileKey2=%ProgramFiles%\Rovio\Bad Piggies\BadPiggies_Data|output_log.txt
 
-[Baidu PC Faster Dump Files*]
-LangSecRef=3024
-Detect=HKCU\Software\Baidu Security
-Default=False
-FileKey1=%Documents%\Baidu Security\Bav\Dump|*.*|REMOVESELF
-FileKey2=%Documents%\Baidu Security\PC Faster\*\Dump|*.*|REMOVESELF
-
-[Baidu PC Faster Log Files*]
-LangSecRef=3024
-Detect=HKCU\Software\Baidu Security
-Default=False
-FileKey1=%Documents%\Baidu Security\PC Faster\*\log|*.*|REMOVESELF
-
-[Baidu PC Faster Temporary Files*]
+[Baidu PC Faster*]
 LangSecRef=3024
 Detect=HKCU\Software\Baidu Security
 Default=False
 FileKey1=%CommonAppData%\Baidu Security\RpData|*.tmp
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Baidu Security\RpData|*.tmp
+FileKey2=%Documents%\Baidu Security\Bav\Dump|*.*|REMOVESELF
+FileKey3=%Documents%\Baidu Security\PC Faster\*\log|*.*|REMOVESELF
+FileKey4=%Documents%\Baidu Security\PC Faster\*\Dump|*.*|REMOVESELF
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\Baidu Security\RpData|*.tmp
 
 [Baidu Spark*]
 LangSecRef=3021
@@ -3196,7 +3076,7 @@ Warning=This will delete the contents of your output folder.
 Default=False
 FileKey1=%Documents%\Bandicam|*.*|RECURSE
 
-[Banished Crash dump*]
+[Banished*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\242920
 Default=False
@@ -3225,8 +3105,7 @@ Section=Games
 Detect1=HKLM\Software\Eidos Interactive Limited\Batman: Arkham Asylum
 Detect2=HKLM\Software\RocksteadyLtd\Batman Arkham Asylum
 Default=False
-FileKey1=%Documents%\Eidos\Batman Arkham Asylum\BmGame|*.log|RECURSE
-FileKey2=%Documents%\Square Enix\Batman Arkham Asylum GOTY\BmGame\Logs|Launch.log
+FileKey1=%Documents%\*\Batman Arkham Asylum*\BmGame|*.log|RECURSE
 
 [Batman: Arkham City*]
 Section=Games
@@ -3241,7 +3120,7 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\209000
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Batman Arkham Origins\SinglePlayer\BMGame\Logs|*.*
-FileKey2=%ProgramFiles%\Steam\steamapps\common\Batman Arkham Origins\SinglePlayer\BMGame\Logs|*.*
+FileKey2=%ProgramFiles%\Steam\steamapps\common\Batman Arkham Origins\SinglePlayer\BMGame\Logs
 
 [Battle Islands*]
 Section=Games
@@ -3254,38 +3133,24 @@ Section=Games
 Detect=HKCU\Software\Blizzard Entertainment\Battle.net
 Default=False
 FileKey1=%CommonAppData%\Battle.net|*.log|RECURSE
-FileKey2=%CommonAppData%\Battle.net\Agent\Agent.*\Logs|*.*|RECURSE
-FileKey3=%CommonAppData%\Battle.net\Agent\Logs|*.*|RECURSE
-FileKey4=%CommonAppData%\Battle.net\Setup\*\Logs|*.*
-FileKey5=%CommonAppData%\Battle.net\Telemetry|*.*
-FileKey6=%CommonAppData%\Blizzard Entertainment\Battle.net\Cache|*.*|REMOVESELF
-FileKey7=%LocalAppData%\Blizzard Entertainment\Battle.net\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Battle.net\Errors|*.*
-FileKey9=%LocalAppData%\Blizzard Entertainment\System Survey|log.txt
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Battle.net|*.log|RECURSE
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Agent\Agent.*\Logs|*.*|RECURSE
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Agent\Logs|*.*|RECURSE
-FileKey13=%LocalAppData%\VirtualStore\ProgramData\Blizzard Entertainment\Battle.net\Cache|*.*|REMOVESELF
-
-[Battle.net Client Cache*]
-Section=Games
-Detect=HKCU\Software\Blizzard Entertainment\Battle.net
-Default=False
-FileKey1=%CommonAppData%\BlizzardEntertainment\Battle.net\Cache|*.*|RECURSE
-FileKey2=%LocalAppData%\Battle.net\BrowserCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Battle.net\Cache|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\BlizzardEntertainment\Battle.net\Cache|*.*|RECURSE
-
-[Battle.Net Client Logs*]
-Section=Games
-Detect=HKCU\Software\Blizzard Entertainment\Battle.net
-Default=False
-FileKey1=%CommonAppData%\Battle.net\Client\Blizzard Launcher.*\Logs|*.*|RECURSE
-FileKey2=%CommonAppData%\Battle.net\Client\Logs|*.*|RECURSE
-FileKey3=%LocalAppData%\Battle.net\Logs|*.*|RECURSE
-FileKey4=%LocalAppData%\Blizzard Entertainment\System Survey|*.log|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Client\Blizzard Launcher.*\Logs|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Client\Logs|*.*|RECURSE
+FileKey2=%CommonAppData%\Battle.net\*\Logs|*.*|RECURSE
+FileKey3=%CommonAppData%\Battle.net\Agent\Agent.*\Logs|*.*|RECURSE
+FileKey4=%CommonAppData%\Battle.net\Client\Blizzard Launcher.*\Logs|*.*|RECURSE
+FileKey5=%CommonAppData%\Battle.net\Setup\*\Logs|*.*
+FileKey6=%CommonAppData%\Battle.net\Telemetry|*.*
+FileKey7=%CommonAppData%\Blizzard Entertainment\Battle.net\Cache|*.*|REMOVESELF
+FileKey8=%LocalAppData%\Battle.net\BrowserCache|*.*|RECURSE
+FileKey9=%LocalAppData%\Battle.net\Cache|*.*|RECURSE
+FileKey10=%LocalAppData%\Battle.net\Errors|*.*
+FileKey11=%LocalAppData%\Battle.net\Logs|*.*|RECURSE
+FileKey12=%LocalAppData%\Blizzard Entertainment\System Survey|*.log|RECURSE
+FileKey13=%LocalAppData%\Blizzard Entertainment\Battle.net\Cache|*.*|RECURSE
+FileKey14=%LocalAppData%\Blizzard Entertainment\System Survey|log.txt
+FileKey15=%LocalAppData%\VirtualStore\ProgramData\Battle.net|*.log|RECURSE
+FileKey16=%LocalAppData%\VirtualStore\ProgramData\Battle.net\*\Logs|*.*|RECURSE
+FileKey17=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Agent\Agent.*\Logs|*.*|RECURSE
+FileKey18=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Client\Blizzard Launcher.*\Logs|*.*|RECURSE
+FileKey19=%LocalAppData%\VirtualStore\ProgramData\Blizzard Entertainment\Battle.net\Cache|*.*|REMOVESELF
 
 [Battlefield 3*]
 Section=Games
@@ -3325,32 +3190,32 @@ FileKey7=%WinDir%\system32\MTSLog|*.*|REMOVESELF
 LangSecRef=3021
 Detect=HKCU\SOFTWARE\Beckhoff
 Default=False
-FileKey1=%UserProfile%|*TwinCat*.log;TC*.log;TF*.log
+FileKey1=%UserProfile%\|*TwinCat*.log;TC*.log;TF*.log
 FileKey2=%HomeDrive%\TwinCAT\3.1\Components\TcEventLogger\EventConfigurator|~evtCfgTmp*.html
 
 [Belarc Advisor*]
 LangSecRef=3024
 Detect=HKCU\Software\Belarc
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Belarc\Advisor\System|Progress.Log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Belarc\Advisor\System\Security\BelNotify|BelNotify.log;History.log;HistoryHF.log
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Belarc\Advisor\System\Tmp|*.*
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Belarc\BelArcAdvisor\System|Progress.Log
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Belarc\BelArcAdvisor\System\Security\BelNotify|BelNotify.log;History.log;HistoryHF.log
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Belarc\BelArcAdvisor\System\Tmp|*.*
-FileKey7=%ProgramFiles%\Belarc\Advisor\System|Progress.Log
-FileKey8=%ProgramFiles%\Belarc\Advisor\System\Security\BelNotify|BelNotify.log;History.log;HistoryHF.log
-FileKey9=%ProgramFiles%\Belarc\Advisor\System\Tmp|*.*
-FileKey10=%ProgramFiles%\Belarc\BelArcAdvisor\System|Progress.Log
-FileKey11=%ProgramFiles%\Belarc\BelArcAdvisor\System\Security\BelNotify|BelNotify.log;History.log;HistoryHF.log
-FileKey12=%ProgramFiles%\Belarc\BelArcAdvisor\System\Tmp|*.*
-FileKey13=%ProgramFiles%\Belarc\BelarcAdvisor|install.log
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Belarc\*Advisor\System|Progress.Log
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Belarc\*Advisor\System\Security\BelNotify|BelNotify.log;History.log;HistoryHF.log
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Belarc\*Advisor\System\Tmp|*.*
+FileKey4=%ProgramFiles%\Belarc\*Advisor\System|Progress.Log
+FileKey5=%ProgramFiles%\Belarc\*Advisor\System\Security\BelNotify|BelNotify.log;History.log;HistoryHF.log
+FileKey6=%ProgramFiles%\Belarc\*Advisor\System\Tmp|*.*
+FileKey7=%ProgramFiles%\Belarc\*Advisor|install.log
 
 [BestBuy Software Installer*]
 LangSecRef=3024
 DetectFile=%CommonAppData%\Best Buy Software Installer
 Default=False
 FileKey1=%CommonAppData%\Best Buy Software Installer\Resources\Cache|*.*
+
+[Betrayer*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\105430
+Default=False
+FileKey1=%Documents%\Betrayer\UDKGame\Logs|*.*
 
 [Better Explorer*]
 LangSecRef=3024
@@ -3379,6 +3244,13 @@ Default=False
 FileKey1=%CommonAppData%\JollyBear\Big City Adventure Sydney|error.*
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\JollyBear\Big City Adventure Sydney|error.*
 
+[Big Fish Games Installers*]
+Section=Games
+Detect=HKCU\Software\Big Fish Games
+Default=False
+FileKey1=%CommonAppData%\BigFishCache|*.exe|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\ProgramData\BigFishCache|*.exe|RECURSE
+
 [Big Fish Games*]
 Section=Games
 Detect=HKCU\Software\Big Fish Games
@@ -3392,19 +3264,18 @@ FileKey6=%LocalAppData%\VirtualStore\ProgramData\Big Fish Games\Game Manager\res
 FileKey7=%LocalAppData%\VirtualStore\ProgramData\BigFishCache\GameManager\log|*.txt|RECURSE
 FileKey8=%LocalAppData%\VirtualStore\ProgramData\BigFishGamesCache\GameManager\log|*.*
 
-[Big Fish Games Installers*]
-Section=Games
-Detect=HKCU\Software\Big Fish Games
-Default=False
-FileKey1=%CommonAppData%\BigFishCache|*.exe|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\BigFishCache|*.exe|RECURSE
-
 [Binding of Isaac Afterbirth+*]
 Section=Games
 Detect=HKCU\SOFTWARE\Valve\Steam\Apps\570660
 DetectFile=%Documents%\My Games\Binding of Isaac Afterbirth+
 Default=False
 FileKey1=%Documents%\My Games\Binding of Isaac Afterbirth+|*.dmp;isaacv*.txt;log.txt
+
+[Binding of Isaac Rebirth*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\250900
+Default=False
+FileKey1=%Documents%\my games\Binding of Isaac Rebirth|log.txt
 
 [Bing Dynamic*]
 LangSecRef=3023
@@ -3504,20 +3375,17 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\Microsoft.BingWeather_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\CLR_v4.0|*.log
-FileKey6=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\PRICache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Temp|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState|*.tmp
-FileKey13=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\Cache|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.BingWeather_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\CLR_v4.0|*.log
+FileKey4=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\PRICache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Temp|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState|*.tmp
+FileKey10=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\Cache|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.BingWeather_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingWeather_8wekyb3d8bbwe\SearchHistory
 
 [BioShock Infinite*]
@@ -3556,7 +3424,7 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Softwin\Bitdefender*\Logs|*.*
 FileKey2=%ProgramFiles%\Softwin\Bitdefender*\Logs|*.*
 FileKey3=%AppData%\Bitdefender\Desktop\profiles\Logs\*|*.xml
-FileKey4=%SystemDrive%|bdlog.txt
+FileKey4=%SystemDrive%\|bdlog.txt
 
 [BITS Logs*]
 LangSecRef=3025
@@ -3583,19 +3451,14 @@ DetectFile2=%ProgramFiles%\BitTorrent\BitTorrent.exe
 Default=False
 FileKey1=%AppData%\BitTorrent\Updates|*.exe
 
-[BlackBeltPrivacy DarkNet Logs*]
-LangSecRef=3023
-DetectFile=%LocalAppData%\BlackBeltPrivacy
-Default=False
-FileKey1=%LocalAppData%\BlackBeltPrivacy\darkNet\logs|*.*|RECURSE
-FileKey2=%LocalAppData%\BlackBeltPrivacy\Logs|*.*|RECURSE
-FileKey3=%LocalAppData%\BlackBeltPrivacy\MicroSip|MicroSIP.log
-
-[BlackBeltPrivacy DarkNet Runtime*]
+[BlackBeltPrivacy DarkNet*]
 LangSecRef=3023
 DetectFile=%LocalAppData%\BlackBeltPrivacy
 Default=False
 FileKey1=%LocalAppData%\BlackBeltPrivacy\3rdParty|*.*|RECURSE
+FileKey2=%LocalAppData%\BlackBeltPrivacy\darkNet\logs|*.*|RECURSE
+FileKey3=%LocalAppData%\BlackBeltPrivacy\Logs|*.*|RECURSE
+FileKey4=%LocalAppData%\BlackBeltPrivacy\MicroSip|MicroSIP.log
 
 [BlackBerry AddinSync*]
 LangSecRef=3021
@@ -3608,7 +3471,7 @@ LangSecRef=3023
 Detect=HKCU\Software\Research In Motion\BlackBerry
 Default=False
 FileKey1=%AppData%\Research In Motion\BlackBerry Desktop|*.dmp
-FileKey2=%AppData%|Rim*.log
+FileKey2=%AppData%\|Rim*.log
 FileKey3=%LocalAppData%\Research In Motion\BlackBerry*Desktop\*\*|*.backup
 FileKey4=%LocalAppData%\Research In Motion\BlackBerry*Desktop\*\*\Log|*.html
 FileKey5=%LocalAppData%\Research In Motion\BlackBerry*Desktop\Logs|*.*|REMOVESELF
@@ -3661,12 +3524,12 @@ FileKey1=%ProgramFiles%\Blimb Entertainment\AIRSTRIKE3D|*.log
 LangSecRef=3021
 Detect=HKCU\Software\VSO\Blindwrite
 Default=False
-FileKey1=%AppData%|pcouffin.log;ezplay.log
+FileKey1=%AppData%\|pcouffin.log;ezplay.log
 FileKey2=%AppData%\VSO|*.log|REMOVESELF
 FileKey3=%CommonAppData%\VSO\Blindwrite\*|*.log|REMOVESELF
 FileKey4=%Documents%\PcSetup|*.log|REMOVESELF
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\VSO\Blindwrite\*|*.log|REMOVESELF
-FileKey6=%UserProfile%|timestamp.txt
+FileKey6=%UserProfile%\|timestamp.txt
 
 [Blood Bowl: Legendary Edition*]
 Section=Games
@@ -3758,19 +3621,19 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\BOINC|stdout*.*;stderr*.*
 FileKey2=%ProgramFiles%\BOINC|stdout*.*;stderr*.*
 
-[Borderlands*]
-Section=Games
-Detect1=HKCU\Software\Valve\Steam\Apps\8980
-Detect2=HKLM\Software\Borderlands
-Default=False
-FileKey1=%Documents%\My Games\Borderlands*\WillowGame\Logs|*.log
-
 [Borderlands 2*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\49520
 DetectFile=%Documents%\My Games\Borderlands 2
 Default=False
 FileKey1=%Documents%\My Games\Borderlands 2\WillowGame\Logs|*.*
+
+[Borderlands*]
+Section=Games
+Detect1=HKCU\Software\Valve\Steam\Apps\8980
+Detect2=HKLM\Software\Borderlands
+Default=False
+FileKey1=%Documents%\My Games\Borderlands*\WillowGame\Logs|*.log
 
 [Borland C++ Builder 5.0*]
 LangSecRef=3024
@@ -3808,18 +3671,13 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\134D4F5B.Box_2qk4zy5s3qmee
 Default=False
 FileKey1=%LocalAppData%\Packages\*Box_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\*Box_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\*Box_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\*Box_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\*Box_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey6=%LocalAppData%\Packages\*Box_*\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\*Box_*\AC\Microsoft\CLR_v4.0_32|*.log|RECURSE
-FileKey8=%LocalAppData%\Packages\*Box_*\AC\Microsoft\CLR_v4.0_32\NativeImages\Temp|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\*Box_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey10=%LocalAppData%\Packages\*Box_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey11=%LocalAppData%\Packages\*Box_*\AC\PRICache|*.*
-FileKey12=%LocalAppData%\Packages\*Box_*\AC\Temp|*.*
-FileKey13=%LocalAppData%\Packages\*Box_*\LocalState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\*Box_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\*Box_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
+FileKey4=%LocalAppData%\Packages\*Box_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\*Box_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey6=%LocalAppData%\Packages\*Box_*\AC\PRICache|*.*
+FileKey7=%LocalAppData%\Packages\*Box_*\AC\Temp|*.*
+FileKey8=%LocalAppData%\Packages\*Box_*\LocalState|*.*|RECURSE
 
 [Breevy Backups*]
 LangSecRef=3021
@@ -3862,6 +3720,12 @@ FileKey1=%CommonAppData%\Brother\BrLog|*.log
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Brother|*.tmp|RECURSE
 FileKey3=%ProgramFiles%\Brother|*.tmp|RECURSE
 
+[Brothers - A Tale of Two Sons*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\225080
+Default=False
+FileKey1=%Documents%\my games\UnrealEngine3\P13\Logs|*.*
+
 [Browser Exit Codes*]
 LangSecRef=3029
 Detect1=HKCU\Software\Chromium\BrowserExitCodes
@@ -3887,13 +3751,12 @@ FileKey2=%AppData%\BSplayer\cache|*.*
 FileKey3=%AppData%\BSplayer\FFDShow|unreg.log
 FileKey4=%AppData%\BSplayer\Flash Video (FLV)|unreg.log
 FileKey5=%AppData%\BSplayer\Haali media splitter|unreg.log
-FileKey6=%AppData%\BSplayer\MPEG audio decoder|unreg.log
-FileKey7=%AppData%\BSplayer\MPEG2 decoder|unreg.log
-FileKey8=%AppData%\BSplayer\RealMedia splitter|unreg.log
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\Webteh\BSplayerPro|*.jpg
-FileKey10=%LocalAppData%\VirtualStore\Program Files*\Webteh\BSplayerPro\cache|*.mpos
-FileKey11=%ProgramFiles%\Webteh\BSplayerPro|*.jpg
-FileKey12=%ProgramFiles%\Webteh\BSplayerPro\cache|*.mpos
+FileKey6=%AppData%\BSplayer\MPEG*decoder|unreg.log
+FileKey7=%AppData%\BSplayer\RealMedia splitter|unreg.log
+FileKey8=%LocalAppData%\VirtualStore\Program Files*\Webteh\BSplayerPro|*.jpg
+FileKey9=%LocalAppData%\VirtualStore\Program Files*\Webteh\BSplayerPro\cache|*.mpos
+FileKey10=%ProgramFiles%\Webteh\BSplayerPro|*.jpg
+FileKey11=%ProgramFiles%\Webteh\BSplayerPro\cache|*.mpos
 
 [BSD Cache*]
 LangSecRef=3023
@@ -3957,19 +3820,17 @@ FileKey1=%LocalAppData%\Bump Technologies, Inc\BumpTop\Temp|*.*
 
 [Burger Shop*]
 Section=Games
-Detect=HKCU\Software\GoBit\BurgerShop
+Detect1=HKCU\Software\GoBit\BurgerShop
 Detect2=HKCU\Software\GoBit\BurgerShop2
 Default=False
-FileKey1=%CommonAppData%\GoBit Games\BurgerShop2\BigFishGames\cached|*.*|REMOVESELF
-FileKey2=%CommonAppData%\GoBit Games\BurgerShop2\GoBit\cached|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Burger Shop|*.db;*.txt|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Burger Shop\cached|*.*|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\GoBit Games\Burger Shop 2|*.db;*.txt|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\GoBit Games\BurgerShop2\BigFishGames\cached|*.*|REMOVESELF
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\GoBit Games\BurgerShop2\GoBit\cached|*.*|REMOVESELF
-FileKey8=%ProgramFiles%\Burger Shop|*.db;*.txt|RECURSE
-FileKey9=%ProgramFiles%\Burger Shop\cached|*.*|REMOVESELF
-FileKey10=%ProgramFiles%\GoBit Games\Burger Shop 2|*.db;*.txt|RECURSE
+FileKey1=%CommonAppData%\GoBit Games\BurgerShop2\*\cached|*.*|REMOVESELF
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Burger Shop|*.db;*.txt|RECURSE
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Burger Shop\cached|*.*|REMOVESELF
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\GoBit Games\Burger Shop 2|*.db;*.txt|RECURSE
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\GoBit Games\BurgerShop2\*\cached|*.*|REMOVESELF
+FileKey6=%ProgramFiles%\Burger Shop|*.db;*.txt|RECURSE
+FileKey7=%ProgramFiles%\Burger Shop\cached|*.*|REMOVESELF
+FileKey8=%ProgramFiles%\GoBit Games\Burger Shop 2|*.db;*.txt|RECURSE
 
 [Burn Zombie Burn! .NET Installer*]
 Section=Games
@@ -4069,30 +3930,20 @@ FileKey1=%Documents%\Call Of Juarez*\Out\logs|*.log|RECURSE
 
 [Camera*]
 LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Camera_8wekyb3d8bbwe
+Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Camera_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsCamera_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.Camera_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Camera_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Camera_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Camera_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Camera_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Camera_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey7=%LocalAppData%\Packages\Microsoft.Camera_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey8=%LocalAppData%\Packages\Microsoft.Camera_*\AC\PRICache|*.*
-FileKey9=%LocalAppData%\Packages\Microsoft.Camera_*\AC\Temp|*.*
-FileKey10=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\AppCache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\INetCache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\INetCookies|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\INetHistory|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\Temp|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey18=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalCache|*.*|RECURSE
-FileKey19=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\AppData|*.*|RECURSE
-FileKey20=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\Cache|*.*|RECURSE
-FileKey21=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft*Camera_*\AC\AppCache|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft*Camera_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft*Camera_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft*Camera_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\Microsoft*Camera_*\AC\PRICache|*.*
+FileKey6=%LocalAppData%\Packages\Microsoft*Camera_*\AC\Temp|*.*
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalCache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\AppData|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\Cache|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Camera_8wekyb3d8bbwe\SearchHistory
 
 [Cameyo*]
@@ -4139,7 +3990,7 @@ Detect=HKCU\Software\Canon\ZoomBrowser Ex
 DetectFile1=%Pictures%\ZbThumbnail.info
 DetectFile2=%AppData%\ZoomBrowser EX
 Default=False
-FileKey1=%Pictures%|ZbThumbnail.info|RECURSE
+FileKey1=%Pictures%\|ZbThumbnail.info|RECURSE
 
 [Captcha Brotherhood*]
 LangSecRef=3024
@@ -4195,7 +4046,7 @@ Detect=HKCU\Software\Piriform\CCleaner
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\CCleaner|*.log;CCleaner_log*.txt
 FileKey2=%ProgramFiles%\CCleaner|*.log;CCleaner_log*.txt
-FileKey3=%UserProfile%|CCleaner_log*.txt
+FileKey3=%UserProfile%\|CCleaner_log*.txt
 
 [CCTV Security*]
 LangSecRef=3021
@@ -4234,7 +4085,7 @@ RegKey7=HKCU\Software\Centarsia|RecentImage6
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\23460
 Default=False
-FileKey1=%AppData%|ceville_console_history.txt
+FileKey1=%AppData%\|ceville_console_history.txt
 FileKey2=%Documents%\Ceville\logs|*.*
 
 [CFE Exam Prep Course*]
@@ -4245,33 +4096,24 @@ FileKey1=%AppData%\ACFEExamPrep|*.log
 FileKey2=%ProgramFiles%\CFE Exam Prep Course\Log|*.*|RECURSE
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\CFE Exam Prep Course\Log|*.*|RECURSE
 
-[Chameleon Cache*]
+[Chameleon*]
 LangSecRef=3024
 DetectFile=%Documents%\Chameleon Files
 Default=False
 FileKey1=%Documents%\Chameleon Files\Cache|*.*|RECURSE
-
-[Chameleon Log*]
-LangSecRef=3024
-DetectFile=%Documents%\Chameleon Files
-Default=False
-FileKey1=%Documents%\Chameleon Files\Log|*.*|RECURSE
+FileKey2=%Documents%\Chameleon Files\Log|*.*|RECURSE
 
 [Champions Online*]
 Section=Games
 Detect1=HKCU\Software\Cryptic\Champions Online
 Detect2=HKCU\Software\Valve\Steam\Apps\9880
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Champions Online\Champions Online\Live\Cache|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Champions Online\Champions Online\PlayTest\Cache|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Champions Online\Live\Logs\GameClient|*.*
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Champions Online\Playtest\Logs\GameClient|*.*
-FileKey5=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\Champions Online\Live\Cache|*.*
-FileKey6=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\Champions Online\PlayTest\Cache|*.*
-FileKey7=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\Live\Logs\GameClient|*.*
-FileKey8=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\Playtest\Logs\GameClient|*.*
-FileKey9=%Public%\Games\cryptic studios\Champions Online\Live\Cache|*.*
-FileKey10=%Public%\Games\cryptic studios\Champions Online\PlayTest\Cache|*.*
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Champions Online\Champions Online\*\Cache|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Champions Online\*\Logs\GameClient|*.*
+FileKey3=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\Champions Online\*\Cache|*.*
+FileKey4=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\*\Logs\GameClient|*.*
+FileKey5=%Public%\Games\cryptic studios\Champions Online\*\Cache|*.*
+FileKey6=%Public%\Games\cryptic studios\Champions Online\*\Logs\GameClient|*.*
 
 [Cheat Engine*]
 LangSecRef=3021
@@ -4297,8 +4139,7 @@ FileKey2=%ProgramFiles%\Chicken Hunter|debug.txt
 [Chicken Invaders*]
 Section=Games
 DetectFile1=%AppData%\InterAction studios\CI3demo
-DetectFile2=%ProgramFiles%\ChickenInvaders*
-DetectFile3=%ProgramFiles%\Chicken Invaders*
+DetectFile2=%ProgramFiles%\Chicken*Invaders*
 Default=False
 FileKey1=%AppData%\InterAction studios|*.log|RECURSE
 FileKey2=%CommonAppData%\InterAction studios|*.log|RECURSE
@@ -4318,8 +4159,7 @@ FileKey1=%Documents%\Tilted Mill\Children of the Nile|*.log
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\219640
 Default=False
-FileKey1=%Documents%\My Games\Chivalry Medieval Warfare\UDKGame\Logs|*.*
-FileKey2=%Documents%\My Games\Chivalry Medieval Warfare Beta\UDKGame\Logs|*.*
+FileKey1=%Documents%\My Games\Chivalry Medieval Warfare*\UDKGame\Logs|*.*
 
 [Christmas Adventure - Candy Storm*]
 Section=Games
@@ -4379,7 +4219,7 @@ Detect3=HKLM\Software\Big Fish Games\Persistence\Install\F2676T1L1
 Detect4=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Cinema Tycoon 2  Movie Mania1.0
 Default=False
 FileKey1=%ProgramFiles%\Cinema Tycoon*|flashplayer7_winax.exe;*.txt
-FileKey2=%WinDir%|Cinema Tycoon 2  Movie Mania Setup Log.txt
+FileKey2=%WinDir%\|Cinema Tycoon 2  Movie Mania Setup Log.txt
 
 [Cisco Connect*]
 LangSecRef=3022
@@ -4417,6 +4257,20 @@ Detect=HKLM\Software\Citrix\ICA Client
 Default=False
 FileKey1=%CommonAppData%\Citrix\Citrix Online Plug-in - Web|*.msi;*.cab;eula*.rtf
 
+[Civilization 5 Installers*]
+Section=Games
+Detect=HKCU\Software\Firaxis\Civilization5
+Default=False
+Warning=This will remove DirectX and Visual C++ installers in your Civilization 5 installation directory. They can be reinstalled in your installation source.
+FileKey1=%ProgramFiles%\Civilization V*\DirectX|*.*|REMOVESELF
+FileKey2=%ProgramFiles%\Civilization V*\VCRedist|*.*|REMOVESELF
+
+[Civilization 5 Old Autosaves*]
+Section=Games
+Detect=HKCU\Software\Firaxis\Civilization5
+Default=False
+FileKey1=%Documents%\My Games\Sid Meier's Civilization 5\Saves\*\auto\prev|*.Civ5Save
+
 [Civilization Cache*]
 Section=Games
 Detect1=HKLM\Software\Firaxis Games
@@ -4440,26 +4294,10 @@ FileKey2=%Documents%\My Games\Sid Meier's Civilization *\Logs|*.*
 FileKey3=%Documents%\My Games\Warlords\Logs|*.*
 FileKey4=%LocalAppData%\VirtualStore\Program Files*\2K Games\Firaxis Games\Sid Meier's Civilization IV Colonization|*.txt
 FileKey5=%LocalAppData%\VirtualStore\Program Files*\Firaxis Games\Sid Meier's Civilization 4|*.txt
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Firaxis Games\Sid Meier's Civilization 4\Beyond the Sword|*.txt
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Firaxis Games\Sid Meier's Civilization 4\Warlords|*.txt
-FileKey8=%ProgramFiles%\2K Games\Firaxis Games\Sid Meier's Civilization IV Colonization|*.txt
-FileKey9=%ProgramFiles%\Firaxis Games\Sid Meier's Civilization 4|*.txt
-FileKey10=%ProgramFiles%\Firaxis Games\Sid Meier's Civilization 4\Beyond the Sword|*.txt
-FileKey11=%ProgramFiles%\Firaxis Games\Sid Meier's Civilization 4\Warlords|*.txt
-
-[Civilization 5 Installers*]
-Section=Games
-Detect=HKCU\Software\Firaxis\Civilization5
-Default=False
-Warning=This will remove DirectX and Visual C++ installers in your Civilization 5 installation directory. They can be reinstalled in your installation source.
-FileKey1=%ProgramFiles%\Civilization V*\DirectX|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Civilization V*\VCRedist|*.*|REMOVESELF
-
-[Civilization 5 Old Autosaves*]
-Section=Games
-Detect=HKCU\Software\Firaxis\Civilization5
-Default=False
-FileKey1=%Documents%\My Games\Sid Meier's Civilization 5\Saves\*\auto\prev|*.Civ5Save
+FileKey6=%LocalAppData%\VirtualStore\Program Files*\Firaxis Games\Sid Meier's Civilization 4\*|*.txt
+FileKey7=%ProgramFiles%\2K Games\Firaxis Games\Sid Meier's Civilization IV Colonization|*.txt
+FileKey8=%ProgramFiles%\Firaxis Games\Sid Meier's Civilization 4|*.txt
+FileKey9=%ProgramFiles%\Firaxis Games\Sid Meier's Civilization 4\*|*.txt
 
 [Clam Sentinel*]
 LangSecRef=3021
@@ -4503,7 +4341,7 @@ FileKey2=%WinDir%\$regcmp$|*.*|REMOVESELF
 LangSecRef=3024
 Detect=HKCU\Software\stevengould.org\CleanUp!
 Default=False
-FileKey1=%AppData%|CleanUp!.log
+FileKey1=%AppData%\|CleanUp!.log
 
 [Clementine*]
 LangSecRef=3023
@@ -4543,16 +4381,13 @@ Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.CloudExperienceHost_cw5n1h2txyewy
 FileKey1=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\TempState|*.*|RECURSE
 
 [Cloudfogger Keys*]
 LangSecRef=3023
@@ -4581,13 +4416,6 @@ Detect=HKCU\Software\Clover
 Default=False
 FileKey1=%LocalAppData%\Clover\User Data\Default|Bookmarks.bak
 
-[Clover JumpListIcons*]
-LangSecRef=3024
-Detect=HKCU\Software\Clover
-Default=False
-FileKey1=%LocalAppData%\Clover\User Data\Default\JumpListIcons|*tmp
-FileKey2=%LocalAppData%\Clover\User Data\Default\JumpListIconsOld|*tmp
-
 [Clover Session*]
 LangSecRef=3024
 Detect=HKCU\Software\Clover
@@ -4599,51 +4427,30 @@ LangSecRef=3024
 Detect=HKCU\Software\Clover
 Default=False
 FileKey1=%LocalAppData%\Clover\User Data\temp|*.*|RECURSE
+FileKey2=%LocalAppData%\Clover\User Data\Default\JumpListIcons|*tmp
+FileKey3=%LocalAppData%\Clover\User Data\Default\JumpListIconsOld|*tmp
 
-[CNET Tech Tracker Backup*]
+[CNET Tech Tracker*]
 LangSecRef=3024
 Detect=HKCU\Software\CBS Interactive\CNET TechTracker
 Default=False
 FileKey1=%AppData%\CBS Interactive\CNET TechTracker|*.bak
-
-[CNET Tech Tracker Databases*]
-LangSecRef=3024
-Detect=HKCU\Software\CBS Interactive\CNET TechTracker
-Default=False
-FileKey1=%AppData%\CBS Interactive\CNET TechTracker\data|*.db
-
-[CNET Tech Tracker Downloads*]
-LangSecRef=3024
-Detect=HKCU\Software\CBS Interactive\CNET TechTracker
-Default=False
-FileKey1=%Documents%\Downloads\CNET TechTracker|*.*
-
-[CNET Tech Tracker Recent Files*]
-LangSecRef=3024
-Detect=HKCU\Software\CBS Interactive\CNET TechTracker
-Default=False
+FileKey2=%AppData%\CBS Interactive\CNET TechTracker\data|temp.html;ztempimages*.png;*.db
+FileKey3=%AppData%\CBS Interactive\CNET TechTracker\temp|*.*|REMOVESELF
+FileKey4=%Documents%\Downloads\CNET TechTracker|*.*
 RegKey1=HKCU\Software\CBS Interactive\CNET TechTracker\Recent File List
-
-[CNET Tech Tracker Temp Files*]
-LangSecRef=3024
-Detect=HKCU\Software\CBS Interactive\CNET TechTracker
-Default=False
-FileKey1=%AppData%\CBS Interactive\CNET TechTracker\data|temp.html;ztempimages*.png
-FileKey2=%AppData%\CBS Interactive\CNET TechTracker\temp|*.*|REMOVESELF
 
 [CNN*]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\588E6FFA.CNNAppforWindows_cs8eyncph15zy
 DetectFile=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_cs8eyncph15zy
 Default=False
-FileKey1=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\PRICache|*.*
-FileKey6=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\Temp|*.*
-FileKey7=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\TempState|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\Microsoft\CLR_v4.0|*.log
+FileKey1=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\Microsoft\CLR_v4.0|*.log
+FileKey3=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\PRICache|*.*
+FileKey5=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\Temp|*.*
+FileKey6=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\TempState|*.*|RECURSE
 
 [CodeGear RAD Studio 2009*]
 LangSecRef=3024
@@ -4682,14 +4489,12 @@ LangSecRef=3024
 DetectFile=%SystemDrive%\Qoobox
 Default=False
 Warning=This will delete ComboFix History. Do not delete until you have reviewed these logs.
-FileKey1=%SystemDrive%|ComboFix.txt
-FileKey2=%SystemDrive%\CE.tmp|*.*|REMOVESELF
-FileKey3=%SystemDrive%\D6.tmp|*.*|REMOVESELF
-FileKey4=%SystemDrive%\Qoobox|*.txt
-FileKey5=%SystemDrive%\Qoobox\LastRun|*.*|REMOVESELF
-FileKey6=%SystemDrive%\Qoobox\Quarantine|*.log
-FileKey7=%SystemDrive%\Qoobox\Test|*.*|REMOVESELF
-FileKey8=%SystemDrive%\Qoobox\TestC|*.*|REMOVESELF
+FileKey1=%SystemDrive%\|ComboFix.txt
+FileKey2=%SystemDrive%\*.tmp|*.*|REMOVESELF
+FileKey3=%SystemDrive%\Qoobox|*.txt
+FileKey4=%SystemDrive%\Qoobox\LastRun|*.*|REMOVESELF
+FileKey5=%SystemDrive%\Qoobox\Quarantine|*.log
+FileKey6=%SystemDrive%\Qoobox\Test*|*.*|REMOVESELF
 
 [Comcast Toolbar*]
 LangSecRef=3022
@@ -4721,16 +4526,48 @@ Section=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.CommsPhone_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.CommsPhone_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.CommsPhone_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.CommsPhone_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.CommsPhone_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.CommsPhone_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.CommsPhone_*\TempState|*.*|RECURSE
+
+[Comodo CertSentry Logs*]
+LangSecRef=3022
+Detect=HKLM\Software\COMODO\CertSentry
+Default=False
+FileKey1=%LocalAppData%\COMODO\CertSentry|*.log
+
+[Comodo Dragon More*]
+LangSecRef=3029
+Detect=HKLM\Software\ComodoGroup\Dragon
+Default=False
+FileKey1=%LocalAppData%\COMODO|*.lock;*.old|RECURSE
+FileKey2=%LocalAppData%\COMODO\Dragon\User Data|*.*
+FileKey3=%LocalAppData%\COMODO\Dragon\User Data\Temp|*.*|RECURSE
+FileKey4=%LocalAppData%\COMODO\Dragon\User Data\Default|Archived History;Archived History-journal;Extension Cookies;History;History Index;History Index *;History-journal;Network Action Predictor-journal;Top Sites;Top Sites-journal;Visited Links
+FileKey5=%LocalAppData%\COMODO\Dragon\User Data\Default\Application Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\COMODO\Dragon\User Data\Default\Extensions\Temp|*.*
+FileKey7=%LocalAppData%\COMODO\Dragon\User Data\Default\Extension Rules|*.*|RECURSE
+FileKey8=%LocalAppData%\COMODO\Dragon\User Data\Default\File System|*.*|RECURSE
+FileKey9=%LocalAppData%\COMODO\Dragon\User Data\Default\GPUCache|*.*|RECURSE
+FileKey10=%LocalAppData%\COMODO\Dragon\User Data\Default\Media Cache|*.*|RECURSE
+FileKey11=%LocalAppData%\COMODO\Dragon\User Data\Default\Session Storage|*.*|RECURSE
+FileKey12=%LocalAppData%\COMODO\Dragon\User Data\Default\Temp|*.*|RECURSE
+FileKey13=%LocalAppData%\COMODO\Dragon\User Data\Performance Monitor Databases|*.*|REMOVESELF
+FileKey14=%SystemDrive%\first_launch|*.*|REMOVESELF
+ExcludeKey1=FILE|%LocalAppData%\COMODO\Dragon\User Data\|First Run
+ExcludeKey2=FILE|%LocalAppData%\COMODO\Dragon\User Data\|Local State
+
+[Comodo GeekBuddy*]
+LangSecRef=3021
+Detect=HKLM\Software\GeekBuddyRSP
+DetectFile=%ProgramFiles%\Common Files\COMODO\GeekBuddyRSP.exe
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Comodo\GeekBuddy\logs|*.*|RECURSE
+FileKey2=%ProgramFiles%\Comodo\GeekBuddy\logs|*.*|RECURSE
 
 [Comodo*]
 LangSecRef=3024
@@ -4750,65 +4587,13 @@ FileKey11=%LocalAppData%\VirtualStore\ProgramData\Comodo\Installer|*.*
 FileKey12=%LocalAppData%\VirtualStore\ProgramData\Comodo Downloader|*.*
 FileKey13=%ProgramFiles%\COMODO\COMODO Internet Security|*.tmp;CRASH.DMP;cmdagent.zip
 
-[Comodo CertSentry Logs*]
-LangSecRef=3022
-Detect=HKLM\Software\COMODO\CertSentry
-Default=False
-FileKey1=%LocalAppData%\COMODO\CertSentry|*.log
-
-[Comodo Dragon More*]
-LangSecRef=3029
-Detect=HKLM\Software\ComodoGroup\Dragon
-Default=False
-FileKey1=%LocalAppData%\COMODO|*.lock;*.old|RECURSE
-FileKey2=%LocalAppData%\COMODO\Dragon\User Data|*.*
-FileKey3=%LocalAppData%\COMODO\Dragon\User Data\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\COMODO\Dragon\User Data\Default|Archived History
-FileKey5=%LocalAppData%\COMODO\Dragon\User Data\Default|Archived History-journal
-FileKey6=%LocalAppData%\COMODO\Dragon\User Data\Default|Extension Cookies
-FileKey7=%LocalAppData%\COMODO\Dragon\User Data\Default|History
-FileKey8=%LocalAppData%\COMODO\Dragon\User Data\Default|History Index
-FileKey9=%LocalAppData%\COMODO\Dragon\User Data\Default|History Index *
-FileKey10=%LocalAppData%\COMODO\Dragon\User Data\Default|History-journal
-FileKey11=%LocalAppData%\COMODO\Dragon\User Data\Default|Network Action Predictor-journal
-FileKey12=%LocalAppData%\COMODO\Dragon\User Data\Default|Top Sites
-FileKey13=%LocalAppData%\COMODO\Dragon\User Data\Default|Top Sites-journal
-FileKey14=%LocalAppData%\COMODO\Dragon\User Data\Default|Visited Links
-FileKey15=%LocalAppData%\COMODO\Dragon\User Data\Default\Application Cache|*.*|RECURSE
-FileKey16=%LocalAppData%\COMODO\Dragon\User Data\Default\Extensions\Temp|*.*
-FileKey17=%LocalAppData%\COMODO\Dragon\User Data\Default\Extension Rules|*.*|RECURSE
-FileKey18=%LocalAppData%\COMODO\Dragon\User Data\Default\File System|*.*|RECURSE
-FileKey19=%LocalAppData%\COMODO\Dragon\User Data\Default\GPUCache|*.*|RECURSE
-FileKey20=%LocalAppData%\COMODO\Dragon\User Data\Default\Media Cache|*.*|RECURSE
-FileKey21=%LocalAppData%\COMODO\Dragon\User Data\Default\Session Storage|*.*|RECURSE
-FileKey22=%LocalAppData%\COMODO\Dragon\User Data\Default\Temp|*.*|RECURSE
-FileKey23=%LocalAppData%\COMODO\Dragon\User Data\Performance Monitor Databases|*.*|REMOVESELF
-FileKey24=%SystemDrive%\first_launch|*.*|REMOVESELF
-ExcludeKey1=FILE|%LocalAppData%\COMODO\Dragon\User Data\|First Run
-ExcludeKey2=FILE|%LocalAppData%\COMODO\Dragon\User Data\|Local State
-
-[Comodo GeekBuddy*]
-LangSecRef=3021
-Detect=HKLM\Software\GeekBuddyRSP
-DetectFile=%ProgramFiles%\Common Files\COMODO\GeekBuddyRSP.exe
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Comodo\GeekBuddy\logs|*.*|RECURSE
-FileKey2=%ProgramFiles%\Comodo\GeekBuddy\logs|*.*|RECURSE
-
-[Company of Heroes Cache*]
+[Company of Heroes*]
 Section=Games
-DetectFile1=%Documents%\My Games\Company of Heroes
-DetectFile2=%Documents%\My Games\Company of Heroes Relaunch
-Default=False
-FileKey1=%Documents%\My Games\Company of Heroes*\Cache|*.*
-
-[Company of Heroes Logs*]
-Section=Games
-DetectFile1=%Documents%\My Games\Company of Heroes
-DetectFile2=%Documents%\My Games\Company of Heroes Relaunch
+DetectFile1=%Documents%\My Games\Company of Heroes*
 Default=False
 FileKey1=%Documents%\My Games\Company of Heroes*|*.log
-FileKey2=%Documents%\My Games\Company of Heroes*\LogFiles|*.*
+FileKey2=%Documents%\My Games\Company of Heroes*\Cache|*.*
+FileKey3=%Documents%\My Games\Company of Heroes*\LogFiles|*.*
 
 [Compatibility Assistant*]
 LangSecRef=3025
@@ -4819,24 +4604,6 @@ RegKey2=HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Compati
 RegKey3=HKU\.DEFAULT\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Compatibility Assistant\Persisted
 RegKey4=HKU\.DEFAULT\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Compatibility Assistant\Store
 
-[Conceiva Mezzmo*]
-LangSecRef=3023
-Detect=HKLM\Software\Conceiva\Mezzmo
-Default=False
-FileKey1=%CommonAppData%\Conceiva\*|*.bat;*.exe;*.txt
-FileKey2=%LocalAppData%\Conceiva\Logs|*.*|REMOVESELF
-FileKey3=%LocalAppData%\Conceiva\Mezzmo|DebugCERwrite.txt
-FileKey4=%LocalAppData%\Conceiva\Mezzmo\Temporary_Dlna_Files|*.*|REMOVESELF
-FileKey5=%LocalAppData%\Conceiva\Mezzmo\Temporary_Subtitle_Files|*.*|REMOVESELF
-FileKey6=%LocalAppData%\Conceiva\Mezzmo\Temporary_Thumbnail_Files|*.*|REMOVESELF
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo|*.txt
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo\Third\OGMDemuxer\doc|*.*|REMOVESELF
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo\Third\MKVToolNix|*.txt
-FileKey10=%ProgramFiles%\Conceiva\Mezzmo|*.txt
-FileKey11=%ProgramFiles%\Conceiva\Mezzmo\Third\OGMDemuxer\doc|*.*|REMOVESELF
-FileKey12=%ProgramFiles%\Conceiva\Mezzmo\Third\MKVToolNix|*.txt
-RegKey1=HKCU\Software\Conceiva\Mezzmo\General|LastWatchFolder
-
 [Conceiva Mezzmo Crash Dump*]
 LangSecRef=3023
 Detect=HKLM\Software\Conceiva
@@ -4844,19 +4611,30 @@ Default=False
 FileKey1=%CommonAppData%\Conceiva\Mezzmo\CER|*.zip
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Conceiva\Mezzmo\CER|*.zip
 
-[Conduit Cache*]
-LangSecRef=3021
-Detect=HKCU\Software\Conduit
+[Conceiva Mezzmo*]
+LangSecRef=3023
+Detect=HKLM\Software\Conceiva\Mezzmo
 Default=False
-FileKey1=%LocalLowAppData%\ConduitEngine\CacheIcons|*.*
-FileKey2=%WinDir%\System32|ConduitEngine.tmp
+FileKey1=%CommonAppData%\Conceiva\*|*.bat;*.exe;*.txt
+FileKey2=%LocalAppData%\Conceiva\Logs|*.*|REMOVESELF
+FileKey3=%LocalAppData%\Conceiva\Mezzmo|DebugCERwrite.txt
+FileKey4=%LocalAppData%\Conceiva\Mezzmo\Temporary_*_Files|*.*|REMOVESELF
+FileKey5=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo|*.txt
+FileKey6=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo\Third\OGMDemuxer\doc|*.*|REMOVESELF
+FileKey7=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo\Third\MKVToolNix|*.txt
+FileKey8=%ProgramFiles%\Conceiva\Mezzmo|*.txt
+FileKey9=%ProgramFiles%\Conceiva\Mezzmo\Third\OGMDemuxer\doc|*.*|REMOVESELF
+FileKey10=%ProgramFiles%\Conceiva\Mezzmo\Third\MKVToolNix|*.txt
+RegKey1=HKCU\Software\Conceiva\Mezzmo\General|LastWatchFolder
 
-[Conduit Logs*]
+[Conduit*]
 LangSecRef=3021
 Detect=HKCU\Software\Conduit
 Default=False
 FileKey1=%LocalLowAppData%\Conduit\Community Alerts\Log|*.*|REMOVESELF
-FileKey2=%LocalLowAppData%\ConduitEngine\Logs|*.*
+FileKey2=%LocalLowAppData%\ConduitEngine\CacheIcons|*.*
+FileKey3=%LocalLowAppData%\ConduitEngine\Logs|*.*
+FileKey4=%WinDir%\System32|ConduitEngine.tmp
 
 [Config.msi Folder*]
 LangSecRef=3025
@@ -4878,16 +4656,13 @@ Section=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ConnectivityStore_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\TempState|*.*|RECURSE
 
 [Conquer Online Log*]
 Section=Games
@@ -4902,23 +4677,17 @@ Section=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Windows.ContactSupport_cw5n1h2txyewy
 Default=False
 FileKey1=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0|*.log
-FileKey6=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0_32|*.log
-FileKey9=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0_32\NativeImages\Temp|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0_32\UsageLogs|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Temp|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalCache|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalState\Cache|*.*|RECURSE
-FileKey18=%LocalAppData%\Packages\Windows.ContactSupport_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*|*.log
+FileKey4=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Temp|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalCache|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalState\Cache|*.*|RECURSE
+FileKey12=%LocalAppData%\Packages\Windows.ContactSupport_*\TempState|*.*|RECURSE
 
 [Content Delivery Manager*]
 DetectOS=10.0|
@@ -4926,23 +4695,20 @@ Section=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.ContentDeliveryManager_cw5n1h2txyewy
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\Assets|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\ContentManagementSDK\Creatives|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\Features|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\OneSettingsResponseCache|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\StagedAssets|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\TargetedContentCache\v3|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\Settings|*.dat
-FileKey18=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\Assets|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\ContentManagementSDK\Creatives|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\Features|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\OneSettingsResponseCache|*.*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\StagedAssets|*.*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\TargetedContentCache\v3|*.*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\Settings|*.dat
+FileKey15=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\TempState|*.*|RECURSE
 ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\INetCache\|container.dat
 ExcludeKey2=FILE|%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\INetHistory\BackgroundTransferApi\|container.dat
 
@@ -4957,7 +4723,7 @@ RegKey2=HKCU\Software\Eden\ConTEXT\FindHistory
 LangSecRef=3023
 Detect=HKCU\Software\VSO\ConvertXtoDVD\5
 Default=False
-FileKey1=%AppData%|pcouffin.log
+FileKey1=%AppData%\|pcouffin.log
 FileKey2=%CommonAppData%\VSO\vsothumbs|*.*|REMOVESELF
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\VSO\ConvertX\5|*.log;*.rtf
 FileKey4=%LocalAppData%\VirtualStore\ProgramData\VSO\vsothumbs|*.*|REMOVESELF
@@ -4966,19 +4732,17 @@ FileKey5=%ProgramFiles%\VSO\ConvertX\5|*.log;*.rtf
 [Cook'n Backups*]
 LangSecRef=3021
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Cook'n
-DetectFile1=%LocalAppData%\DVO\Cook'n10App\Cook'n.exe
-DetectFile2=%LocalAppData%\DVO\Cook'n11App\Cook'n.exe
+DetectFile=%LocalAppData%\DVO\Cook'n*App\Cook'n.exe
 Default=False
 FileKey1=%Documents%\Cook'n10\Workspace\data|download;dvodb.backup
-FileKey3=%Documents%\Cook'n10\Workspace\update|update.zip
-FileKey4=%Documents%\Cook'n11\Download|*.*
-FileKey5=%Documents%\Cook'n Backups|*.ckn
+FileKey2=%Documents%\Cook'n10\Workspace\update|update.zip
+FileKey3=%Documents%\Cook'n11\Download|*.*
+FileKey4=%Documents%\Cook'n Backups|*.ckn
 
 [Cook'n Cache*]
 LangSecRef=3021
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Cook'n
-DetectFile1=%LocalAppData%\DVO\Cook'n10App\Cook'n.exe
-DetectFile2=%LocalAppData%\DVO\Cook'n11App\Cook'n.exe
+DetectFile=%LocalAppData%\DVO\Cook'n*App\Cook'n.exe
 Default=False
 FileKey1=%AppData%\Mozilla\eclipse\Cache|*.*
 
@@ -4993,8 +4757,7 @@ FileKey1=%LocalAppData%\DVO\Cook'n10App\plugins|Getting Started Guide.rtf|RECURS
 [Cook'n Logs*]
 LangSecRef=3021
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Cook'n
-DetectFile1=%LocalAppData%\DVO\Cook'n10App\Cook'n.exe
-DetectFile2=%LocalAppData%\DVO\Cook'n11App\Cook'n.exe
+DetectFile=%LocalAppData%\DVO\Cook'n*App\Cook'n.exe
 Default=False
 FileKey1=%Documents%\Cook'n*|*.log|RECURSE
 FileKey2=%LocalAppData%\DVO\Cook'n*App|*.log|RECURSE
@@ -5137,6 +4900,20 @@ Default=False
 FileKey1=%LocalAppData%\Corel\AfterShot Pro *\Cache|*.*|RECURSE
 FileKey2=%LocalAppData%\Corel\AfterShot Pro *|*.log
 
+[Corel PaintShop Pro 2018 Downloads*]
+LangSecRef=3023
+Detect=HKCU\Software\Corel\PaintShop Pro\X10
+Default=False
+FileKey1=%CommonAppData%\Corel\Downloads|*.*|RECURSE
+
+[Corel PaintShop Pro AutoPreserve*]
+LangSecRef=3023
+Detect1=HKCU\Software\Corel\PaintShop Pro\X6
+Detect2=HKCU\Software\Corel\PaintShop Pro\X7
+Detect3=HKCU\Software\Corel\PaintShop Pro\X10
+Default=False
+FileKey1=%Pictures%\Corel Auto-Preserve|*.*
+
 [Corel PaintShop Pro*]
 LangSecRef=3023
 Detect1=HKCU\Software\Corel\PhotoDownloader\2
@@ -5156,20 +4933,6 @@ RegKey1=HKCU\Software\Corel\PaintShop Pro\X7\CoreMemoryManager\0
 RegKey2=HKCU\Software\Corel\PhotoDownloader\2\PhotoDownloader\DefaultDownloadFolder
 RegKey3=HKCU\Software\Corel\PhotoDownloader\2\PhotoDownloader\DownloadFolder
 RegKey4=HKCU\Software\Corel\PaintShop Pro\X10\CoreMemoryManager\0
-
-[Corel PaintShop Pro 2018 Downloads*]
-LangSecRef=3023
-Detect=HKCU\Software\Corel\PaintShop Pro\X10
-Default=False
-FileKey1=%CommonAppData%\Corel\Downloads|*.*|RECURSE
-
-[Corel PaintShop Pro AutoPreserve*]
-LangSecRef=3023
-Detect1=HKCU\Software\Corel\PaintShop Pro\X6
-Detect2=HKCU\Software\Corel\PaintShop Pro\X7
-Detect3=HKCU\Software\Corel\PaintShop Pro\X10
-Default=False
-FileKey1=%Pictures%\Corel Auto-Preserve|*.*
 
 [Corel VideoStudio Pro*]
 LangSecRef=3023
@@ -5193,13 +4956,11 @@ FileKey1=%ProgramFiles%\Corel\CorelDRAW Graphics Suite X7\Setup|*.*|REMOVESELF
 FileKey2=%CommonAppData%\Bitstream\Font Navigator\6.0\Cache|*.*|RECURSE
 FileKey3=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw\Export|dialog.export.web.xml
 FileKey4=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw\Presets\HTML Export|default.pst
-FileKey5=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Config|corelpdf.ini
-FileKey6=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw|FindAndReplaceMRU.xml
-FileKey7=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw\PreviewCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Connect|Connect.config
-FileKey9=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Config|corelpdf.ini
-FileKey10=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\PHOTO-PAINT\PreviewCache|*.*|RECURSE
-FileKey11=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Config|capture.ini
+FileKey5=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw|FindAndReplaceMRU.xml
+FileKey6=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw\PreviewCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Connect|Connect.config
+FileKey8=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Config|corelpdf.ini;capture.ini
+FileKey9=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\PHOTO-PAINT\PreviewCache|*.*|RECURSE
 RegKey1=HKCU\Software\Bitstream\Font Navigator\6.0\Copy|Folders
 RegKey2=HKCU\Software\Bitstream\Font Navigator\6.0\Move|Folders
 RegKey3=HKCU\Software\Corel\CorelDRAW\17.0\Draw\Application Preferences\Directories|DrawDocsDir
@@ -5213,29 +4974,15 @@ Section=3031
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Cortana_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Cortana_cw5n1h2txyewy
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.Cortana_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Cortana_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Cortana_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Cortana_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Cortana_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Cortana_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Cortana_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Cortana_*\AC\Temp|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Cortana_*\TempState|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\AC\AppCache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\AC\INetCache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\AC\INetCookies|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\AC\INetHistory|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\AC\Temp|*.*|RECURSE
-FileKey18=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey19=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\LocalCache|*.*|RECURSE
-FileKey20=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\LocalState\Cache|*.*|RECURSE
-FileKey21=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\LocalState\AppIconCache|*.*|RECURSE
-FileKey22=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\LocalState\DeviceSearchCache|*.*|RECURSE
-FileKey23=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft*Cortana_*\AC\AppCache|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft*Cortana_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft*Cortana_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft*Cortana_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft*Cortana_*\AC\Temp|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft*Cortana_*\TempState|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\LocalCache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\LocalState\*Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\TempState|*.*|RECURSE
 
 [CounterSpy*]
 LangSecRef=3024
@@ -5432,44 +5179,6 @@ Default=False
 FileKey1=%Pictures%\PhotoDirector\*.0\*|*.*|RECURSE
 ExcludeKey1=PATH|%Pictures%\PhotoDirector\*.0\*\|*.phd
 
-[CyberLink PowerDirector*]
-LangSecRef=3023
-Detect1=HKCU\Software\CyberLink\PowerDirector10
-Detect2=HKCU\Software\CyberLink\PowerDirector11
-Detect3=HKCU\Software\CyberLink\PowerDirector12
-Detect4=HKCU\Software\CyberLink\PowerDirector13
-Detect5=HKCU\Software\CyberLink\PowerDirector14
-Detect6=HKCU\Software\CyberLink\PowerDirector15
-Detect7=HKCU\Software\CyberLink\PowerDirector16
-Default=False
-FileKey1=%AppData%\CyberLink\MediaCache|*.*|RECURSE
-FileKey2=%AppData%\Cyberlink\PowerDirector\*.0|Recentfiles.ini
-FileKey3=%AppData%\CyberLink\PowerDirector\*.0\AutoSave|*.*|RECURSE
-FileKey4=%AppData%\CyberLink\PowerDirector\*.0\photoTmp|*.*|RECURSE
-FileKey5=%AppData%\Cyberlink\PowerDirector\*.0\WaveForms|*.*|RECURSE
-FileKey6=%Documents%\CyberLink\PowerDirector\*.0|Snapshot(*).jpg
-FileKey7=%Documents%\CyberLink\PowerDirector\*.0\MyTitles|*.*|RECURSE
-FileKey8=%Documents%\Cyberlink\PowerDirector\*.0\PDRMUSIC.TMP|*.*|REMOVESELF
-FileKey9=%Documents%\Cyberlink\PowerDirector\*.0\PP.TWOPASS|*.*|REMOVESELF
-FileKey10=%Documents%\CyberLink\PowerDirector\*.0\Preview Cache Files|*.*
-FileKey11=%Documents%\CyberLink\PowerDirector\*.0\ShadowEditFiles|*.MPG
-FileKey12=%Documents%\CyberLink\PowerDirector\*.0\SplitterIndex|*.maidx
-RegKey1=HKCU\Software\CyberLink\Hanuman
-RegKey2=HKCU\Software\CyberLink\PowerDirector10\MediaObj\MediaCache5\Data5
-RegKey3=HKCU\Software\CyberLink\PowerDirector10\MediaObj\MediaCache5\Thumbnail5
-RegKey4=HKCU\Software\CyberLink\PowerDirector11\MediaObj\MediaCache5\Data5
-RegKey5=HKCU\Software\CyberLink\PowerDirector11\MediaObj\MediaCache5\Thumbnail5
-RegKey6=HKCU\Software\CyberLink\PowerDirector12\MediaObj\MediaCache5\Data5
-RegKey7=HKCU\Software\CyberLink\PowerDirector12\MediaObj\MediaCache5\Thumbnail5
-RegKey8=HKCU\Software\CyberLink\PowerDirector13\MediaObj\MediaCache5\Data5
-RegKey9=HKCU\Software\CyberLink\PowerDirector13\MediaObj\MediaCache5\Thumbnail5
-RegKey10=HKCU\Software\CyberLink\PowerDirector14\MediaObj\MediaCache5\Data5
-RegKey11=HKCU\Software\CyberLink\PowerDirector14\MediaObj\MediaCache5\Thumbnail5
-RegKey12=HKCU\Software\CyberLink\PowerDirector15\MediaObj\MediaCache5\Data5
-RegKey13=HKCU\Software\CyberLink\PowerDirector15\MediaObj\MediaCache5\Thumbnail5
-RegKey14=HKCU\Software\CyberLink\PowerDirector16\MediaObj\MediaCache5\Data5
-RegKey15=HKCU\Software\CyberLink\PowerDirector16\MediaObj\MediaCache5\Thumbnail5
-
 [CyberLink Power2Go*]
 LangSecRef=3023
 Detect1=HKCU\Software\CyberLink\Power2Go9\9.0
@@ -5479,8 +5188,8 @@ Default=False
 FileKey1=%AppData%\CyberLink\MediaCache|*.*|RECURSE
 FileKey2=%Documents%\PDRMUSIC.TMP|*.*|REMOVESELF
 FileKey3=%LocalAppData%\Cyberlink\Power2Go*|DLDB.db
-FileKey4=%Music%|*.tmp
-FileKey5=%Pictures%|*.tmp
+FileKey4=%Music%\|*.tmp
+FileKey5=%Pictures%\|*.tmp
 FileKey6=%ProgramFiles%\Cyberlink\Power2Go*|*.tmp
 FileKey7=%ProgramFiles%\Cyberlink\Power2Go*|Thumbs.db|RECURSE
 FileKey8=%SystemDrive%\Users\Public\Documents\Cyberlink\Power2Go11|MP3Cache.log
@@ -5537,6 +5246,44 @@ Detect=HKCU\Software\Cyberlink\PowerCinema
 DetectFile=%LocalAppData%\PowerCinema
 Default=False
 FileKey1=%LocalAppData%\PowerCinema|trace.log;trace.txt
+
+[CyberLink PowerDirector*]
+LangSecRef=3023
+Detect1=HKCU\Software\CyberLink\PowerDirector10
+Detect2=HKCU\Software\CyberLink\PowerDirector11
+Detect3=HKCU\Software\CyberLink\PowerDirector12
+Detect4=HKCU\Software\CyberLink\PowerDirector13
+Detect5=HKCU\Software\CyberLink\PowerDirector14
+Detect6=HKCU\Software\CyberLink\PowerDirector15
+Detect7=HKCU\Software\CyberLink\PowerDirector16
+Default=False
+FileKey1=%AppData%\CyberLink\MediaCache|*.*|RECURSE
+FileKey2=%AppData%\Cyberlink\PowerDirector\*.0|Recentfiles.ini
+FileKey3=%AppData%\CyberLink\PowerDirector\*.0\AutoSave|*.*|RECURSE
+FileKey4=%AppData%\CyberLink\PowerDirector\*.0\photoTmp|*.*|RECURSE
+FileKey5=%AppData%\Cyberlink\PowerDirector\*.0\WaveForms|*.*|RECURSE
+FileKey6=%Documents%\CyberLink\PowerDirector\*.0|Snapshot(*).jpg
+FileKey7=%Documents%\CyberLink\PowerDirector\*.0\MyTitles|*.*|RECURSE
+FileKey8=%Documents%\Cyberlink\PowerDirector\*.0\PDRMUSIC.TMP|*.*|REMOVESELF
+FileKey9=%Documents%\Cyberlink\PowerDirector\*.0\PP.TWOPASS|*.*|REMOVESELF
+FileKey10=%Documents%\CyberLink\PowerDirector\*.0\Preview Cache Files|*.*
+FileKey11=%Documents%\CyberLink\PowerDirector\*.0\ShadowEditFiles|*.MPG
+FileKey12=%Documents%\CyberLink\PowerDirector\*.0\SplitterIndex|*.maidx
+RegKey1=HKCU\Software\CyberLink\Hanuman
+RegKey2=HKCU\Software\CyberLink\PowerDirector10\MediaObj\MediaCache5\Data5
+RegKey3=HKCU\Software\CyberLink\PowerDirector10\MediaObj\MediaCache5\Thumbnail5
+RegKey4=HKCU\Software\CyberLink\PowerDirector11\MediaObj\MediaCache5\Data5
+RegKey5=HKCU\Software\CyberLink\PowerDirector11\MediaObj\MediaCache5\Thumbnail5
+RegKey6=HKCU\Software\CyberLink\PowerDirector12\MediaObj\MediaCache5\Data5
+RegKey7=HKCU\Software\CyberLink\PowerDirector12\MediaObj\MediaCache5\Thumbnail5
+RegKey8=HKCU\Software\CyberLink\PowerDirector13\MediaObj\MediaCache5\Data5
+RegKey9=HKCU\Software\CyberLink\PowerDirector13\MediaObj\MediaCache5\Thumbnail5
+RegKey10=HKCU\Software\CyberLink\PowerDirector14\MediaObj\MediaCache5\Data5
+RegKey11=HKCU\Software\CyberLink\PowerDirector14\MediaObj\MediaCache5\Thumbnail5
+RegKey12=HKCU\Software\CyberLink\PowerDirector15\MediaObj\MediaCache5\Data5
+RegKey13=HKCU\Software\CyberLink\PowerDirector15\MediaObj\MediaCache5\Thumbnail5
+RegKey14=HKCU\Software\CyberLink\PowerDirector16\MediaObj\MediaCache5\Data5
+RegKey15=HKCU\Software\CyberLink\PowerDirector16\MediaObj\MediaCache5\Thumbnail5
 
 [CyberLink PowerDVD 16/17*]
 LangSecRef=3023
@@ -5661,7 +5408,7 @@ DetectFile=%ProgramFiles%\PotPlayer
 Default=False
 FileKey1=%LocalAppData%\Daum\PotPlayer\Log|*.xml
 
-[David FX Basic Log*]
+[David FX Basic*]
 LangSecRef=3024
 Detect=HKCU\Software\Tobit
 Default=False
@@ -5670,12 +5417,7 @@ FileKey2=%SystemDrive%\David\Apps\Postman\Code|*.chk
 FileKey3=%SystemDrive%\David\Code|*.old;*.chk;*.log
 FileKey4=%SystemDrive%\David\Tld\COMMON|*DAVID.LOG
 FileKey5=%SystemDrive%\David\Tld\Port\Extra|*.chk
-
-[David FX Basic Temp*]
-LangSecRef=3024
-Detect=HKCU\Software\Tobit
-Default=False
-FileKey1=%SystemDrive%\David\Archive\USER\*\temp|*.*
+FileKey6=%SystemDrive%\David\Archive\USER\*\temp|*.*
 
 [DayZ*]
 Section=Games
@@ -5756,33 +5498,19 @@ Detect=HKCU\Software\Piriform\Defraggler
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Defraggler|*.dmp;*statistics*;*.log;Defraggler*.txt
 FileKey2=%ProgramFiles%\Defraggler|*.dmp;*statistics*;*.log;Defraggler*.txt
-FileKey3=%UserProfile%|Defraggler*.txt
+FileKey3=%UserProfile%\|Defraggler*.txt
 
 [Delfix*]
 LangSecRef=3024
 DetectFile=%SystemDrive%\DelFix.txt
 Default=False
-FileKey1=%SystemDrive%|DelFix.txt
+FileKey1=%SystemDrive%\|DelFix.txt
 
 [Delivery Optimization Service Events Logs*]
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\Windows
 Default=False
 FileKey1=%WinDir%\Logs\dosvc|*.*|RECURSE
-
-[Dell Backup and Recovery Logs*]
-LangSecRef=3024
-DetectFile=%ProgramFiles%\Dell Backup and Recovery
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Dell Backup and Recovery|*.log|RECURSE
-FileKey2=%ProgramFiles%\Dell Backup and Recovery|*.log|RECURSE
-
-[Dell DataSafe Local Backup*]
-LangSecRef=3024
-DetectFile=%ProgramFiles%\Dell DataSafe Local Backup
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Dell DataSafe Local Backup|*.log|RECURSE
-FileKey2=%ProgramFiles%\Dell DataSafe Local Backup|*.log|RECURSE
 
 [Dell Installation Files*]
 LangSecRef=3024
@@ -5791,47 +5519,35 @@ Warning=This will delete your Dell installation files.
 Default=False
 FileKey1=%SystemDrive%\dell|*.*|REMOVESELF
 
+[Dell Logs*]
+LangSecRef=3024
+DetectFile1=%CommonAppData%\Dell
+DetectFile2=%LocalAppData%\Dell\
+DetectFile3=%ProgramFiles%\Dell*\
+DetectFile4=%LocalAppData%\SupportSoft\DellSupportCenter
+DetectFile5=%AppData%\Creative\DELL Webcam Center
+Default=False
+FileKey1=%AppData%\Creative\DELL Webcam Center|MO_Log.txt
+FileKey2=%AppData%\PCDr\*\Logs|*.*
+FileKey3=%CommonAppData%\Dell\*\Log|*.*
+FileKey4=%CommonAppData%\Dell\Drivers\*|*.tmp
+FileKey5=%CommonAppData%\PCDr\*\logs|*.log
+FileKey6=%CommonAppData%\PCDr\*\Cache\archives|*.*|RECURSE
+FileKey7=%CommonAppData%\PCDr\*\Cache\BUMA|*.*
+FileKey8=%CommonAppData%\PCDr\*\Cache\DriverScan|*.*
+FileKey9=%CommonAppData%\PCDr\*\Cache|*.xml
+FileKey10=%LocalAppData%\Dell\UpdatePackage\Log|*.*
+FileKey11=%LocalAppData%\VirtualStore\ProgramData\Dell\UpdatePackage\Log|*.*
+FileKey12=%LocalAppData%\VirtualStore\Program Files*\Dell*|*.log|RECURSE
+FileKey13=%LocalAppData%\SupportSoft\DellSupportCenter\*\state\logs|*.*
+FileKey14=%ProgramFiles%\Dell*|*.log|RECURSE
+
 [Dell PC Doctor*]
 LangSecRef=3024
 DetectFile=%CommonAppData%\PCDr
 Default=False
 FileKey1=%CommonAppData%\PCDr|*.dmp|RECURSE
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\PCDr|*.dmp|RECURSE
-
-[Dell SupportAssist*]
-LangSecRef=3024
-DetectFile=%ProgramFiles%\Dell\SupportAssist
-Default=False
-FileKey1=%CommonAppData%\PCDr\Bart\logs|*.log
-FileKey2=%CommonAppData%\PCDr\*\logs|*.log
-FileKey3=%CommonAppData%\PCDr\*\Cache\archives|*.*|RECURSE
-FileKey4=%CommonAppData%\PCDr\*\Cache\BUMA|*.*
-FileKey5=%CommonAppData%\PCDr\*\Cache\DriverScan|*.*
-FileKey6=%CommonAppData%\PCDr\*\Cache|*.xml
-FileKey7=%AppData%\PCDr\Installer\Logs|*.*
-FileKey8=%AppData%\PCDr\Update\Logs|*.*
-
-[Dell Support Center*]
-LangSecRef=3024
-DetectFile=%LocalAppData%\SupportSoft\DellSupportCenter
-Default=False
-FileKey1=%LocalAppData%\SupportSoft\DellSupportCenter\*\state\logs|*.*
-
-[Dell UpdatePackage*]
-LangSecRef=3024
-DetectFile1=%LocalAppData%\Dell\UpdatePackage
-DetectFile2=%CommonAppData%\Dell
-Default=False
-FileKey1=%CommonAppData%\Dell\UpdatePackage\Log|*.*
-FileKey2=%LocalAppData%\Dell\UpdatePackage\Log|*.*
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Dell\UpdatePackage\Log|*.*
-FileKey4=%CommonAppData%\Dell\Drivers\*|*.tmp
-
-[Dell Webcam Center*]
-LangSecRef=3023
-DetectFile=%AppData%\Creative\DELL Webcam Center
-Default=False
-FileKey1=%AppData%\Creative\DELL Webcam Center|MO_Log.txt
 
 [Dependency Walker*]
 LangSecRef=3025
@@ -5912,19 +5628,19 @@ DetectFile=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Device
 Default=False
 FileKey1=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Device Metadata\dmrccache\downloads|*.tmp
 
-[Device Manager Cache*]
-DetectOS=6.0|
-LangSecRef=3025
-Warning=This clears cached drivers of connected devices. As soon as you connect a new device, this file regenerates.
-Default=False
-FileKey1=%WinDir%\System32\DriverStore|INFCACHE.1
-
 [Device Manager Cache XP*]
 DetectOS=|5.1
 LangSecRef=3025
 Default=False
 Warning=This clears cached drivers of connected devices. As soon as you connect a new device, this file regenerates.
 FileKey1=%WinDir%\inf|INFCACHE.1
+
+[Device Manager Cache*]
+DetectOS=6.0|
+LangSecRef=3025
+Warning=This clears cached drivers of connected devices. As soon as you connect a new device, this file regenerates.
+Default=False
+FileKey1=%WinDir%\System32\DriverStore|INFCACHE.1
 
 [DeviceDoctor*]
 LangSecRef=3024
@@ -5965,11 +5681,9 @@ Section=Games
 Detect=HKCU\Software\Blizzard Entertainment\D3
 Default=False
 FileKey1=%CommonAppData%\Battle.net\Setup\diablo3_engb\Log|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Diablo III\Logs|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Diablo III Beta\Logs|*.*
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Setup\diablo3_engb\Log|*.*
-FileKey5=%ProgramFiles%\Diablo III\Logs|*.*
-FileKey6=%ProgramFiles%\Diablo III Beta\Logs|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Diablo III*\Logs|*.*
+FileKey3=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Setup\diablo3_engb\Log|*.*
+FileKey4=%ProgramFiles%\Diablo III*\Logs|*.*
 
 [Diagnostics Logs*]
 LangSecRef=3025
@@ -5990,29 +5704,19 @@ Detect=HKCU\Software\Davide Vitelaru\Digital Janitor
 Default=False
 FileKey1=%AppData%\Digital Janitor|ToSortHistory
 
-[Digsby Cache*]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\Digsby
-Default=False
-FileKey1=%LocalAppData%\Digsby\Cache|*.*|RECURSE
-
 [Digsby Chat Logs*]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Digsby
 Default=False
 FileKey1=%Documents%\Digsby Logs|*.*|RECURSE
 
-[Digsby Logs*]
+[Digsby*]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Digsby
 Default=False
-FileKey1=%LocalAppData%\Digsby\Logs|*.*|RECURSE
-
-[Digsby Temp*]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\Digsby
-Default=False
-FileKey1=%LocalAppData%\Digsby\Temp|*.*|RECURSE
+FileKey1=%LocalAppData%\Digsby\Cache|*.*|RECURSE
+FileKey2=%LocalAppData%\Digsby\Logs|*.*|RECURSE
+FileKey3=%LocalAppData%\Digsby\Temp|*.*|RECURSE
 
 [Directory Opus Caches*]
 LangSecRef=3024
@@ -6020,6 +5724,17 @@ Detect=HKLM\Software\GPSoftware\Directory Opus
 Default=False
 FileKey1=%AppData%\GPSoftware\Directory Opus\Icon Cache Roaming|*.*|RECURSE
 FileKey2=%LocalAppData%\GPSoftware\Directory Opus\Thumbnail Cache|*.*|RECURSE
+
+[Discord*]
+LangSecRef=3022
+Detect1=HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\Discord
+Detect2=HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\Discordcanary
+Default=False
+FileKey1=%AppData%\discord*|modules.log
+FileKey2=%AppData%\discord*\Cache|*.*|RECURSE
+FileKey3=%AppData%\discord*\GPUCache|*.*
+FileKey4=%LocalAppData%\discord*|*.log
+FileKey5=%LocalAppData%\SquirrelTemp|*.*
 
 [Dishonored*]
 Section=Games
@@ -6053,30 +5768,11 @@ Detect=HKCU\Software\KoshyJohn.com
 Default=False
 FileKey1=%AppData%\KoshyJohn.com\DiskMax|DiskMax Log.txt
 
-[DisplayFusion Setup File & Log*]
+[DisplayFusion*]
 LangSecRef=3024
 Detect=HKCU\Software\Binary Fortress Software\DisplayFusion
 Default=False
-FileKey1=%AppData%\DisplayFusion|DisplayFusionSetup.log;DisplayFusionSetup.exe
-
-[DisplayFusion TroubleShooting Log*]
-LangSecRef=3024
-Detect=HKCU\Software\Binary Fortress Software\DisplayFusion
-Default=False
-FileKey1=%AppData%\DisplayFusion|DisplayFusion.log;DebugInfo.*
-
-[DivX Cache*]
-LangSecRef=3023
-Detect=HKCU\Software\DivX
-Default=False
-FileKey1=%AppData%\DivX|Font Cache.|RECURSE
-
-[DivX Logs*]
-LangSecRef=3023
-Detect=HKCU\Software\DivX
-Default=False
-FileKey1=%CommonAppData%\DivX|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\DivX|*.log|RECURSE
+FileKey1=%AppData%\DisplayFusion|DisplayFusionSetup.log;DisplayFusionSetup.exe;DisplayFusion.log;DebugInfo.*
 
 [DivX Movies Cache*]
 LangSecRef=3023
@@ -6101,6 +5797,14 @@ RegKey2=HKCU\Software\DivX\Settings\Converter|outputDir
 RegKey3=HKCU\Software\DivX\Settings\Player\PlayerState|LastOpenFileLocation
 RegKey4=HKCU\Software\DivX\Settings\TransferWizard|LastBrwosedDir
 RegKey5=HKCU\Software\DivXNetworks\DivX Player|file
+
+[DivX*]
+LangSecRef=3023
+Detect=HKCU\Software\DivX
+Default=False
+FileKey1=%AppData%\DivX|Font Cache.|RECURSE
+FileKey2=%CommonAppData%\DivX|*.log|RECURSE
+FileKey3=%LocalAppData%\VirtualStore\ProgramData\DivX|*.log|RECURSE
 
 [DLExpert*]
 LangSecRef=3021
@@ -6138,6 +5842,12 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\214320
 Default=False
 FileKey1=%Documents%\My Games\DollarDash\PKGame\Logs|*.*
+
+[Dolphin Emulator*]
+Section=Games
+DetectFile=%Documents%\Dolphin Emulator
+Default=False
+FileKey1=%Documents%\Dolphin Emulator\Logs|*.*|RECURSE
 
 [Don't Starve*]
 Section=Games
@@ -6177,12 +5887,6 @@ DetectFile=%SystemDrive%\Dooble
 Default=False
 FileKey1=%SystemDrive%\Dooble\*\.dooble|history.db
 
-[Download App Cache*]
-LangSecRef=3024
-Detect=HKCU\Software\CBS Interactive\Download App
-Default=False
-FileKey1=%AppData%\CBS Interactive\Download App\Cache|*.*
-
 [Download App Databases*]
 LangSecRef=3024
 Detect=HKCU\Software\CBS Interactive\Download App
@@ -6195,11 +5899,12 @@ Detect=HKCU\Software\CBS Interactive\Download App
 Default=False
 FileKey1=%Documents%\Downloads\Download App|*.*
 
-[Download App Logs*]
+[Download App*]
 LangSecRef=3024
 Detect=HKCU\Software\CBS Interactive\Download App
 Default=False
 FileKey1=%AppData%\CBS Interactive\Download App|*.log
+FileKey2=%AppData%\CBS Interactive\Download App\Cache|*.*
 
 [Downloaded Installations*]
 LangSecRef=3025
@@ -6224,7 +5929,7 @@ FileKey1=%AppData%\HitPoint Studios\DrD|logfile.txt
 LangSecRef=3024
 DetectFile=%WinDir%\DKSService.exe
 Default=False
-FileKey1=%WinDir%|DksSystem.log
+FileKey1=%WinDir%\|DksSystem.log
 
 [Dr. Watson*]
 LangSecRef=3025
@@ -6352,25 +6057,17 @@ FileKey1=%LocalAppData%\Innovative Solutions\DriverMax\Agent\Downloded Drivers|*
 FileKey2=%LocalAppData%\Innovative Solutions\DriverMax\Agent\Uploads|*.*|RECURSE
 FileKey3=%LocalAppData%\Innovative Solutions\DriverMax\Backup|*.*
 FileKey4=%LocalAppData%\Innovative Solutions\DriverMax\LastScan|*.*
-FileKey5=%LocalAppData%\Innovative Solutions\DriverMax\Temp|*.*
-FileKey6=%LocalAppData%\Innovative Solutions\DriverMax\TempBackup|*.*
-FileKey7=%LocalAppData%\Innovative Solutions\DriverMax\Agent|dmxlog.txt
-FileKey8=%LocalAppData%\Innovative Solutions\DriverMax\Agent|*.tmp
+FileKey5=%LocalAppData%\Innovative Solutions\DriverMax\Temp*|*.*
+FileKey6=%LocalAppData%\Innovative Solutions\DriverMax\Agent|dmxlog.txt;*.tmp
 
-[DriverPack Solution Bug Report*]
+[DriverPack Solution*]
 LangSecRef=3024
 Detect=HKCU\Software\drpsu
 Default=False
 Warning=This will delete your bug report. Use this only if you know what you are doing.
 FileKey1=%WinDir%\Logs\SysInfo|*.*
-FileKey2=%WinDir%\Logs\DRPLog|*.png
+FileKey2=%WinDir%\Logs\DRPLog|*.png;*.txt
 FileKey3=%Documents%\DRP-Log|*.*
-
-[DriverPack Solution Logs*]
-LangSecRef=3024
-Detect=HKCU\Software\drpsu
-Default=False
-FileKey1=%WinDir%\Logs\DRPLog|*.txt
 
 [DriverRadarPro*]
 LangSecRef=3024
@@ -6421,6 +6118,14 @@ FileKey4=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\DRM|*.log
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\DRM\Cache|*.*|RECURSE
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\DRM\PreUpgrade|*.log
 
+[Dropbox Cache*]
+LangSecRef=3024
+Detect=HKCU\Software\Dropbox
+Default=False
+Warning=This will remove cached versions of modified and deleted files.
+FileKey1=%Documents%\Dropbox\.dropbox.cache|*.*|RECURSE
+FileKey2=%UserProfile%\Dropbox\.dropbox.cache|*.*|RECURSE
+
 [Dropbox*]
 LangSecRef=3024
 Detect=HKCU\Software\Dropbox
@@ -6433,26 +6138,18 @@ FileKey5=%CommonAppData%\Dropbox\Update\Log|*.*
 FileKey6=%LocalAppData%\Dropbox\Logs|*.*|RECURSE
 FileKey7=%ProgramFiles%\Dropbox\Update\Download|*.*|REMOVESELF
 
-[Dropbox Cache*]
-LangSecRef=3024
-Detect=HKCU\Software\Dropbox
-Default=False
-Warning=This will remove cached versions of modified and deleted files.
-FileKey1=%Documents%\Dropbox\.dropbox.cache|*.*|RECURSE
-FileKey2=%UserProfile%\Dropbox\.dropbox.cache|*.*|RECURSE
-
-[DUC*]
-LangSecRef=3022
-Detect=HKCU\Software\Vitalwerks\DUC
-Default=False
-FileKey1=%LocalAppData%\Vitalwerks\DUC|DUC.log
-
 [DU meter*]
 LangSecRef=3022
 Detect=HKCU\Software\Hagel\DU Meter
 Default=False
 FileKey1=%CommonAppData%\Hagel Technologies\DU Meter|*.csv
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Hagel Technologies\DU Meter|*.csv
+
+[DUC*]
+LangSecRef=3022
+Detect=HKCU\Software\Vitalwerks\DUC
+Default=False
+FileKey1=%LocalAppData%\Vitalwerks\DUC|DUC.log
 
 [Duke Nukem 3D*]
 Section=Games
@@ -6466,6 +6163,12 @@ LangSecRef=3024
 Detect=HKCU\Software\KC Softwares\DUMo
 Default=False
 FileKey1=%AppData%\KC Softwares\DUMo|*.log
+
+[Dungeon Of The Endless*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\249050
+Default=False
+FileKey1=%Documents%\Dungeon of the Endless\Temporary Files|*.*
 
 [Dungeons - The Dark Lord*]
 Section=Games
@@ -6493,13 +6196,6 @@ FileKey4=%ProgramFiles%\dvbdream\Logs|*.*
 FileKey5=%SystemDrive%\dvbdream|*.log;*.bak;*levellog*|RECURSE
 FileKey6=%SystemDrive%\dvbdream\Logs|*.*
 
-[DVBViewer*]
-LangSecRef=3023
-Detect=HKLM\Software\CM&V\DVBViewer
-Default=False
-FileKey1=%CommonAppData%\CMUV\DVBViewer|*.bak;*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\CMUV\DVBViewer|*.bak;*.log
-
 [DVBViewer Setup Files*]
 LangSecRef=3023
 Detect=HKLM\Software\CM&V\DVBViewer
@@ -6519,6 +6215,13 @@ Default=False
 FileKey1=%CommonAppData%\CMUV\DVBViewer TE2|*.bak;*.log
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\CMUV\DVBViewer TE2|*.bak;*.log
 
+[DVBViewer*]
+LangSecRef=3023
+Detect=HKLM\Software\CM&V\DVBViewer
+Default=False
+FileKey1=%CommonAppData%\CMUV\DVBViewer|*.bak;*.log
+FileKey2=%LocalAppData%\VirtualStore\ProgramData\CMUV\DVBViewer|*.bak;*.log
+
 [DVD-Cloner*]
 LangSecRef=3023
 Detect1=HKCU\Software\Dvd-cloner
@@ -6527,13 +6230,13 @@ Detect3=HKCU\Software\iPod-Cloner
 Default=False
 FileKey1=%AppData%\DVD-Cloner*|*.log
 FileKey2=%CommonAppData%\DVD-Cloner*|*.log
-FileKey3=%Documents%|Smart.log;Smart_result.log
+FileKey3=%Documents%\|Smart.log;Smart_result.log
 FileKey4=%LocalAppData%\VirtualStore\Program Files*\DVD-Cloner*|*.log|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\Program Files*\DVD-Cloner Platinum\*\readcache|*.*
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\DVD-Cloner*|*.log
 FileKey7=%ProgramFiles%\DVD-Cloner*|*.log|RECURSE
 FileKey8=%ProgramFiles%\DVD-Cloner Platinum\*\readcache|*.*
-FileKey9=%SystemDrive%|dtdlog.txt
+FileKey9=%SystemDrive%\|dtdlog.txt
 FileKey10=%WinDir%\system32|dvdtest10024.dat
 
 [DVD-Ranger*]
@@ -6547,6 +6250,20 @@ FileKey4=%Documents%\DVDRanger\Screenshots|*.*|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\DVDRanger\DDF626ADdvdcss|*.*
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\DVDRanger\Logs|*.*
 FileKey7=%SystemDrive%\DVDRanger|*.*|REMOVESELF
+
+[DVD Flick Logs*]
+LangSecRef=3023
+DetectFile=%ProgramFiles%\DVD Flick\dvdflick.exe
+Default=False
+FileKey1=%AppData%\DVD Flick|dvdflick.log;report.txt
+
+[DVD Shrink Analysis Results*]
+LangSecRef=3023
+Detect=HKCU\Software\DVD Shrink
+Default=False
+Warning=Each time you use this you'll have to agree to the DVD Shrink license.
+FileKey1=%CommonAppData%\DVD Shrink|*.*
+FileKey2=%LocalAppData%\VirtualStore\ProgramData\DVD Shrink|*.*
 
 [dvdcss*]
 LangSecRef=3023
@@ -6585,20 +6302,6 @@ Detect=HKCU\Software\DVDFab Passkey
 Default=False
 FileKey1=%Documents%\DVDFab Passkey\Log|*.*|REMOVESELF
 
-[DVD Flick Logs*]
-LangSecRef=3023
-DetectFile=%ProgramFiles%\DVD Flick\dvdflick.exe
-Default=False
-FileKey1=%AppData%\DVD Flick|dvdflick.log;report.txt
-
-[DVD Shrink Analysis Results*]
-LangSecRef=3023
-Detect=HKCU\Software\DVD Shrink
-Default=False
-Warning=Each time you use this you'll have to agree to the DVD Shrink license.
-FileKey1=%CommonAppData%\DVD Shrink|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\DVD Shrink|*.*
-
 [DVDSmith*]
 LangSecRef=3023
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\DVDSmith Movie Backup_is1
@@ -6611,25 +6314,19 @@ Detect=HKCU\Software\DVDVideoSoft
 Default=False
 FileKey1=%AppData%\DVDVideoSoft\Backup|*.*|RECURSE
 
-[DVDVideoSoft History*]
-LangSecRef=3024
-Detect=HKCU\Software\DVDVideoSoft
-Default=False
-FileKey1=%AppData%\DVDVideoSoft\*\History|*.*|RECURSE
-
-[DVDVideoSoft Logs*]
-LangSecRef=3023
-Detect=HKCU\Software\DVDVideoSoft
-Default=False
-FileKey1=%AppData%\DVDVideoSoft\installation_logs|*.*|RECURSE
-FileKey2=%AppData%\DVDVideoSoft\Logs|*.*|RECURSE
-FileKey3=%Documents%\DVDVideoSoft|*log.txt|RECURSE
-
 [DVDVideoSoft Toolbar Logs*]
 LangSecRef=3024
 Detect=HKCU\Software\AppDataLow\Software\DVDVideoSoftTB
 Default=False
 FileKey1=%LocalAppData%\DVDVideoSoftTB\Logs|*.*|RECURSE
+
+[DVDVideoSoft*]
+LangSecRef=3023
+Detect=HKCU\Software\DVDVideoSoft
+Default=False
+FileKey1=%AppData%\DVDVideoSoft\*Logs|*.*|RECURSE
+FileKey2=%Documents%\DVDVideoSoft|*log.txt|RECURSE
+FileKey3=%AppData%\DVDVideoSoft\*\History|*.*|RECURSE
 
 [DVDx*]
 LangSecRef=3023
@@ -6649,20 +6346,17 @@ Detect4=HKLM\Software\DxO
 Detect5=HKLM\Software\DxO Labs
 Detect6=HKLM\Software\DxOLabs
 Default=False
-FileKey1=%Documents%\DxO FilmPack *\log|*.*
+FileKey1=%Documents%\DxO*\log|*.*
 FileKey2=%Documents%\DxO Optics*Pro * crash*s|*.*
 FileKey3=%Documents%\DxO Optics*Pro * logs|*.*
 FileKey4=%Documents%\DxO PhotoLab logs|*.*
-FileKey5=%Documents%\DxO ViewPoint*\log|*.*
-FileKey6=%LocalAppData%\DxO\DxO PhotoLab *\Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\DxO_Labs\DataCache|*.*|RECURSE
-FileKey8=%LocalAppData%\DxO_Labs\DxO FilmPack *\CrashReports|*.*
-FileKey9=%LocalAppData%\DxO_Labs\DxO FilmPack *\DiskCache|*.*
-FileKey10=%LocalAppData%\DxO_Labs\DxO FilmPack *\Logs|*.*
-FileKey11=%LocalAppData%\DxO_Labs\DxO Optics*Pro *\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\DxO_Labs\DxO ViewPoint *\DiskCache|*.*
-FileKey13=%LocalAppData%\DxO_Labs\DxO ViewPoint *\Logs|*.*
-FileKey14=%LocalAppData%\DxO_Labs\Logs|*.*
+FileKey5=%LocalAppData%\DxO\DxO PhotoLab *\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\DxO_Labs\DataCache|*.*|RECURSE
+FileKey7=%LocalAppData%\DxO_Labs\DxO*\CrashReports|*.*
+FileKey8=%LocalAppData%\DxO_Labs\DxO*\Logs|*.*
+FileKey9=%LocalAppData%\DxO_Labs\DxO*\Cache|*.*|RECURSE
+FileKey10=%LocalAppData%\DxO_Labs\DxO*\DiskCache|*.*
+FileKey11=%LocalAppData%\DxO_Labs\Logs|*.*
 
 [Dyn Updater*]
 LangSecRef=3022
@@ -6671,22 +6365,17 @@ Default=False
 FileKey1=%CommonAppData%\Dyn\Updater|*.log;*.msi
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Dyn\Updater|*.log;*.msi
 
-[EA Core Cache*]
+[EA Core*]
 Section=Games
 Detect=HKCU\Software\EA Games\EA Core
 Default=False
 FileKey1=%CommonAppData%\EA Core\Cache|*.*|REMOVESELF
 FileKey2=%LocalAppData%\EA Core\Cache|*.*|REMOVESELF
 FileKey3=%LocalAppData%\VirtualStore\ProgramData\EA Core\Cache|*.*|REMOVESELF
-
-[EA Core Logs*]
-Section=Games
-Detect=HKCU\Software\EA Games\EA Core
-Default=False
-FileKey1=%CommonAppData%\EA Logs|*.*
-FileKey2=%CommonAppData%\Electronic Arts\EA Core\logs|*.*
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\EA Logs|*.*
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Electronic Arts\EA Core\logs|*.*
+FileKey4=%CommonAppData%\EA Logs|*.*
+FileKey5=%CommonAppData%\Electronic Arts\EA Core\logs|*.*
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\EA Logs|*.*
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\Electronic Arts\EA Core\logs|*.*
 
 [EA Download Manager*]
 Section=Games
@@ -6786,19 +6475,13 @@ FileKey4=%ProgramFiles%\eBay\eBay Toolbar*\eBayhistory|*.*|RECURSE
 RegKey1=HKCU\Software\eBay\eBayToolbar\History
 RegKey2=HKCU\Software\eBay\eBayToolbar\RecentSearches
 
-[eBay TurboLister Logs*]
+[eBay TurboLister*]
 LangSecRef=3021
-Detect=HKCU\Software\eBay\Turbo lister
+Detect1=HKCU\Software\eBay\Turbo lister
+Detect2=HKCU\Software\eBay\Turbo lister2
 Default=False
-FileKey1=%CommonAppData%\eBay\Turbo Lister|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\eBay\Turbo Lister|*.log|RECURSE
-
-[eBay TurboLister2 Logs*]
-LangSecRef=3021
-Detect=HKCU\Software\eBay\Turbo lister2
-Default=False
-FileKey1=%CommonAppData%\eBay\Turbo Lister2|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\eBay\Turbo Lister2|*.log|RECURSE
+FileKey1=%CommonAppData%\eBay\Turbo Lister*|*.log|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\ProgramData\eBay\Turbo Lister*|*.log|RECURSE
 
 [EC XTRA Timer*]
 LangSecRef=3021
@@ -6880,19 +6563,14 @@ RegKey1=HKCU\Software\EmSoft\EmEditor v3\Recent File List
 RegKey2=HKCU\Software\EmSoft\EmEditor v3\Recent Folder List
 RegKey3=HKCU\Software\EmSoft\EmEditor v3\Recent Font List
 
-[emesene2 Avatars*]
+[emesene2*]
 LangSecRef=3022
 DetectFile=%AppData%\emesene\emesene2
 Default=False
 FileKey1=%AppData%\emesene\emesene2\*\*\*\avatars|*.*|RECURSE
 FileKey2=%AppData%\emesene\emesene2\*\*\avatars|*.*|RECURSE
 FileKey3=%AppData%\emesene\emesene2\*\*\cached_avatars|*.*|RECURSE
-
-[emesene2 Logs*]
-LangSecRef=3022
-DetectFile=%AppData%\emesene\emesene2
-Default=False
-FileKey1=%AppData%\emesene\emesene2\*\*\log|*.*|RECURSE
+FileKey4=%AppData%\emesene\emesene2\*\*\log|*.*|RECURSE
 
 [Emsisoft HiJackFree*]
 LangSecRef=3024
@@ -6911,14 +6589,12 @@ FileKey1=%AppData%\EndNote|*.log;*.16
 FileKey2=%CommonAppData%\Thomson.ResearchSoft.Installers|*.*|REMOVESELF
 FileKey3=%CommonProgramFiles%\Risxtd|*.LOG;*.txt
 FileKey4=%Documents%\My EndNote Library.Data\Trash|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\EndNote Web|*.txt
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\EndNote X6|*.txt
-FileKey7=%LocalAppData%\VritualStore\Program Files*\Common Files\Risxtd|*.LOG;*.txt
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\EndNote X6\Product-Support\ThirdParty\Apache2|NOTICE
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Thomson.ResearchSoft.Installers|*.*|REMOVESELF
-FileKey10=%ProgramFiles%\EndNote Web|*.txt
-FileKey11=%ProgramFiles%\EndNote X6|*.txt
-FileKey12=%ProgramFiles%\EndNote X6\Product-Support\ThirdParty\Apache2|NOTICE
+FileKey5=%LocalAppData%\VirtualStore\Program Files*\EndNote*|*.txt
+FileKey6=%LocalAppData%\VritualStore\Program Files*\Common Files\Risxtd|*.LOG;*.txt
+FileKey7=%LocalAppData%\VirtualStore\Program Files*\EndNote X6\Product-Support\ThirdParty\Apache2|NOTICE
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\Thomson.ResearchSoft.Installers|*.*|REMOVESELF
+FileKey9=%ProgramFiles%\EndNote*|*.txt
+FileKey10=%ProgramFiles%\EndNote X6\Product-Support\ThirdParty\Apache2|NOTICE
 
 [EnhanceMy8*]
 LangSecRef=3024
@@ -6926,12 +6602,6 @@ DetectFile=%ProgramFiles%\EnhanceMy8
 Default=False
 FileKey1=%AppData%\SeriousBit\EnhanceMy8|Logs.txt
 FileKey2=%AppData%\SeriousBit\EnhanceMy8\Backups|*.*|RECURSE
-
-[Epson*]
-LangSecRef=3021
-Detect=HKCU\Software\EPSON
-Default=False
-FileKey1=%AppData%\Epson\FAX Utility\FAXLOG|*.*
 
 [Epic Games Launcher*]
 Section=Games
@@ -6943,12 +6613,29 @@ FileKey3=%LocalAppData%\EpicGamesLauncher\Saved\webcache|*.*|REMOVESELF
 FileKey4=%LocalAppData%\FortniteGame\Saved\Logs|*.log
 FileKey5=%LocalAppData%\FortniteGame\Saved\webcache|*.*|REMOVESELF
 
+[Epson*]
+LangSecRef=3021
+Detect=HKCU\Software\EPSON
+Default=False
+FileKey1=%AppData%\Epson\FAX Utility\FAXLOG|*.*
+
 [Eraser*]
 LangSecRef=3024
 Detect=HKCU\Software\Heidi Computers Ltd\Eraser\5.5
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Eraser|schedlog.txt
 FileKey2=%ProgramFiles%\Eraser*|schedlog.txt
+
+[ESET Online Scanner*]
+LangSecRef=3024
+Detect=HKLM\Software\ESET\ESET Security
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner|log.txt
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner\Modules\data\updfiles\temp|*.*
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner\Quarantine|*.*
+FileKey4=%ProgramFiles%\ESET\ESET Online Scanner|log.txt
+FileKey5=%ProgramFiles%\ESET\ESET Online Scanner\Modules\data\updfiles\temp|*.*
+FileKey6=%ProgramFiles%\ESET\ESET Online Scanner\Quarantine|*.*
 
 [ESET*]
 LangSecRef=3021
@@ -6962,17 +6649,6 @@ FileKey4=%LocalAppData%\VirtualStore\ProgramData\ESET\ESET*\Logs|*.*|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\ESET\ESET*\Oldfiles|*.*|RECURSE
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\ESET\ESET*\Updfiles|*.*|REMOVESELF
 
-[ESET Online Scanner*]
-LangSecRef=3024
-Detect=HKLM\Software\ESET\ESET Security
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner|log.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner\Modules\data\updfiles\temp|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner\Quarantine|*.*
-FileKey4=%ProgramFiles%\ESET\ESET Online Scanner|log.txt
-FileKey5=%ProgramFiles%\ESET\ESET Online Scanner\Modules\data\updfiles\temp|*.*
-FileKey6=%ProgramFiles%\ESET\ESET Online Scanner\Quarantine|*.*
-
 [eSobi*]
 LangSecRef=3022
 DetectFile=%AppData%\eSobi
@@ -6984,32 +6660,27 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma
 DetectFile=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma
 Default=False
-FileKey1=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey6=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey7=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey8=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\PRICache|*.*
-FileKey10=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Temp|*.*
-FileKey11=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\LocalState|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\CLR_v4.0|*.log|RECURSE
+FileKey4=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\PRICache|*.*
+FileKey7=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Temp|*.*
+FileKey8=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\LocalState|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\TempState|*.*|RECURSE
 
 [ESPN FC*]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma
 DetectFile=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma
 Default=False
-FileKey1=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey5=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\PRICache|*.*
-FileKey6=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\Temp|*.*
-FileKey7=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\LocalState|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\Microsoft\CLR_v4.0|*.log|RECURSE
+FileKey3=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\PRICache|*.*
+FileKey4=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\Temp|*.*
+FileKey5=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\LocalState|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\TempState|*.*|RECURSE
 
 [ESPN Motion*]
 LangSecRef=3023
@@ -7026,24 +6697,10 @@ RegKey1=HKCU\Software\ENT3\Recent
 
 [EssentialPIM Desktop Logs*]
 LangSecRef=3021
+Detect=HKLM\Software\clients\mail\essentialpim pro
 DetectFile=%AppData%\EssentialPIM
 Default=False
-FileKey1=%AppData%\EssentialPIM\Logs|*.*
-
-[EssentialPIM Pro Desktop Logs*]
-LangSecRef=3021
-Detect=HKLM\Software\clients\mail\essentialpim pro
-Default=False
-FileKey1=%AppData%\EssentialPIM Pro\Logs|*.*
-
-[Euro Truck Simulator*]
-Section=Games
-Detect1=HKCU\Software\SCS Software
-Detect2=HKLM\Software\SCS Software
-DetectFile=%ProgramFiles%\Euro Truck Simulator 2
-Default=False
-FileKey1=%Documents%\Euro Truck Simulator|*.log;*.crash
-FileKey2=%Documents%\Euro Truck Simulator 2|*.log;*log.txt;*.crash
+FileKey1=%AppData%\EssentialPIM*\Logs|*.*
 
 [Euro Truck Simulator Profile backups*]
 Section=Games
@@ -7055,6 +6712,14 @@ FileKey1=%Documents%\Euro Truck Simulator|backups.txt
 FileKey2=%Documents%\Euro Truck Simulator\profiles*.bak|*.*|REMOVESELF
 FileKey3=%Documents%\Euro Truck Simulator 2|backups.txt
 FileKey4=%Documents%\Euro Truck Simulator 2\profiles*.bak|*.*|REMOVESELF
+
+[Euro Truck Simulator*]
+Section=Games
+Detect1=HKCU\Software\SCS Software
+Detect2=HKLM\Software\SCS Software
+DetectFile=%ProgramFiles%\Euro Truck Simulator 2
+Default=False
+FileKey1=%Documents%\Euro Truck Simulator*|*.log;*.crash
 
 [EuroSYSTEMS CoCut Professional 2011*]
 LangSecRef=3021
@@ -7077,14 +6742,9 @@ FileKey2=%ProgramFiles%\EUROSYSTEMS\SmartCut Pro|*.bak;*.tmp
 Section=Games
 Detect=HKCU\Software\CCP
 Default=False
-FileKey1=%Documents%\EVE\Logs|*.*|RECURSE
-FileKey2=%LocalAppData%\CCP\EVE|history.txt
-
-[EVEMon*]
-Section=Games
-Detect=HKCU\Software\CCP
-Default=False
 FileKey1=%AppData%\EVEMon|*.bak
+FileKey2=%Documents%\EVE\Logs|*.*|RECURSE
+FileKey3=%LocalAppData%\CCP\EVE|history.txt
 
 [Evernote Skitch*]
 LangSecRef=3021
@@ -7157,17 +6817,12 @@ Detect=HKCU\Software\Perception\EZ Backup Ultimate
 Default=False
 FileKey1=%AppData%\EZ Backup Ultimate|lastlog.html
 
-[F-Secure Password Manager LocalStorage*]
+[F-Secure Password Manager*]
 LangSecRef=3021
 Detect=HKCU\Software\F-Secure
 Default=False
 FileKey1=%LocalAppData%\F-Secure\Pwmgr|*.log
-
-[F-Secure Password Manager Log*]
-LangSecRef=3021
-Detect=HKCU\Software\F-Secure
-Default=False
-FileKey1=%LocalAppData%\F-Secure\Pwmgr\LocalStorage|*.*|RECURSE
+FileKey2=%LocalAppData%\F-Secure\Pwmgr\LocalStorage|*.*|RECURSE
 
 [Facebook Messenger*]
 LangSecRef=3022
@@ -7192,7 +6847,7 @@ FileKey1=%LocalAppData%\Facebook\CrashReports|*.*
 LangSecRef=3023
 Detect=HKCU\Software\Lenovo
 Default=False
-FileKey1=%SystemDrive%|Faceprov.*
+FileKey1=%SystemDrive%\|Faceprov.*
 
 [Fallout Shelter*]
 Section=Games
@@ -7236,27 +6891,23 @@ RegKey19=HKCU\Software\Far18\SavedHistory
 RegKey20=HKCU\Software\Far18\SavedViewHistory
 RegKey21=HKCU\Software\Far18\Viewer\LastPositions
 
-[Farming Simulator*]
-Section=Games
-Detect=HKLM\Software\SCS Software
-Default=False
-FileKey1=%Documents%\My Games\FarmingSimulator2011|*.txt
-FileKey2=%Documents%\My Games\FarmingSimulator2011\pdlc2.1|*.dlc|REMOVESELF
-FileKey3=%Documents%\My Games\FarmingSimulator2011\shader_cache|*.xml|REMOVESELF
-FileKey4=%Documents%\My Games\FarmingSimulator2013|*.txt
-FileKey5=%Documents%\My Games\FarmingSimulator2013\pdlc|*.dlc|REMOVESELF
-FileKey6=%Documents%\My Games\FarmingSimulator2013\shader_cache|*.shc|REMOVESELF
-
 [Farming Simulator Old Autosaves*]
 Section=Games
 Detect=HKLM\Software\SCS Software
 Default=False
-FileKey1=%Documents%\My Games\FarmingSimulator2011\savegame*|*.*|REMOVESELF
-FileKey2=%Documents%\My Games\FarmingSimulator2011\savegame*_autoBackup*|*.*|REMOVESELF
-FileKey3=%Documents%\My Games\FarmingSimulator2013\savegame*|*.*|REMOVESELF
+FileKey1=%Documents%\My Games\FarmingSimulator*\savegame*|*.*|REMOVESELF
 ExcludeKey1=PATH|%Documents%\My Games\FarmingSimulator2011\savegame1\|*.*
 ExcludeKey2=PATH|%Documents%\My Games\FarmingSimulator2013\savegame1\|*.*
 ExcludeKey3=PATH|%Documents%\My Games\FarmingSimulator2013\savegameBackup\|*.*
+
+[Farming Simulator*]
+Section=Games
+Detect=HKLM\Software\SCS Software
+Default=False
+FileKey1=%Documents%\My Games\FarmingSimulator*|*.txt
+FileKey2=%Documents%\My Games\FarmingSimulator*\pdlc2.1|*.dlc|REMOVESELF
+FileKey3=%Documents%\My Games\FarmingSimulator2011\shader_cache|*.xml|REMOVESELF
+FileKey4=%Documents%\My Games\FarmingSimulator2013\shader_cache|*.shc|REMOVESELF
 
 [Fast Clean Pro*]
 LangSecRef=3024
@@ -7323,8 +6974,25 @@ LangSecRef=3024
 Detect=HKCU\Software\Fighters
 Default=False
 Warning=Fighter System Tray Application needs closed to completely clear all logs.
-FileKey1=%AppData%\Fighters\Suite\Logs|*.*
-FileKey2=%AppData%\Fighters\Tray\Logs|*.*
+FileKey1=%AppData%\Fighters\*\Logs|*.*
+
+[File Shredder*]
+LangSecRef=3024
+Detect=HKCU\Software\Shredder
+Default=False
+RegKey1=HKCU\Software\Shredder\{FF14D9EE-48EB-4873-80AC-8E224BEE5823}
+
+[File Transfer Manager*]
+LangSecRef=3025
+DetectFile=%AppData%\Microsoft\File Transfer Manager
+Default=False
+FileKey1=%AppData%\Microsoft\File Transfer Manager|*.bak
+
+[File Type Doctor Last Selected*]
+LangSecRef=3024
+Detect=HKCU\Software\Creative Element\File Type Doctor
+Default=False
+RegKey1=HKCU\Software\Creative Element\File Type Doctor|LastSelected
 
 [FileCleaner*]
 LangSecRef=3024
@@ -7359,24 +7027,6 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Metability Software\FileMindQuickFix|*.log|RECURSE
 FileKey2=%ProgramFiles%\Metability Software\FileMindQuickFix|*.log|RECURSE
 
-[File Shredder*]
-LangSecRef=3024
-Detect=HKCU\Software\Shredder
-Default=False
-RegKey1=HKCU\Software\Shredder\{FF14D9EE-48EB-4873-80AC-8E224BEE5823}
-
-[File Transfer Manager*]
-LangSecRef=3025
-DetectFile=%AppData%\Microsoft\File Transfer Manager
-Default=False
-FileKey1=%AppData%\Microsoft\File Transfer Manager|*.bak
-
-[File Type Doctor Last Selected*]
-LangSecRef=3024
-Detect=HKCU\Software\Creative Element\File Type Doctor
-Default=False
-RegKey1=HKCU\Software\Creative Element\File Type Doctor|LastSelected
-
 [FileZilla Temps*]
 LangSecRef=3022
 Detect=HKLM\Software\FileZilla Client
@@ -7389,13 +7039,10 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\FilmOnLiveTVFree.FilmOnLiveTVFree_zx03kxexxb716
 DetectFile=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_zx03kxexxb716
 Default=False
-FileKey1=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey2=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey3=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 FileKey4=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\INetCache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\INetCookies|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\INetHistory|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\FilmOnLiveTVFree.FilmOnLiveTVFree_zx03kxexxb716\SearchHistory
 
 [Firebird Project Logs*]
@@ -7419,10 +7066,9 @@ FileKey1=%AppData%\FixCleaner\Logs|*.*
 
 [Flash Media Encoder*]
 LangSecRef=3023
-DetectFile1=%ProgramFiles%\Adobe\Flash Media Live Encoder 3.1
-DetectFile2=%ProgramFiles%\Adobe\Flash Media Live Encoder 3.2
+DetectFile=%ProgramFiles%\Adobe\Flash Media Live Encoder *
 Default=False
-FileKey1=%Video%|fmle*.log
+FileKey1=%Video%\|fmle*.log
 
 [FlashFXP*]
 LangSecRef=3022
@@ -7500,6 +7146,12 @@ Default=False
 FileKey1=%AppData%\Forte\Agent|errorlog.xml;*.log|RECURSE
 FileKey2=%SystemDrive%\My Data\ForteAgent|*.bak;*.log
 
+[Fortnite*]
+Section=Games
+DetectFile=%LocalAppData%\FortniteGame\
+Default=False
+FileKey1=%LocalAppData%\FortniteGame\Saved\Logs|*.*
+
 [Forward Observer*]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\AAForwardObserver\AAForwardObserver.exe
@@ -7513,31 +7165,17 @@ Detect=HKLM\SOFTWARE\Mozilla\FossaMail
 Default=False
 FileKey1=%AppData%\FossaMail\Profiles|*.corrupt|RECURSE
 
-[FossaMail Crash Reports*]
-LangSecRef=3030
-Detect=HKLM\SOFTWARE\Mozilla\FossaMail
-Default=False
-FileKey1=%AppData%\FossaMail\Crash Reports|*.*|REMOVESELF
-
-[FossaMail Extensions Log*]
-LangSecRef=3030
-Detect=HKLM\SOFTWARE\Mozilla\FossaMail
-Default=False
-FileKey1=%AppData%\FossaMail\Profiles\*|extensions.log
-
 [FossaMail Log*]
 LangSecRef=3030
 Detect=HKLM\SOFTWARE\Mozilla\FossaMail
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\FossaMail|*.log
-FileKey2=%ProgramFiles%\FossaMail|*.log
-
-[FossaMail Maintenance Service*]
-LangSecRef=3030
-Detect=HKLM\SOFTWARE\Mozilla\FossaMail
-Default=False
-FileKey1=%CommonAppData%\Mozilla*\logs|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Mozilla*\logs|*.*|REMOVESELF
+FileKey1=%AppData%\FossaMail\Crash Reports|*.*|REMOVESELF
+FileKey2=%AppData%\FossaMail\Profiles\*|TestPilotErrorLog.*;extensions.log|RECURSE
+FileKey3=%CommonAppData%\Mozilla*\logs|*.*|REMOVESELF
+FileKey4=%LocalAppData%\FossaMail\Mozilla\*\Updates|*.log|RECURSE
+FileKey5=%LocalAppData%\VirtualStore\Program Files*\FossaMail|*.log
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Mozilla*\logs|*.*|REMOVESELF
+FileKey7=%ProgramFiles%\FossaMail|*.log
 
 [FossaMail Minidumps*]
 LangSecRef=3030
@@ -7556,18 +7194,6 @@ LangSecRef=3030
 Detect=HKLM\SOFTWARE\Mozilla\FossaMail
 Default=False
 FileKey1=%LocalAppData%\FossaMail\Profiles\*\startupCache|*.*
-
-[FossaMail TestPilot Error Logs*]
-LangSecRef=3030
-Detect=HKLM\SOFTWARE\Mozilla\FossaMail
-Default=False
-FileKey1=%AppData%\FossaMail\Profiles\*|TestPilotErrorLog.*|RECURSE
-
-[FossaMail Update Logs*]
-LangSecRef=3030
-Detect=HKLM\SOFTWARE\Mozilla\FossaMail
-Default=False
-FileKey1=%LocalAppData%\FossaMail\Mozilla\*\Updates|*.log|RECURSE
 
 [FossaMail webappsstore.sqlite*]
 LangSecRef=3030
@@ -7630,7 +7256,7 @@ FileKey1=%AppData%\Free Download Manager|downloads.del.sav
 LangSecRef=3024
 Detect=HKCU\Software\shbox\FreePdfXP
 Default=False
-FileKey1=%SystemDrive%|IfpRedmon.log
+FileKey1=%SystemDrive%\|IfpRedmon.log
 
 [Free Registry Defrag*]
 LangSecRef=3024
@@ -7686,12 +7312,16 @@ FileKey2=%AppData%\Fighters\Suite\Logs|*log.txt
 FileKey3=%AppData%\Fighters\Tray\Logs|*log.txt
 FileKey4=%CommonAppData%\Common Toolkit Suite\Tools\Logs|*.log
 FileKey5=%CommonAppData%\Fighters\FULL-DISKfighter\Logs|*.log
-FileKey6=%CommonAppData%\Fighters\Suite\Logs|*.log
-FileKey7=%CommonAppData%\Fighters\Tray\Logs|*.log
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Common Toolkit Suite\Tools\Logs|*.log
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Fighters\FULL-DISKfighter\Logs|*.log
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Fighters\Suite\Logs|*.log
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\Fighters\Tray\Logs|*.log
+FileKey6=%CommonAppData%\Fighters\*\Logs|*.log
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\Common Toolkit Suite\Tools\Logs|*.log
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\Fighters\FULL-DISKfighter\Logs|*.log
+FileKey9=%LocalAppData%\VirtualStore\ProgramData\Fighters\*\Logs|*.log
+
+[Full Bore*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\105430
+Default=False
+FileKey1=%Documents%\Full Bore|log.txt
 
 [Full Tilt Poker*]
 Section=Games
@@ -7716,25 +7346,14 @@ FileKey7=%ProgramFiles%\G Data\AntiVirus\AVK\UpdatePGM|*.log
 LangSecRef=3022
 Detect=HKCU\Software\Gadu-Gadu
 Default=False
-FileKey1=%WinDir%|TEMP*.htm*
+FileKey1=%WinDir%\|TEMP*.htm*
 
-[Gajim Avatars*]
+[Gajim*]
 LangSecRef=3022
 DetectFile=%AppData%\Gajim
 Default=False
-FileKey1=%AppData%\Gajim\Avatars|*.*
-
-[Gajim Cache*]
-LangSecRef=3022
-DetectFile=%AppData%\Gajim
-Default=False
-FileKey1=%AppData%\Gajim|cache.db
-
-[Gajim Logs*]
-LangSecRef=3022
-DetectFile=%AppData%\Gajim
-Default=False
-FileKey1=%AppData%\Gajim|Logs.db;gajim.log
+FileKey1=%AppData%\Gajim|cache.db;Logs.db;gajim.log
+FileKey2=%AppData%\Gajim\Avatars|*.*
 
 [Game Maker*]
 LangSecRef=3021
@@ -7810,11 +7429,9 @@ Detect2=HKCR\GSM_gsdu
 Detect3=HKCR\GSM_gsms
 Default=False
 FileKey1=%AppData%\GameSave Manager*\TaskLogs|*.*
-FileKey2=%AppData%\GameSave Manager*\TaskCache|*.*
-FileKey3=%AppData%\GameSave Manager*\GameCache|*.*
-FileKey4=%AppData%\GameSave Manager*\$$ CacheDir $$|*.*|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\GameSave Manager*\settings|*.log;ScanResults.txt|RECURSE
-FileKey6=%ProgramFiles%\GameSave Manager*\settings|*.log;ScanResults.txt|RECURSE
+FileKey2=%AppData%\GameSave Manager*\*Cache*|*.*
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\GameSave Manager*\settings|*.log;ScanResults.txt|RECURSE
+FileKey4=%ProgramFiles%\GameSave Manager*\settings|*.log;ScanResults.txt|RECURSE
 
 [Gardens Inc. 2 - The Road to Fame*]
 Section=Games
@@ -7869,13 +7486,11 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\45351D82.GasBuddy-FindCheapGasPrices_932xwky9axss4
 DetectFile=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_932xwky9axss4
 Default=False
-FileKey1=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\PRICache|*.*
-FileKey6=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Temp|*.*
-FileKey7=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\PRICache|*.*
+FileKey4=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Temp|*.*
+FileKey5=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\TempState|*.*|RECURSE
 
 [gBurner*]
 LangSecRef=3021
@@ -7934,23 +7549,13 @@ Detect=HKCU\Software\Genie-Soft
 Default=False
 FileKey1=%AppData%\Genie-soft\*\logs|*.*
 
-[Genieo Cache*]
-LangSecRef=3022
-DetectFile=%AppData%\Genieo
-Default=False
-FileKey1=%AppData%\Genieo\sp_cache|*.*|RECURSE
-
-[Genieo Log*]
+[Genieo*]
 LangSecRef=3022
 DetectFile=%AppData%\Genieo
 Default=False
 FileKey1=%AppData%\Genieo\log|*.*|RECURSE
-
-[Genieo Temps*]
-LangSecRef=3022
-DetectFile=%AppData%\Genieo
-Default=False
-FileKey1=%AppData%\Genieo\tmp|*.*|RECURSE
+FileKey2=%AppData%\Genieo\tmp|*.*|RECURSE
+FileKey3=%AppData%\Genieo\sp_cache|*.*|RECURSE
 
 [Genymobile Logs*]
 LangSecRef=3024
@@ -7959,18 +7564,29 @@ Default=False
 FileKey1=%LocalAppData%\Genymobile|*.log
 FileKey2=%UserProfile%\VirtualBox VMs\*|genymotion-player*.log;logcat*.txt
 
+[Get Office*]
+DetectOS=10.0|
+Section=3031
+Default=False
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MicrosoftOfficeHub_8wekyb3d8bbwe
+FileKey1=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\Temp|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalState\AppData\Local\Office\16.0\WebServiceCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalState\Cache|*.*|RECURSE
+
 [Get Started*]
 DetectOS=10.0|
 Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Getstarted_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.Getstarted_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Getstarted_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Getstarted_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Getstarted_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Getstarted_*\LocalCache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Getstarted_*\LocalState\Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Getstarted_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.Getstarted_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Getstarted_*\AC\Temp|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Getstarted_*\LocalCache|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Getstarted_*\LocalState\Cache|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.Getstarted_*\TempState|*.*|RECURSE
 
 [GetDiz Recent Files List*]
 LangSecRef=3021
@@ -7994,22 +7610,6 @@ Default=False
 RegKey1=HKCU\Software\GetFLV|DownloadDir
 RegKey2=HKCU\Software\getflv|FLVTitle
 RegKey3=HKCU\Software\GetFLV|FLVURL
-
-[Get Office*]
-DetectOS=10.0|
-Section=3031
-Default=False
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MicrosoftOfficeHub_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalCache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalState\AppData\Local\Office\16.0\WebServiceCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalState\Cache|*.*|RECURSE
 
 [GetRight*]
 LangSecRef=3022
@@ -8063,24 +7663,17 @@ FileKey2=%LocalAppData%\Shalsoft\Gigatribe\*\resources|*.*|RECURSE
 LangSecRef=3021
 DetectFile=%UserProfile%\.gimp-2.8
 Default=False
-FileKey1=%LocalAppData%|recently-used.xbel
+FileKey1=%LocalAppData%\|recently-used.xbel
 FileKey2=%LocalAppData%\webkit|*.*|REMOVESELF
 
-[Ginger Logs*]
+[Ginger*]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Ginger
 Default=False
 FileKey1=%Documents%\Add-in Express|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ginger|*.log|RECURSE
-FileKey3=%ProgramFiles%\Ginger|*.log|RECURSE
-FileKey4=%SystemDrive%|GingerSetup.log
-
-[Ginger Temps*]
-LangSecRef=3021
-DetectFile=%ProgramFiles%\Ginger
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Ginger|*.tmp|RECURSE
-FileKey2=%ProgramFiles%\Ginger|*.tmp|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ginger|*.log;*.tmp|RECURSE
+FileKey3=%ProgramFiles%\Ginger|*.log;*.tmp|RECURSE
+FileKey4=%SystemDrive%\|GingerSetup.log
 
 [GitHub*]
 LangSecRef=3022
@@ -8161,17 +7754,11 @@ Default=False
 FileKey1=%AppData%\GoodSync|*.log|RECURSE
 FileKey2=%Documents%\_gsdata_|*.log|RECURSE
 
-[Google Apps Migration*]
-LangSecRef=3022
-DetectFile=%LocalAppData%\Google\Google Apps Migration
-Default=False
-FileKey1=%LocalAppData%\Google\Google Apps Migration|*.log|RECURSE
-
 [Google Apps Sync*]
 LangSecRef=3022
-DetectFile=%LocalAppData%\Google\Google Apps Sync
+DetectFile=%LocalAppData%\Google\Google Apps *
 Default=False
-FileKey1=%LocalAppData%\Google\Google Apps Sync|*.log|RECURSE
+FileKey1=%LocalAppData%\Google\Google Apps *|*.log|RECURSE
 
 [Google Calendar Sync*]
 LangSecRef=3022
@@ -8269,29 +7856,21 @@ Detect=HKCU\Software\Gradekeeper
 Default=False
 FileKey1=%AppData%\Gradekeeper|*.*
 
-[Gratuitous Space Battles Debug*]
+[Gratuitous Space Battles*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\41800
 Default=False
 FileKey1=%Documents%\My Games\GratuitousSpaceBattles\debug|*.*
-
-[Gratuitous Space Battles Temp*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\41800
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\gratuitous space battles\data\temp|*.*|RECURSE
-FileKey2=%ProgramFiles%\Steam\Steamapps\common\gratuitous space battles\data\temp|*.*|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\gratuitous space battles\data\temp|*.*|RECURSE
+FileKey3=%ProgramFiles%\Steam\Steamapps\common\gratuitous space battles\data\temp|*.*|RECURSE
 
 [Gravity Guy*]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\MiniclipSA.GravityGuy_gpanv85qtf6rc
 DetectFile=%LocalAppData%\Packages\MiniclipSA.GravityGuy_gpanv85qtf6rc
 Default=False
-FileKey1=%LocalAppData%\Packages\MiniclipSA.GravityGuy_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\MiniclipSA.GravityGuy_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\MiniclipSA.GravityGuy_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\MiniclipSA.GravityGuy_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey5=%LocalAppData%\Packages\MiniclipSA.GravityGuy_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
+FileKey1=%LocalAppData%\Packages\MiniclipSA.GravityGuy_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\MiniclipSA.GravityGuy_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 
 [Green Ranch Log*]
 Section=Games
@@ -8338,23 +7917,18 @@ Detect=HKCU\Software\Novell\Messenger
 Default=False
 FileKey1=%LocalAppData%\Novell\GroupWise Messenger\history\%username%|*.*
 
-[Growl Cache*]
-LangSecRef=3024
-Detect=HKCU\Software\Growl
-Default=False
-FileKey1=%LocalAppData%\Growl\*\ImageCache|*.*|RECURSE
-
 [Growl History*]
 LangSecRef=3024
 Detect=HKCU\Software\Growl
 Default=False
 FileKey1=%LocalAppData%\Growl\*\History|*.*|RECURSE
 
-[Growl Logs*]
+[Growl*]
 LangSecRef=3024
 Detect=HKCU\Software\Growl
 Default=False
-FileKey1=%LocalAppData%\Growl\*\Log|*.*|RECURSE
+FileKey1=%LocalAppData%\Growl\*\ImageCache|*.*|RECURSE
+FileKey2=%LocalAppData%\Growl\*\Log|*.*|RECURSE
 
 [GSpot*]
 LangSecRef=3024
@@ -8399,11 +7973,8 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.HaloSpartanAssault_8wekyb3d8bbwe
 DetectFile=%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey5=%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
+FileKey1=%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 
 [HandBrake*]
 LangSecRef=3024
@@ -8435,17 +8006,12 @@ FileKey1=%AppData%\Novosoft\Handy Backup\logs|*.*
 Section=Games
 Detect=HKCU\Software\HappyCloud
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\ProgramData\HappyCloud\cache|*.*
+FileKey1=%CommonAppData%\HappyCloud|*.log
 FileKey2=%CommonAppData%\HappyCloud\cache|*.*
+FileKey3=%LocalAppData%\VirtualStore\ProgramData\HappyCloud|*.log
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\HappyCloud\cache|*.*
 
-[HappyCloud Logs*]
-Section=Games
-Detect=HKCU\Software\HappyCloud
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\ProgramData\HappyCloud|*.log
-FileKey2=%CommonAppData%\HappyCloud|*.log
-
-[Hard Drive Inspector Error Log*]
+[Hard Drive Inspector*]
 LangSecRef=3024
 DetectFile=%CommonAppData%\AltrixSoft\Hard Drive Inspector
 Default=False
@@ -8456,7 +8022,7 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData\AltrixSoft\Hard Drive Inspector
 LangSecRef=3024
 Detect=HKLM\SOFTWARE\Hauppauge
 Default=False
-FileKey1=%SystemDrive%|hcwDriverInstall.txt
+FileKey1=%SystemDrive%\|hcwDriverInstall.txt
 FileKey2=%Public%\WinTV|Settings-old.xml
 FileKey3=%Public%\WinTV\Channel Database|hcwChanDB_5-lastgood.mdb
 FileKey4=%Public%\WinTV\Logs\minidump|*.*|RECURSE
@@ -8467,6 +8033,13 @@ Detect=HKLM\SYSTEM\CurrentControlSet\services\HDDHealth
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\HDD Health|*.tmp
 FileKey2=%ProgramFiles%\HDD Health|*.tmp
+
+[HDD Regenerator*]
+LangSecRef=3024
+DetectFile=%ProgramFiles%\HDD Regenerator
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\HDD Regenerator|*.log|RECURSE
+FileKey2=%ProgramFiles%\HDD Regenerator|*.log|RECURSE
 
 [HDD Thermometer*]
 LangSecRef=3024
@@ -8525,7 +8098,7 @@ FileKey3=%LocalAppData%\VirtualStore\Program Files*\Hi-Rez Studios\hireztemp|*.*
 FileKey4=%LocalAppData%\VirtualStore\ProgramData\Hi-Rez Studios\BrowserCacheTribes\Default|*.*|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\Hi-Rez Studios\HiPatchService\log|*.*
 FileKey6=%ProgramFiles%\Hi-Rez Studios\hireztemp|*.*
-FileKey7=%RootDir%|HiRezUpdateInstallLog.txt
+FileKey7=%RootDir%\|HiRezUpdateInstallLog.txt
 
 [HijackThis Backups*]
 LangSecRef=3024
@@ -8680,30 +8253,12 @@ Detect=HKLM\Software\microsoft\windows\currentversion\uninstall\HP Drive Key Boo
 Default=False
 FileKey1=%SystemDrive%\CPQSYSTEM|*.*|REMOVESELF
 
-[HP Guide Cache*]
-LangSecRef=3024
-DetectFile=%LocalAppData%\HP Guide
-Default=False
-FileKey1=%LocalAppData%\HP Guide\mp_cache|*.*
-
-[HP Guide Log*]
+[HP Guide*]
 LangSecRef=3024
 DetectFile=%LocalAppData%\HP Guide
 Default=False
 FileKey1=%LocalAppData%\HP Guide|log1.*
-
-[HP Install Logs*]
-LangSecRef=3021
-Detect=HKCU\Software\HP
-DetectFile=%CommonAppData%\HP
-Default=False
-FileKey1=%AppData%\HP\WebRegLogs|WebRegLog.txt
-FileKey2=%CommonAppData%|hpzinstall.log
-FileKey3=%CommonAppData%\Hewlett-Packard|*.log*.*;*Log.txt|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData|hpzinstall.log
-FileKey5=%SystemDrive%\Documents and Settings\All Users\Application Data|hpzinstall.log
-FileKey6=%SystemDrive%\hp\bin\logs|*.log
-FileKey7=%SystemDrive%\Users\All Users|hpzinstall.log
+FileKey2=%LocalAppData%\HP Guide\mp_cache|*.*
 
 [HP Install Temps*]
 LangSecRef=3021
@@ -8717,7 +8272,7 @@ FileKey4=%LocalAppData%\VirtualStore\ProgramData\HP\Installer\Temp|*.*
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\HP\Temp|*.*
 FileKey6=%ProgramFiles%\HP\Temp|*.*|RECURSE
 FileKey7=%SystemDrive%\Users\All Users\HP\Installer\Temp|*.*
-FileKey8=%WinDir%|*.dat.temp
+FileKey8=%WinDir%\|*.dat.temp
 
 [HP Installation Files*]
 LangSecRef=3024
@@ -8727,13 +8282,35 @@ Default=False
 FileKey1=%SystemDrive%\swsetup|*.*|REMOVESELF
 FileKey2=%SystemDrive%\HP Universal Print Driver|*.*|REMOVESELF
 
+[HP Logs*]
+LangSecRef=3021
+Detect=HKCU\Software\HP
+DetectFile1=%CommonAppData%\HP
+DetectFile2=%CommonAppData%\Hewlett-Packard\
+DetectFile3=%AppData%\hpqlog
+DetectFile4=%ProgramFiles%\HPQ\Shared\Sierra Wireless
+DetectFile5=%LocalAppData%\TouchSmartData
+Default=False
+FileKey1=%AppData%\HP\WebRegLogs|WebRegLog.txt
+FileKey2=%AppData%\hpqlog|*.log
+FileKey3=%CommonAppData%\|hpzinstall.log
+FileKey4=%CommonAppData%\Hewlett-Packard|*.log*.*;*Log.txt|RECURSE
+FileKey5=%CommonAppData%\Hewlett-Packard\HP*\Log*|*.*|RECURSE
+FileKey6=%LocalAppData%\TouchSmartData\Log|*.*
+FileKey7=%LocalAppData%\VirtualStore\Program Files*\HPQ\Shared\Sierra Wireless|*.log|RECURSE
+FileKey8=%LocalAppData%\VirtualStore\ProgramData|hpzinstall.log
+FileKey9=%LocalAppData%\VirtualStore\ProgramData\Hewlett-Packard\HP*\Logs|*.*|RECURSE
+FileKey10=%ProgramFiles%\HPQ\Shared\Sierra Wireless|*.log|RECURSE
+FileKey11=%SystemDrive%\Documents and Settings\All Users\Application Data|hpzinstall.log
+FileKey12=%SystemDrive%\hp\bin\logs|*.log
+FileKey13=%SystemDrive%\Users\All Users|hpzinstall.log
+
 [HP MediaSmart Photo*]
 LangSecRef=3023
 DetectFile=%LocalAppData%\Hewlett-Packard\MediaSmart\Photo
 Default=False
 FileKey1=%LocalAppData%\Hewlett-Packard\MediaSmart\Photo|subsys.cache
-FileKey2=%LocalAppData%\Hewlett-Packard\MediaSmart\Photo\tmbCache|*.*|REMOVESELF
-FileKey3=%LocalAppData%\Hewlett-Packard\MediaSmart\Photo\tmpCache|*.*|REMOVESELF
+FileKey2=%LocalAppData%\Hewlett-Packard\MediaSmart\Photo\tm*Cache|*.*|REMOVESELF
 
 [HP Photosmart Premier*]
 LangSecRef=3021
@@ -8747,30 +8324,12 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\AD2F1837.HPPrinterControl_v10z8vjag6ke6
 Default=False
 FileKey1=%LocalAppData%\Packages\*HPPrinterControl_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\*HPPrinterControl_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\*HPPrinterControl_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\*HPPrinterControl_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\*HPPrinterControl_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey6=%LocalAppData%\Packages\*HPPrinterControl_*\AC\Microsoft\CLR_v4.0_32|*.log|RECURSE
-FileKey7=%LocalAppData%\Packages\*HPPrinterControl_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey8=%LocalAppData%\Packages\*HPPrinterControl_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey9=%LocalAppData%\Packages\*HPPrinterControl_*\AC\PRICache|*.*
-FileKey10=%LocalAppData%\Packages\*HPPrinterControl_*\AC\Temp|*.*
-FileKey11=%LocalAppData%\Packages\*HPPrinterControl_*\LocalState|*.*|RECURSE
-
-[HP Recovery*]
-LangSecRef=3021
-DetectFile=%CommonAppData%\Hewlett-Packard\HP Recovery
-Default=False
-FileKey1=%CommonAppData%\Hewlett-Packard\HP Recovery\Log|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Hewlett-Packard\HP Recovery\Log|*.*
-
-[HP Registration Service*]
-LangSecRef=3021
-DetectFile=%CommonAppData%\Hewlett-Packard\HP Registration Service
-Default=False
-FileKey1=%CommonAppData%\Hewlett-Packard\HP Registration Service\Log|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Hewlett-Packard\HP Registration Service\Log|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\*HPPrinterControl_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\*HPPrinterControl_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
+FileKey4=%LocalAppData%\Packages\*HPPrinterControl_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\*HPPrinterControl_*\AC\PRICache|*.*
+FileKey6=%LocalAppData%\Packages\*HPPrinterControl_*\AC\Temp|*.*
+FileKey7=%LocalAppData%\Packages\*HPPrinterControl_*\LocalState|*.*|RECURSE
 
 [HP Scan and Capture*]
 LangSecRef=3031
@@ -8778,48 +8337,18 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\AD2F1837.HPScanandCapture_v10z8vjag6ke6
 Default=False
 FileKey1=%LocalAppData%\Packages\*HPScanandCapture_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\*HPScanandCapture_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\*HPScanandCapture_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\*HPScanandCapture_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\*HPScanandCapture_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey6=%LocalAppData%\Packages\*HPScanandCapture_*\AC\Microsoft\CLR_v4.0_32|*.log|RECURSE
-FileKey7=%LocalAppData%\Packages\*HPScanandCapture_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey8=%LocalAppData%\Packages\*HPScanandCapture_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey9=%LocalAppData%\Packages\*HPScanandCapture_*\AC\PRICache|*.*
-FileKey10=%LocalAppData%\Packages\*HPScanandCapture_*\AC\Temp|*.*
-FileKey11=%LocalAppData%\Packages\*HPScanandCapture_*\LocalState|*.*|RECURSE
-
-[HP Sierra Wireless Log*]
-LangSecRef=3021
-DetectFile=%ProgramFiles%\HPQ\Shared\Sierra Wireless
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\HPQ\Shared\Sierra Wireless|*.log|RECURSE
-FileKey2=%ProgramFiles%\HPQ\Shared\Sierra Wireless|*.log|RECURSE
-
-[HP Support Framework*]
-LangSecRef=3021
-DetectFile=%CommonAppData%\Hewlett-Packard\HP Support Framework
-Default=False
-FileKey1=%CommonAppData%\Hewlett-Packard\HP Support Framework\Logs|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Hewlett-Packard\HP Support Framework\Logs|*.*|RECURSE
-
-[HP Touchsmart Logs*]
-LangSecRef=3021
-DetectFile=%LocalAppData%\TouchSmartData
-Default=False
-FileKey1=%LocalAppData%\TouchSmartData\Log|*.*
+FileKey2=%LocalAppData%\Packages\*HPScanandCapture_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\*HPScanandCapture_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
+FileKey4=%LocalAppData%\Packages\*HPScanandCapture_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\*HPScanandCapture_*\AC\PRICache|*.*
+FileKey6=%LocalAppData%\Packages\*HPScanandCapture_*\AC\Temp|*.*
+FileKey7=%LocalAppData%\Packages\*HPScanandCapture_*\LocalState|*.*|RECURSE
 
 [HP Update*]
 LangSecRef=3021
 DetectFile=%AppData%\HPUpdate
 Default=False
 FileKey1=%AppData%\HpUpdate|*.*
-
-[HPqlog*]
-LangSecRef=3021
-DetectFile=%AppData%\hpqlog
-Default=False
-FileKey1=%AppData%\hpqlog|*.log
 
 [HTC Home Apis*]
 LangSecRef=3021
@@ -8873,14 +8402,11 @@ FileKey1=%LocalAppData%\HuluDesktop\Data|*.log
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\HuluLLC.HuluPlus_fphbd361v8tya
 Default=False
-FileKey1=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\Temp|*.*
-FileKey5=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey6=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey7=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\TempState|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\LocalState|*.tmp|RECURSE
+FileKey1=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\Temp|*.*
+FileKey3=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey4=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\LocalState|*.tmp|RECURSE
 ExcludeKey1=FILE|%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\INetCache\|container.dat
 
 [Huru Beach Party*]
@@ -8900,14 +8426,11 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\19120CensoredUser.HyperforYouTube_c0tqyanwsgfn6
 DetectFile=%LocalAppData%\Packages\19120CensoredUser.HyperforYouTube_c0tqyanwsgfn6
 Default=False
-FileKey1=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey2=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey3=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\INetCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\INetCookies|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\INetHistory|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\*.HyperforYouTube_*\TempState|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\*.HyperforYouTube_*\LocalState|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey2=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\*.HyperforYouTube_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\*.HyperforYouTube_*\LocalState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\19120CensoredUser.HyperforYouTube_c0tqyanwsgfn6\SearchHistory
 
 [HyperSnap 7*]
@@ -8935,7 +8458,7 @@ LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
 Warning=You may need to restart explorer.exe for this to take effect.
-FileKey1=%LocalAppData%|IconCache.db
+FileKey1=%LocalAppData%\|IconCache.db
 
 [Icon Explorer*]
 LangSecRef=3024
@@ -8964,14 +8487,6 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\ID Security Suite\ID Privacy Shield\logs|*.*|RECURSE
 FileKey2=%ProgramFiles%\ID Security Suite\ID Privacy Shield\logs|*.*|RECURSE
 
-[IDEA Caches*]
-LangSecRef=3021
-Detect1=HKCU\Software\JetBrains\IntelliJ IDEA
-Detect2=HKCU\Software\JetBrains\IntelliJ IDEA Community Edition
-Default=False
-FileKey1=%UserProfile%\.IdeaC*\System\Caches|*.*
-FileKey2=%UserProfile%\.IntelliJIdea12\system\Caches|*.*
-
 [IDEA History*]
 LangSecRef=3021
 Detect1=HKCU\Software\JetBrains\IntelliJ IDEA
@@ -8980,21 +8495,17 @@ Default=False
 FileKey1=%UserProfile%\.IdeaC*\System\LocalHistory|*.*
 FileKey2=%UserProfile%\.IntelliJIdea12\system\LocalHistory|*.*
 
-[IDEA Logs*]
+[IDEA*]
 LangSecRef=3021
 Detect1=HKCU\Software\JetBrains\IntelliJ IDEA
 Detect2=HKCU\Software\JetBrains\IntelliJ IDEA Community Edition
 Default=False
-FileKey1=%UserProfile%\.IdeaC*\System\Logs|*.*
-FileKey2=%UserProfile%\.IntelliJIdea12\system\log|*.*
-
-[IDEA Temp*]
-LangSecRef=3021
-Detect1=HKCU\Software\JetBrains\IntelliJ IDEA
-Detect2=HKCU\Software\JetBrains\IntelliJ IDEA Community Edition
-Default=False
-FileKey1=%UserProfile%\.IdeaC*\System\tmp|*.*|RECURSE
-FileKey2=%UserProfile%\.IntelliJIdea12\system\tmp|*.*|RECURSE
+FileKey1=%UserProfile%\.IdeaC*\System\Caches|*.*
+FileKey2=%UserProfile%\.IdeaC*\System\Logs|*.*
+FileKey3=%UserProfile%\.IdeaC*\System\tmp|*.*|RECURSE
+FileKey4=%UserProfile%\.IntelliJIdea12\system\Caches|*.*
+FileKey5=%UserProfile%\.IntelliJIdea12\system\log|*.*
+FileKey6=%UserProfile%\.IntelliJIdea12\system\tmp|*.*|RECURSE
 
 [IdeaSoft Scrapbooks Plus 1.0*]
 LangSecRef=3021
@@ -9061,18 +8572,15 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\windows.immersivecontrolpanel_cw5n1h2txyewy
 Default=False
 FileKey1=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey7=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey8=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\PRICache|*.*
-FileKey10=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Temp|*.*
-FileKey11=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\PRICache|*.*
+FileKey7=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Temp|*.*
+FileKey8=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\windows.immersivecontrolpanel_cw5n1h2txyewy\SearchHistory
 
 [Immunet*]
@@ -9095,6 +8603,7 @@ FileKey2=%AppData%\iMobie\AnyTrans\Backup|*.*|RECURSE
 FileKey3=%AppData%\iMobie\AnyTrans\ErrorLog|*.*|RECURSE
 FileKey4=%AppData%\iMobie\AnyTrans\iMobieConfig|*.*|RECURSE
 FileKey5=%AppData%\iMobie\Backup|*.*|RECURSE
+FileKey6=%AppData%\iMobie\DownloadWebFile\ErrorLog|*.log
 ExcludeKey1=FILE|%AppData%\iMobie\AnyTrans\iMobieConfig\|ConfigReg.ini
 
 [iMobie PhoneClean*]
@@ -9155,14 +8664,11 @@ Detect=HKCU\Software\IMVU
 Default=False
 FileKey1=%AppData%\IMVU|*.chk|RECURSE
 FileKey2=%AppData%\IMVU|*.db;mini.dmp.bak;*.pickle;*.jpg;*.txt;*.log.*;*.log
-FileKey3=%AppData%\IMVU\AssetCache|*.*|REMOVESELF
-FileKey4=%AppData%\IMVU\cache|*.*|REMOVESELF
-FileKey5=%AppData%\IMVU\HTTPCache|*.*|REMOVESELF
-FileKey6=%AppData%\IMVU\PixmapCache|*.*|REMOVESELF
-FileKey7=%AppData%\IMVUClient|*.icns|RECURSE
-FileKey8=%AppData%\IMVUClient\installer|*.*|RECURSE
-FileKey9=%AppData%\IMVUClient\ui\profile\cache|*.*|REMOVESELF
-FileKey10=%AppData%\IMVUClient\ui\profile|*.sqlite;*.js;*.dat;*.mfl
+FileKey3=%AppData%\IMVU\*Cache|*.*|REMOVESELF
+FileKey4=%AppData%\IMVUClient|*.icns|RECURSE
+FileKey5=%AppData%\IMVUClient\installer|*.*|RECURSE
+FileKey6=%AppData%\IMVUClient\ui\profile\cache|*.*|REMOVESELF
+FileKey7=%AppData%\IMVUClient\ui\profile|*.sqlite;*.js;*.dat;*.mfl
 
 [Incredimail*]
 LangSecRef=3022
@@ -9184,27 +8690,16 @@ LangSecRef=3023
 Detect=HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\inkscape.exe
 Default=False
 FileKey1=%AppData%\InkScape|*.log|RECURSE
-FileKey2=%LocalAppData%|recently-used.xbel
-FileKey3=%UserProfile%|.recently-used.xbel
+FileKey2=%LocalAppData%\|recently-used.xbel
+FileKey3=%UserProfile%\|.recently-used.xbel
 
-[Inky Cache*]
+[Inky*]
 LangSecRef=3022
 Detect=HKCU\Software\Inky
 Default=False
-FileKey1=%LocalAppData%\Inky|data_*;f_*;index
-
-[Inky Local Storage*]
-LangSecRef=3022
-Detect=HKCU\Software\Inky
-Default=False
-FileKey1=%LocalAppData%\Inky\Local Storage|*.*
-
-[Inky Logs*]
-LangSecRef=3022
-Detect=HKCU\Software\Inky
-Default=False
-FileKey1=%LocalAppData%\Arcode\Plugin|*.log|RECURSE
-FileKey2=%LocalAppData%\Inky|*.log
+FileKey1=%LocalAppData%\Inky|data_*;f_*;index;*.log
+FileKey2=%LocalAppData%\Arcode\Plugin|*.log|RECURSE
+FileKey3=%LocalAppData%\Inky\Local Storage|*.*
 
 [Inno Setup*]
 LangSecRef=3021
@@ -9225,21 +8720,16 @@ FileKey3=%ProgramFiles%\InnoExtractor|Historial.dat
 FileKey4=%SystemDrive%\Programs\InnoExtractor|Historial.dat
 FileKey5=%Temp%\InnoExtractorCache|*.*|RECURSE
 
-[InnoTab Logs*]
+[InnoTab*]
 LangSecRef=3021
 DetectFile=%CommonAppData%\VTech\DA
 Default=False
 FileKey1=%CommonAppData%\VTech\DA|*.log;InnoTab.txt;IntallLog.txt|RECURSE
 FileKey2=%CommonAppData%\VTech\DA\InnoTab\ConsoleLog|*.*
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\VTech\DA|*.log;InnoTab.txt;IntallLog.txt|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\VTech\DA\InnoTab\ConsoleLog|*.*
-
-[InnoTab Temporary Files*]
-LangSecRef=3021
-DetectFile=%CommonAppData%\VTech\DA
-Default=False
-FileKey1=%CommonAppData%\VTech\DA\InnoTab\Games\tmp|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\VTech\DA\InnoTab\Games\tmp|*.*|REMOVESELF
+FileKey3=%CommonAppData%\VTech\DA\InnoTab\Games\tmp|*.*|REMOVESELF
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\VTech\DA|*.log;InnoTab.txt;IntallLog.txt|RECURSE
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\VTech\DA\InnoTab\ConsoleLog|*.*
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\VTech\DA\InnoTab\Games\tmp|*.*|REMOVESELF
 
 [Inpaint*]
 LangSecRef=3021
@@ -9253,13 +8743,6 @@ LangSecRef=3024
 Detect=HKCU\Software\MetaGeek, LLC\inSSIDer Home
 Default=False
 FileKey1=%LocalAppData%\MetaGeek,_LLC|ConnectionErrorLog;MetaGeek-OUI.backup
-
-[InstallShield*]
-LangSecRef=3024
-Detect=HKCU\Software\InstallShield
-Default=False
-FileKey1=%ProgramFiles%|_ISTMP1.DIR
-FileKey2=%SystemDrive%|_ISTMP*.DIR
 
 [InstallShield Installation Information Logs*]
 LangSecRef=3024
@@ -9285,6 +8768,19 @@ RegKey9=HKCU\Software\InstallShield\InstallShield Professional\6.0\IsCabVu|MRU2
 RegKey10=HKCU\Software\InstallShield\InstallShield Professional\6.0\IsCabVu|MRU3
 RegKey11=HKCU\Software\InstallShield\InstallShield Professional\6.0\IsCabVu|MRU4
 
+[InstallShield*]
+LangSecRef=3024
+Detect=HKCU\Software\InstallShield
+Default=False
+FileKey1=%ProgramFiles%\|_ISTMP1.DIR
+FileKey2=%SystemDrive%\|_ISTMP*.DIR
+
+[Instant Dungeon!*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\326720
+Default=False
+FileKey1=%AppData%\Instant Dungeon|log.txt
+
 [Instantbird Cache*]
 LangSecRef=3022
 DetectFile=%AppData%\Instantbird
@@ -9297,36 +8793,22 @@ DetectFile=%AppData%\Instantbird
 Default=False
 FileKey1=%AppData%\Instantbird\Profiles|*.corrupt|RECURSE
 
-[Instantbird Crash Reports*]
-LangSecRef=3022
-DetectFile=%AppData%\Instantbird
-Default=False
-FileKey1=%AppData%\Instantbird\Crash Reports|*.*|RECURSE
-
-[Instantbird Extensions Log*]
-LangSecRef=3022
-DetectFile=%AppData%\Instantbird
-Default=False
-FileKey1=%AppData%\Instantbird\Profiles\*|extensions.log
-
 [Instantbird Icons*]
 LangSecRef=3022
 DetectFile=%AppData%\Instantbird
 Default=False
 FileKey1=%AppData%\Instantbird\Profiles\*\icons|*.*|RECURSE
 
-[Instantbird Install Log*]
-LangSecRef=3022
-DetectFile=%AppData%\Instantbird
-Default=False
-FileKey1=%ProgramFiles%\Instantbird|install.log
-
 [Instantbird Logs*]
 LangSecRef=3022
 DetectFile=%AppData%\Instantbird
 Default=False
 Warning=This will delete your chat logs as well.
-FileKey1=%AppData%\Instantbird\Profiles\*\logs|*.*|RECURSE
+FileKey1=%AppData%\Instantbird\Crash Reports|*.*|RECURSE
+FileKey2=%AppData%\Instantbird\Profiles\*|extensions.log
+FileKey3=%AppData%\Instantbird\Profiles\*\logs|*.*|RECURSE
+FileKey4=%LocalAppData%\Instantbird\Profiles\*\Updates|*.log|RECURSE
+FileKey5=%ProgramFiles%\Instantbird|install.log
 
 [Instantbird Minidumps*]
 LangSecRef=3022
@@ -9339,12 +8821,6 @@ LangSecRef=3022
 DetectFile=%AppData%\Instantbird
 Default=False
 FileKey1=%LocalAppData%\Instantbird\Profiles\*\startupCache|*.*
-
-[Instantbird Update Logs*]
-LangSecRef=3022
-DetectFile=%AppData%\Instantbird
-Default=False
-FileKey1=%LocalAppData%\Instantbird\Profiles\*\Updates|*.log|RECURSE
 
 [InstEd*]
 LangSecRef=3024
@@ -9490,26 +8966,6 @@ RegKey74=HKCU\Software\DownloadManager\73
 RegKey75=HKCU\Software\DownloadManager\74
 RegKey76=HKCU\Software\DownloadManager\75
 
-[Internet Explorer*]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\windows_ie_ac_001
-DetectFile=%LocalAppData%\Packages\windows_ie_ac_001
-Default=False
-FileKey1=%LocalAppData%\Packages\windows_ie_ac_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\windows_ie_ac_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\windows_ie_ac_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\windows_ie_ac_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey7=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey8=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\windows_ie_ac_*\AC\PRICache|*.*
-FileKey10=%LocalAppData%\Packages\windows_ie_ac_*\AC\Temp|*.*
-FileKey11=%LocalAppData%\Packages\windows_ie_ac_*\LocalState\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\windows_ie_ac_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\windows_ie_ac_*\TempState|*.*|RECURSE
-RegKey1=HKCR\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\windows_ie_ac_001\Internet Explorer\DOMStorage
-
 [Internet Explorer More*]
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Internet Explorer
@@ -9519,24 +8975,15 @@ FileKey2=%AppData%\Microsoft\Internet Explorer\UserData|*.*|RECURSE
 FileKey3=%LocalAppData%\Microsoft\Internet Explorer|frameiconcache.dat;tabiconcache.dat;brndlog.txt;brndlog.bak
 FileKey4=%LocalAppData%\Microsoft\Internet Explorer\Recovery\Last Active|*.*|RECURSE
 FileKey5=%LocalAppData%\Microsoft\SmartScreen|*.tmp
-FileKey6=%LocalAppData%\Microsoft\Windows\AppCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Microsoft\Windows\IECompatCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Microsoft\Windows\IECompatUACache|*.*|RECURSE
-FileKey9=%LocalAppData%\Microsoft\Windows\INetCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Microsoft\Windows\INetCache\Content.Word|*.*
-FileKey11=%LocalAppData%\Microsoft\Windows\INetCache\IE|*.*|RECURSE
-FileKey12=%LocalAppData%\Microsoft\Windows\WebCache|*.*|RECURSE
-FileKey13=%LocalAppData%\Microsoft\Windows\WebCache.old|*.*|REMOVESELF
-FileKey14=%LocalLowAppData%\Microsoft\Internet Explorer\iconcache|*.*|RECURSE
-FileKey15=%LocalLowAppData%\Microsoft\Windows\AppCache|*.*|RECURSE
-FileKey16=%SystemDrive%\Documents and Settings\Default User\Application Data\Microsoft\Internet Explorer|brndlog.bak;brndlog.txt
-FileKey17=%SystemDrive%\Documents and Settings\LocalService\IETldCache|*.*|RECURSE
-FileKey18=%SystemDrive%\Documents and Settings\NetworkService\IETldCache|*.*|RECURSE
-FileKey19=%WinDir%\ServiceProfiles\LocalService\AppData\Roaming\Microsoft\Windows\IETldCache|*.*|RECURSE
-FileKey20=%WinDir%\ServiceProfiles\NetworkService\AppData\Roaming\Microsoft\Windows\IETldCache|*.*|RECURSE
-FileKey21=%WinDir%\System32\config\Systemprofile\AppData\Local\Microsoft\Windows\INetCache|*.*|RECURSE
-FileKey22=%WinDir%\System32\config\SystemProfile\AppData\LocalLow\Microsoft\Internet Explorer|brndlog.bak;brndlog.txt
-FileKey23=%WinDir%\System32\config\SystemProfile\Application Data\Microsoft\Internet Explorer|brndlog.bak;brndlog.txt
+FileKey6=%LocalAppData%\Microsoft\Windows\*Cache*|*.*|RECURSE
+FileKey7=%LocalLowAppData%\Microsoft\Internet Explorer\iconcache|*.*|RECURSE
+FileKey8=%LocalLowAppData%\Microsoft\Windows\AppCache|*.*|RECURSE
+FileKey9=%SystemDrive%\Documents and Settings\Default User\Application Data\Microsoft\Internet Explorer|brndlog.bak;brndlog.txt
+FileKey10=%SystemDrive%\Documents and Settings\*Service\IETldCache|*.*|RECURSE
+FileKey11=%WinDir%\ServiceProfiles\*Service\AppData\Roaming\Microsoft\Windows\IETldCache|*.*|RECURSE
+FileKey12=%WinDir%\System32\config\Systemprofile\AppData\Local\Microsoft\Windows\INetCache|*.*|RECURSE
+FileKey13=%WinDir%\System32\config\SystemProfile\AppData\LocalLow\Microsoft\Internet Explorer|brndlog.bak;brndlog.txt
+FileKey14=%WinDir%\System32\config\SystemProfile\Application Data\Microsoft\Internet Explorer|brndlog.bak;brndlog.txt
 RegKey1=HKCU\Software\Microsoft\Internet Explorer\International|CNum_CpCache
 RegKey2=HKCU\Software\Microsoft\Internet Explorer\International|CpCache
 RegKey3=HKCU\Software\Microsoft\Internet Explorer\International\CpMRU
@@ -9555,6 +9002,23 @@ Detect=HKCU\Software\Microsoft\Internet Explorer
 Default=False
 Warning=This will clear the saved passwords in the Windows Mail App
 FileKey1=%LocalAppData%\Microsoft\Vault\*|*.vcrd
+
+[Internet Explorer*]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\windows_ie_ac_001
+DetectFile=%LocalAppData%\Packages\windows_ie_ac_001
+Default=False
+FileKey1=%LocalAppData%\Packages\windows_ie_ac_*\AC\AppCache|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\windows_ie_ac_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\windows_ie_ac_*\AC\PRICache|*.*
+FileKey7=%LocalAppData%\Packages\windows_ie_ac_*\AC\Temp|*.*
+FileKey8=%LocalAppData%\Packages\windows_ie_ac_*\LocalState\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\windows_ie_ac_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\windows_ie_ac_*\TempState|*.*|RECURSE
+RegKey1=HKCR\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\windows_ie_ac_001\Internet Explorer\DOMStorage
 
 [Intuit Data Protect*]
 LangSecRef=3024
@@ -9582,7 +9046,7 @@ LangSecRef=3021
 DetectFile=%ProgramFiles%\TurboTax*
 Default=False
 FileKey1=%AppData%\Intuit*|*.log|RECURSE
-FileKey2=%CommonAppData%|*.bc
+FileKey2=%CommonAppData%\|*.bc
 FileKey3=%CommonAppData%\Intuit*|*.log|RECURSE
 FileKey4=%CommonAppData%\Intuit\Common\Metrix\*\Logs|*.*
 FileKey5=%CommonAppData%\Intuit\Common\Update Service\*\Logs|*.*
@@ -9602,9 +9066,7 @@ FileKey17=%ProgramFiles%\TurboTax*|*.txt
 [IObit Advanced SystemCare Logs*]
 LangSecRef=3024
 DetectFile1=%AppData%\IObit\Advanced SystemCare V5
-DetectFile2=%CommonAppData%\IObit\Advanced SystemCare V6
-DetectFile3=%CommonAppData%\IObit\Advanced SystemCare V7
-DetectFile4=%CommonAppData%\IObit\Advanced SystemCare V8
+DetectFile2=%CommonAppData%\IObit\Advanced SystemCare V*
 Default=False
 FileKey1=%AppData%\IObit\Advanced SystemCare V5\Log|*.*|RECURSE
 FileKey2=%AppData%\IObit\Advanced SystemCare *|*.log
@@ -9634,6 +9096,13 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\IObit\Advanced SystemCare 6|*.cab_Temp|REMOVESELF
 FileKey2=%ProgramFiles%\IObit\Advanced SystemCare 6|*.cab_Temp|REMOVESELF
 
+[IObit Advanced SystemCare V6 Ultimate Antivirus Backup*]
+LangSecRef=3024
+DetectFile=%ProgramFiles%\IObit\Advanced SystemCare Ultimate
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\IObit\Advanced SystemCare Ultimate\Antivirus\BackupRec|*.*|RECURSE
+FileKey2=%ProgramFiles%\IObit\Advanced SystemCare Ultimate\Antivirus\BackupRec|*.*|RECURSE
+
 [IObit Advanced SystemCare V6 Ultimate Logs*]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\IObit\Advanced SystemCare Ultimate
@@ -9646,13 +9115,6 @@ FileKey5=%LocalAppData%\VirtualStore\ProgramData\IObit\Advanced SystemCare*\Log|
 FileKey6=%ProgramFiles%\IObit\Advanced SystemCare Ultimate|*.log|RECURSE
 FileKey7=%ProgramFiles%\IObit\Advanced SystemCare Ultimate|ASCService_Log.txt
 FileKey8=%ProgramFiles%\IObit\Advanced SystemCare Ultimate\ASCServiceLog|*.*|RECURSE
-
-[IObit Advanced SystemCare V6 Ultimate Antivirus Backup*]
-LangSecRef=3024
-DetectFile=%ProgramFiles%\IObit\Advanced SystemCare Ultimate
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\IObit\Advanced SystemCare Ultimate\Antivirus\BackupRec|*.*|RECURSE
-FileKey2=%ProgramFiles%\IObit\Advanced SystemCare Ultimate\Antivirus\BackupRec|*.*|RECURSE
 
 [IObit ASCDownloader Logs*]
 LangSecRef=3024
@@ -9668,14 +9130,12 @@ Default=False
 FileKey1=%AppData%\IObit\Driver Booster|*.log|RECURSE
 FileKey2=%ProgramFiles%\IObit\Driver Booster|*.log
 
-[IObit Game Booster*]
+[IObit Game Booster 3 GameBox*]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\IObit\Game Booster 3
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3\Update|Update.tmp
-FileKey3=%ProgramFiles%\IObit\Game Booster 3|*.log
-FileKey4=%ProgramFiles%\IObit\Game Booster 3\Update|Update.tmp
+FileKey1=%CommonAppData%\IObit\Game Booster 3|Defrags.ini
+FileKey2=%LocalAppData%\VirtualStore\ProgramData\IObit\Game Booster 3|Defrags.ini
 
 [IObit Game Booster Backup*]
 LangSecRef=3024
@@ -9692,12 +9152,14 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3\FPS|*.*|RECURSE
 FileKey2=%ProgramFiles%\IObit\Game Booster 3\FPS|*.*|RECURSE
 
-[IObit Game Booster 3 GameBox*]
+[IObit Game Booster*]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\IObit\Game Booster 3
 Default=False
-FileKey1=%CommonAppData%\IObit\Game Booster 3|Defrags.ini
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\IObit\Game Booster 3|Defrags.ini
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3|*.log
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3\Update|Update.tmp
+FileKey3=%ProgramFiles%\IObit\Game Booster 3|*.log
+FileKey4=%ProgramFiles%\IObit\Game Booster 3\Update|Update.tmp
 
 [IObit KB Downloader*]
 LangSecRef=3024
@@ -9715,10 +9177,9 @@ FileKey1=%ProgramFiles%\IObit\LiveUpdate|*.log|RECURSE
 LangSecRef=3024
 DetectFile=%AppData%\IObit\IObit Uninstaller
 Default=False
-FileKey1=%AppData%\IObit\IObit Uninstaller\Log|*.log
+FileKey1=%AppData%\IObit\IObit Uninstaller\*Log|*.log
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\IObit\iObit Uninstaller|*.log|RECURSE
 FileKey3=%ProgramFiles%\IObit\iObit Uninstaller|*.log|RECURSE
-FileKey4=%AppData%\IObit\IObit Uninstaller\UMLog|*.log
 
 [iPod-Cloner*]
 LangSecRef=3023
@@ -9728,7 +9189,7 @@ FileKey1=%LocalAppData%\VirtualStore\Program Files*\iPod-Cloner|*.log
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\iPod-Cloner\ReadCache|*.*
 FileKey3=%ProgramFiles%\iPod-Cloner|*.log
 FileKey4=%ProgramFiles%\iPod-Cloner\ReadCache|*.*
-FileKey5=%SystemDrive%|dtdlog.txt
+FileKey5=%SystemDrive%\|dtdlog.txt
 
 [iResizer*]
 LangSecRef=3021
@@ -9750,29 +9211,21 @@ FileKey7=%LocalAppData%\VirtualStore\Program Files*\Common Files\iSkysoft\iSkyso
 RegKey1=HKLM\SOFTWARE\iSkysoft\iSkysoft Helper Compact
 RegKey2=HKLM\SOFTWARE\Wow6432Node\iSkysoft\iSkysoft Helper Compact
 
-[iSkysoft Video Converter Ultimate*]
-LangSecRef=3023
-Detect=HKLM\Software\iSkysoft\iSkysoft Video Converter Ultimate
-Default=False
-FileKey1=%CommonAppData%\iSkysoft Video Converter Ultimate|*.dat.bak
-FileKey2=%CommonAppData%\iSkysoft Video Converter Ultimate\TempSiteIconDir|*.*|RECURSE
-FileKey3=%CommonAppData%\iSkysoft Video Converter Ultimate\TempThumbDir|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\iSkysoft\Video Converter Ultimate\Log|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\iSkysoft\Video Converter Ultimate\TempThumbDir|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\iSkysoft Video Converter Ultimate|*.dat.bak
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\iSkysoft Video Converter Ultimate\TempSiteIconDir|*.*|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\iSkysoft Video Converter Ultimate\TempThumbDir|*.*|RECURSE
-FileKey9=%ProgramFiles%\iSkysoft\Video Converter Ultimate\Log|*.*|RECURSE
-FileKey10=%ProgramFiles%\iSkysoft\Video Converter Ultimate\TempThumbDir|*.*|RECURSE
-
 [iSkysoft Video Converter*]
 LangSecRef=3023
-Detect=HKLM\Software\iSkysoft\Video Converter
+Detect1=HKLM\Software\iSkysoft\iSkysoft Video Converter Ultimate
+Detect2=HKLM\Software\iSkysoft\iSkysoft Video Converter
 Default=False
-FileKey1=%CommonAppData%\iSkysoft Video Converter|*.dat.bak
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\iSkysoft\Video Converter\Log|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\iSkysoft Video Converter|*.dat.bak
-FileKey4=%ProgramFiles%\iSkysoft\Video Converter\Log|*.*|RECURSE
+FileKey1=%CommonAppData%\iSkysoft Video Converter*|*.dat.bak
+FileKey2=%CommonAppData%\iSkysoft Video Converter*\TempSiteIconDir|*.*|RECURSE
+FileKey3=%CommonAppData%\iSkysoft Video Converter*\TempThumbDir|*.*|RECURSE
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\iSkysoft\Video Converter*\Log|*.*|RECURSE
+FileKey5=%LocalAppData%\VirtualStore\Program Files*\iSkysoft\Video Converter*\TempThumbDir|*.*|RECURSE
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\iSkysoft Video Converter*|*.dat.bak
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\iSkysoft Video Converter*\TempSiteIconDir|*.*|RECURSE
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\iSkysoft Video Converter*\TempThumbDir|*.*|RECURSE
+FileKey9=%ProgramFiles%\iSkysoft\Video Converter*\Log|*.*|RECURSE
+FileKey10=%ProgramFiles%\iSkysoft\Video Converter*\TempThumbDir|*.*|RECURSE
 
 [iSpy*]
 LangSecRef=3021
@@ -9848,20 +9301,6 @@ DetectFile=%AppData%\iZotope\iZotope RX 2 Session Data
 Default=False
 FileKey1=%AppData%\iZotope\iZotope RX 2 Session Data|*.*|RECURSE
 
-[Jabbear Avatars*]
-LangSecRef=3022
-Detect=HKCU\Software\Jabbear
-Default=False
-FileKey1=%ProgramFiles%\Jabbear\avatars|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Jabbear\avatars|*.*|RECURSE
-
-[Jabbear Cache*]
-LangSecRef=3022
-Detect=HKCU\Software\Jabbear
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Jabbear\cachedir|*.*|RECURSE
-FileKey2=%ProgramFiles%\Jabbear\cachedir|*.*|RECURSE
-
 [Jabbear Chat History*]
 LangSecRef=3022
 Detect=HKCU\Software\Jabbear
@@ -9869,12 +9308,16 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Jabbear\Users|*.dat;*.html|RECURSE
 FileKey2=%ProgramFiles%\Jabbear\Users|*.dat;*.html|RECURSE
 
-[Jabbear Logs*]
+[Jabbear*]
 LangSecRef=3022
 Detect=HKCU\Software\Jabbear
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Jabbear|*.log|RECURSE
-FileKey2=%ProgramFiles%\Jabbear|*.log|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Jabbear\avatars|*.*|RECURSE
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Jabbear\cachedir|*.*|RECURSE
+FileKey4=%ProgramFiles%\Jabbear|*.log|RECURSE
+FileKey5=%ProgramFiles%\Jabbear\avatars|*.*|RECURSE
+FileKey6=%ProgramFiles%\Jabbear\cachedir|*.*|RECURSE
 
 [Jagex Cache*]
 Section=Games
@@ -9884,17 +9327,12 @@ FileKey1=%UserProfile%\jagex*|*.*|RECURSE
 FileKey2=%WinDir%\.jagex*|*.*|REMOVESELF
 ExcludeKey1=PATH|%UserProfile%\jagexcache\jagexlauncher\|*.*
 
-[JAJC Avatars*]
+[JAJC*]
 LangSecRef=3022
 DetectFile=%UserProfile%\JAJC
 Default=False
 FileKey1=%UserProfile%\JAJC\Avatars|*.*|RECURSE
-
-[JAJC Logs*]
-LangSecRef=3022
-DetectFile=%UserProfile%\JAJC
-Default=False
-FileKey1=%UserProfile%\JAJC\Logs|*.*|RECURSE
+FileKey2=%UserProfile%\JAJC\Logs|*.*|RECURSE
 
 [Jalatext*]
 LangSecRef=3021
@@ -9951,12 +9389,11 @@ FileKey6=%LocalLowAppData%\Sun\Java\jre*|*.*|REMOVESELF
 
 [JavaRa Log*]
 LangSecRef=3022
-DetectFile1=%ProgramFiles%\JavaRa\JavaRa.exe
-DetectFile2=%ProgramFiles%\JavaRa 2.0\JavaRa.exe
+DetectFile=%ProgramFiles%\JavaRa*\JavaRa.exe
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\JavaRa 2.0|*.log|RECURSE
 FileKey2=%ProgramFiles%\JavaRa 2.0|*.log|RECURSE
-FileKey3=%SystemDrive%|JavaRa.log
+FileKey3=%SystemDrive%\|JavaRa.log
 
 [JDownloader .junique*]
 LangSecRef=3022
@@ -10034,17 +9471,12 @@ FileKey6=%ProgramFiles%\JDownloader*2*\tmp|*.*|RECURSE
 ExcludeKey1=PATH|%ProgramFiles%\JDownloader*2*\cfg\|subconf_*.ejs
 ExcludeKey2=PATH|%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*\cfg\|subconf_*.ejs
 
-[jEdit Cache*]
+[jEdit*]
 LangSecRef=3021
 DetectFile=%UserProfile%\.jedit
 Default=False
 FileKey1=%UserProfile%\.jedit\jars-cache|*.*|RECURSE
-
-[jEdit Log*]
-LangSecRef=3021
-DetectFile=%UserProfile%\.jedit
-Default=False
-FileKey1=%UserProfile%\.jedit|*.log|RECURSE
+FileKey2=%UserProfile%\.jedit|*.log|RECURSE
 
 [JetBrains dotPeek v1.1*]
 LangSecRef=3024
@@ -10092,23 +9524,18 @@ Default=False
 FileKey1=%LocalAppData%\TechSmith\Jing\DataStore|*.*|RECURSE
 FileKey2=%LocalAppData%\TechSmith\Jing\Temp|*.*|RECURSE
 
-[Jitsi Avatar Cache*]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\Jitsi
-Default=False
-FileKey1=%AppData%\Jitsi\avatarcache|*.*|RECURSE
-
 [Jitsi Chat/File History*]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Jitsi
 Default=False
 FileKey1=%AppData%\Jitsi\History*|*.*|RECURSE
 
-[Jitsi Logs*]
+[Jitsi*]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Jitsi
 Default=False
-FileKey1=%AppData%\Jitsi\Log|*.*|RECURSE
+FileKey1=%AppData%\Jitsi\avatarcache|*.*|RECURSE
+FileKey2=%AppData%\Jitsi\Log|*.*|RECURSE
 
 [Joboshare DVD Toolkit*]
 LangSecRef=3023
@@ -10117,7 +9544,7 @@ Default=False
 FileKey1=%AppData%\dvdcss|*.*|REMOVESELF
 FileKey2=%Documents%\Joboshare\DVD Copy\ifo_temp|*.*|REMOVESELF
 FileKey3=%Documents%\Joboshare\DVD Copy\log|*.*|REMOVESELF
-FileKey4=%SystemDrive%|*temp.txt;*test.txt
+FileKey4=%SystemDrive%\|*temp.txt;*test.txt
 
 [Join.Me Install Backups*]
 LangSecRef=3022
@@ -10166,12 +9593,10 @@ FileKey2=%ProgramFiles%\jv16 PowerTools X|StartupOptimizer*.log
 LangSecRef=3023
 Detect=HKLM\Software\KLCodecPack
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\K-Lite|*.log;*.txt|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\K-Lite Codec Pack|*.log;*.txt|RECURSE
-FileKey3=%ProgramFiles%\K-Lite|*.log;*.txt|RECURSE
-FileKey4=%ProgramFiles%\K-Lite Codec Pack|*.log;*.txt|RECURSE
-FileKey5=%SystemDrive%|*klcp_itp_*.tmp;*klcp_iph_*.tmp
-FileKey6=%UserProfile%\Desktop|klcp_codec_log.txt
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\K-Lite*|*.log;*.txt|RECURSE
+FileKey2=%ProgramFiles%\K-Lite*|*.log;*.txt|RECURSE
+FileKey3=%SystemDrive%\|*klcp_itp_*.tmp;*klcp_iph_*.tmp
+FileKey4=%UserProfile%\Desktop|klcp_codec_log.txt
 RegKey1=HKU\S-1-5-21-1409082233-152049171-725345543-500\Software\Gabest\vsfilter\DefTextPathes|Path0
 RegKey2=HKU\S-1-5-21-1409082233-152049171-725345543-500\Software\Gabest\vsfilter\DefTextPathes|Path1
 RegKey3=HKU\S-1-5-21-1409082233-152049171-725345543-500\Software\Gabest\vsfilter\DefTextPathes|Path2
@@ -10188,36 +9613,29 @@ DetectFile=%AppData%\Kalypso Media\Launcher
 Default=False
 FileKey1=%AppData%\Kalypso Media\Launcher|log_appdata.txt;log.txt
 
+[Kaspersky Now*]
+Section=3031
+Default=False
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\KasperskyLab.KasperskyNow_8jx5e25qw3tdc
+FileKey1=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Microsoft\CLR_v4.0_32\UsageLogs|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Microsoft\CLR_v4.0_32|*.log
+FileKey4=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\LocalCache|*.*|RECURSE
+
 [Kaspersky*]
 LangSecRef=3024
 Detect=HKCU\Software\KasperskyLab
 Default=False
 Warning=Make sure to disable "Self Defense" before cleaning.
-FileKey1=%CommonAppData%\Kaspersky Lab\*\Bases\Cache|*.*|RECURSE
-FileKey2=%CommonAppData%\Kaspersky Lab\*\Data\Updater\Temporary Files|*.*|RECURSE
-FileKey3=%CommonAppData%\Kaspersky Lab\*\Temp|*.*
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Kaspersky Lab\*\Bases\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Kaspersky Lab\*\Data\Updater\Temporary Files|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Kaspersky Lab\*\Temp|*.*
-FileKey7=%ProgramFiles%\Kaspersky Lab\NetworkAgent\~dumps|*.*
-
-[Kaspersky Dump Files*]
-LangSecRef=3024
-Detect=HKCU\Software\KasperskyLab
-Default=False
 FileKey1=%CommonAppData%\Kaspersky Lab|*.dmp;*.dmp.stat;*.log
-
-[Kaspersky Now*]
-Section=3031
-Default=False
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\KasperskyLab.KasperskyNow_8jx5e25qw3tdc
-FileKey1=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Microsoft\CLR_v4.0_32\UsageLogs|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Microsoft\CLR_v4.0_32|*.log
+FileKey2=%CommonAppData%\Kaspersky Lab\*\Bases\Cache|*.*|RECURSE
+FileKey3=%CommonAppData%\Kaspersky Lab\*\Data\Updater\Temporary Files|*.*|RECURSE
+FileKey4=%CommonAppData%\Kaspersky Lab\*\Temp|*.*
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\Kaspersky Lab\*\Bases\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Kaspersky Lab\*\Data\Updater\Temporary Files|*.*|RECURSE
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\Kaspersky Lab\*\Temp|*.*
+FileKey8=%ProgramFiles%\Kaspersky Lab\NetworkAgent\~dumps|*.*
 
 [Kate's Video Toolkit Logs*]
 LangSecRef=3023
@@ -10268,11 +9686,9 @@ Default=False
 FileKey1=%AppData%\Kingsoft\*|*.bak
 FileKey2=%AppData%\Kingsoft\*\backup|*.*
 FileKey3=%AppData%\Kingsoft\*\update\log|*.log
-FileKey4=%LocalAppData%\Kingsoft\et\cache\http|*
-FileKey5=%LocalAppData%\Kingsoft\et\cache\https|*
-FileKey6=%LocalAppData%\Kingsoft\wps\cache\http|*
-FileKey7=%LocalAppData%\Kingsoft\wps\cache\https|*
-FileKey8=%ProgramFiles%\Kingsoft\Kingsoft Office\*|update.log
+FileKey4=%LocalAppData%\Kingsoft\et\cache\http*|*
+FileKey5=%LocalAppData%\Kingsoft\wps\cache\http*|*
+FileKey6=%ProgramFiles%\Kingsoft\Kingsoft Office\*|update.log
 
 [KlokworkTeamConsole*]
 LangSecRef=3024
@@ -10295,60 +9711,30 @@ Warning=Disables the Kodak AiO Software from automatically starting with Windows
 RegKey1=HKLM\Software\Microsoft\Windows\CurrentVersion\Run|EKAIO2StatusMonitor
 RegKey2=HKLM\Software\Microsoft\Windows\CurrentVersion\Run|EKStatusMonitor
 
-[Kodak AiO Software Logs*]
+[Kodak Logs*]
 LangSecRef=3021
 Detect1=HKLM\Software\Eastman Kodak Company\KODAK AiO Home Center
 Detect2=HKLM\Software\Kodak\Kodak AiO Software
-Default=False
-FileKey1=%CommonAppData%\Kodak\Diagnostics|*.*
-FileKey2=%CommonAppData%\Kodak\Inkjet Logging|*.*|RECURSE
-FileKey3=%LocalAppData%|LaunchHomeCenter.log
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Kodak\Diagnostics|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Kodak\Inkjet Logging|*.*|RECURSE
-
-[Kodak Logs*]
-LangSecRef=3023
-Detect=HKCU\Software\Kodak
-Default=False
-FileKey1=%LocalAppData%\Kodak\Inkjet Logging|Status Monitor Log.*
-FileKey2=%LocalAppData%\Kodak\Diagnostics|UploadLog.xml
-
-[Kodak Share Button App*]
-LangSecRef=3021
+Detect3=HKCU\Software\Kodak
 DetectFile=%AppData%\Kodak\Share Button App
 Default=False
 FileKey1=%AppData%\Kodak\Share Button App|*.log
+FileKey2=%CommonAppData%\Kodak\Diagnostics|*.*
+FileKey3=%CommonAppData%\Kodak\Inkjet Logging|*.*|RECURSE
+FileKey4=%LocalAppData%\|LaunchHomeCenter.log
+FileKey5=%LocalAppData%\Kodak\Diagnostics|UploadLog.xml
+FileKey6=%LocalAppData%\Kodak\Inkjet Logging|Status Monitor Log.*
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\Kodak\Diagnostics|*.*
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\Kodak\Inkjet Logging|*.*|RECURSE
 
-[Kodi Cache*]
+[Kodi*]
 LangSecRef=3023
 DetectFile=%AppData%\kodi
 Default=False
-FileKey1=%AppData%\kodi\cache|*.*|RECURSE
-
-[Kodi Crash Logs*]
-LangSecRef=3023
-DetectFile=%AppData%\kodi
-Default=False
-FileKey1=%AppData%\kodi|*.dmp
-
-[Kodi Logs*]
-LangSecRef=3023
-DetectFile=%AppData%\kodi
-Default=False
-FileKey1=%AppData%\kodi|*.log
-
-[Kodi Packages*]
-LangSecRef=3023
-DetectFile=%AppData%\kodi
-Default=False
-FileKey1=%AppData%\kodi\addons\packages|*.*|RECURSE
-
-[Kodi Thumbnails*]
-LangSecRef=3023
-DetectFile=%AppData%\kodi
-Default=False
-FileKey1=%AppData%\kodi\userdata\thumbnails|*.*|RECURSE
-FileKey2=%AppData%\kodi.old\userdata\thumbnails|*.*|RECURSE
+FileKey1=%AppData%\kodi|*.log;*.dmp
+FileKey2=%AppData%\kodi\addons\packages|*.*|RECURSE
+FileKey3=%AppData%\kodi\cache|*.*|RECURSE
+FileKey4=%AppData%\kodi*\userdata\thumbnails|*.*|RECURSE
 
 [Koffix Blocker*]
 LangSecRef=3024
@@ -10371,23 +9757,18 @@ RegKey2=HKCU\Software\AKi-Software\Kool-Playa\Videos
 RegKey3=HKCU\Software\AKi-Software\Kool-PlayaX64\VideoHistory
 RegKey4=HKCU\Software\AKi-Software\Kool-PlayaX64\Videos
 
-[LanGuard 10 Cache*]
-LangSecRef=3022
-DetectFile=%CommonAppData%\GFI Software\LanGuard 10
-Default=False
-FileKey1=%CommonAppData%\GFI Software\LanGuard 10\Cache|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10\Cache|*.*|REMOVESELF
-
-[LanGuard 10 Logs*]
+[LanGuard 10*]
 LangSecRef=3022
 DetectFile=%CommonAppData%\GFI Software\LanGuard 10
 Default=False
 FileKey1=%CommonAppData%\GFI Software\LanGuard 10|newfileslog.*
-FileKey2=%CommonAppData%\GFI Software\LanGuard 10\DebugLogs|*.*|RECURSE
-FileKey3=%CommonAppData%\GFI Software\LanGuard 10\OperationalLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10|newfileslog.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10\DebugLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10\OperationalLogs|*.*|RECURSE
+FileKey2=%CommonAppData%\GFI Software\LanGuard 10\Cache|*.*|REMOVESELF
+FileKey3=%CommonAppData%\GFI Software\LanGuard 10\DebugLogs|*.*|RECURSE
+FileKey4=%CommonAppData%\GFI Software\LanGuard 10\OperationalLogs|*.*|RECURSE
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10\Cache|*.*|REMOVESELF
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10|newfileslog.*
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10\DebugLogs|*.*|RECURSE
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10\OperationalLogs|*.*|RECURSE
 
 [LastGood.tmp Folder*]
 LangSecRef=3025
@@ -10398,8 +9779,7 @@ FileKey1=%WinDir%\LastGood.tmp|*.*|REMOVESELF
 LangSecRef=3021
 DetectFile=%AppData%\Launchy
 Default=False
-FileKey1=%AppData%\Launchy\controly-icon-cache|*.*
-FileKey2=%AppData%\Launchy\weby-icon-cache|*.*
+FileKey1=%AppData%\Launchy\*-icon-cache|*.*
 
 [Lavender's Botanicals*]
 Section=Games
@@ -10423,16 +9803,14 @@ DetectFile=%ProgramFiles%\LeapFrog\LeapFrog Connect\LeapFrogConnect.exe
 Default=False
 FileKey1=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\cookies|*.*
 FileKey2=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\data7\*|*.*
-FileKey3=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\http|*.*
-FileKey4=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\https|*.*
-FileKey5=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\prepared|*.*
-FileKey6=%CommonAppData%\Leapfrog\LeapFrog Connect\DownloadCache|*.*
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\cookies|*.*
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\data7\*|*.*
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\http|*.*
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\https|*.*
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\prepared|*.*
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\DownloadCache|*.*
+FileKey3=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\http*|*.*
+FileKey4=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\prepared|*.*
+FileKey5=%CommonAppData%\Leapfrog\LeapFrog Connect\DownloadCache|*.*
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\cookies|*.*
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\data7\*|*.*
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\http*|*.*
+FileKey9=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\prepared|*.*
+FileKey10=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\DownloadCache|*.*
 
 [LeapFTP*]
 LangSecRef=3022
@@ -10465,19 +9843,11 @@ FileKey10=%AppData%\Leawo\Prof. Media\Log|*.*|RECURSE
 
 [Leawo Video Converter*]
 LangSecRef=3023
-DetectFile=%AppData%\Leawo\Video Converter
+DetectFile=%AppData%\Leawo\Video Converter*
 Default=False
-FileKey1=%AppData%\Leawo\Video Converter|*.log
-FileKey2=%AppData%\Leawo\Video Converter\CrashReport|*.*|RECURSE
-FileKey3=%LocalAppData%\Video Converter\cache|*.*|RECURSE
-
-[Leawo Video Converter Pro*]
-LangSecRef=3023
-DetectFile=%AppData%\Leawo\Video Converter Pro
-Default=False
-FileKey1=%AppData%\Leawo\Video Converter Pro|*.log
-FileKey2=%AppData%\Leawo\Video Converter Pro\CrashReport|*.*|RECURSE
-FileKey3=%LocalAppData%\Video Converter Pro\cache|*.*|RECURSE
+FileKey1=%AppData%\Leawo\Video Converter*|*.log
+FileKey2=%AppData%\Leawo\Video Converter*\CrashReport|*.*|RECURSE
+FileKey3=%LocalAppData%\Video Converter*\cache|*.*|RECURSE
 
 [LEGO Universe*]
 Section=Games
@@ -10527,9 +9897,15 @@ FileKey7=%LocalAppData%\VirtualStore\Program Files*\Lexware|*.log|RECURSE
 FileKey8=%LocalAppData%\VirtualStore\ProgramData\Lexware\logs|*.*|REMOVESELF
 FileKey9=%LocalAppData%\VirtualStore\ProgramData\Lexware|*.log;*.logx|RECURSE
 FileKey10=%LocalAppData%\VirtualStore\ProgramData\Lexware\elster\Log|*.*|REMOVESELF
-FileKey11=%SystemDrive%|LxDasi.Log
+FileKey11=%SystemDrive%\|LxDasi.Log
 FileKey12=%ProgramFiles%\Common Files\Lexware|*.log|RECURSE
 FileKey13=%ProgramFiles%\Lexware|*.log|RECURSE
+
+[LibreOffice program_old*]
+LangSecRef=3021
+Detect=HKLM\Software\LibreOffice
+Default=False
+FileKey1=%ProgramFiles%\LibreOffice *.*\program_old*|*.*|REMOVESELF
 
 [LibreOffice*]
 LangSecRef=3021
@@ -10540,23 +9916,15 @@ FileKey2=%AppData%\LibreOffice\*\user\extensions\shared|log.*
 FileKey3=%AppData%\LibreOffice\*\User\temp|*.*
 FileKey4=%AppData%\LibreOffice\*\User\uno_packages\cache|log.*
 
-[LibreOffice program_old*]
-LangSecRef=3021
-Detect=HKLM\Software\LibreOffice
-Default=False
-FileKey1=%ProgramFiles%\LibreOffice *.*\program_old*|*.*|REMOVESELF
-
 [LifeCam*]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.LifeCamDashboard_8wekyb3d8bbwe
 DetectFile=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\PRICache|*.*
-FileKey5=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\Temp|*.*
-FileKey6=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\PRICache|*.*
+FileKey3=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\Temp|*.*
+FileKey4=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\TempState|*.*|RECURSE
 
 [LightScribe*]
 LangSecRef=3023
@@ -10569,7 +9937,13 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData\LightScribe\log|*.xml
 LangSecRef=3022
 DetectFile=%LocalAppData%\Skillbrains\lightshot
 Default=False
-FileKey1=%LocalAppData%|updater.log
+FileKey1=%LocalAppData%\|updater.log
+
+[Lili: Child of Geos - Complete Edition*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\apps\266490
+Default=False
+FileKey1=%Documents%\my games\UnrealEngine3-MazeGame\MazeGame\Logs|*.*
 
 [LimeWire*]
 LangSecRef=3022
@@ -10603,41 +9977,36 @@ FileKey1=%LocalAppData%\EdgeOfReality\Loudout\CrashReports|*.*
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\Windows
 Default=False
-FileKey1=%WinDir%\ServiceProfiles\LocalService\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey2=%WinDir%\ServiceProfiles\LocalService\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
+FileKey1=%WinDir%\ServiceProfiles\LocalService\AppData\LocalLow\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 
 [LocalService Cookies*]
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%SystemDrive%\Documents and Settings\LocalService\Cookies|*.*|RECURSE
-FileKey2=%SystemDrive%\Documents and Settings\LocalService.NT*\Cookies|*.*|RECURSE
-FileKey3=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Temp\Cookies|*.*|REMOVESELF
-FileKey4=%WinDir%\ServiceProfiles\LocalService\AppData\Roaming\Microsoft\Windows\Cookies|*.*|REMOVESELF
+FileKey1=%SystemDrive%\Documents and Settings\LocalService*\Cookies|*.*|RECURSE
+FileKey2=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Temp\Cookies|*.*|REMOVESELF
+FileKey3=%WinDir%\ServiceProfiles\LocalService\AppData\Roaming\Microsoft\Windows\Cookies|*.*|REMOVESELF
 
 [LocalService History*]
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%SystemDrive%\Documents and Settings\LocalService\Local Settings\History|*.*|RECURSE
-FileKey2=%SystemDrive%\Documents and Settings\LocalService.NT*\Local Settings\History|*.*|RECURSE
-FileKey3=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows\History|*.*|RECURSE
+FileKey1=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\History|*.*|RECURSE
+FileKey2=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows\History|*.*|RECURSE
 
 [LocalService Temp Files*]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%SystemDrive%\Documents and Settings\LocalService\Local Settings\Temp|*.*|RECURSE
-FileKey2=%SystemDrive%\Documents and Settings\LocalService.NT*\Local Settings\Temp|*.*|RECURSE
-FileKey3=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Temp|*.*|RECURSE
+FileKey1=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\Temp|*.*|RECURSE
+FileKey2=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Temp|*.*|RECURSE
 
 [LocalService Temporary Internet Files*]
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%SystemDrive%\Documents and Settings\LocalService\Local Settings\Temporary Internet Files|*.*|RECURSE
-FileKey2=%SystemDrive%\Documents and Settings\LocalService.NT*\Local Settings\Temporary Internet Files|*.*|RECURSE
-FileKey3=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows\Temporary Internet Files|*.*|RECURSE
+FileKey1=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\Temporary Internet Files|*.*|RECURSE
+FileKey2=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows\Temporary Internet Files|*.*|RECURSE
 
 [LocalSystem Cached Certification Files*]
 LangSecRef=3025
@@ -10688,16 +10057,13 @@ Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.LockApp_cw5n1h2txyewy
 FileKey1=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.LockApp_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.LockApp_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.LockApp_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.LockApp_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.LockApp_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.LockApp_*\TempState|*.*|RECURSE
 
 [LockHunter Logs*]
 LangSecRef=3024
@@ -10752,10 +10118,8 @@ FileKey6=%WinDir%\System32|lvcoinst.log
 LangSecRef=3022
 Detect=HKLM\Software\LogMeIn, Inc.
 Default=False
-FileKey1=%WinDir%\System32\config\systemprofile\AppData\Local\LogMeIn Hamachi|h2-engine.log;h2-ui.log;*.old;*.bak
-FileKey2=%WinDir%\System32\config\systemprofile\Local Settings\Application Data\LogMeIn Hamachi|h2-engine.log;h2-ui.log;*.old;*.bak
-FileKey3=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\LogMeIn Hamachi|h2-engine.log;h2-ui.log;*.old;*.bak
-FileKey4=%WinDir%\SysWOW64\config\systemprofile\Local Settings\Application Data\LogMeIn Hamachi|h2-engine.log;h2-ui.log;*.old;*.bak
+FileKey1=%WinDir%\System32\config\systemprofile\*\*\LogMeIn Hamachi|h2-engine.log;h2-ui.log;*.old;*.bak
+FileKey2=%WinDir%\SysWOW64\config\systemprofile\*\*\LogMeIn Hamachi|h2-engine.log;h2-ui.log;*.old;*.bak
 
 [LoL Summonerinfo Logs*]
 Section=Games
@@ -10863,17 +10227,12 @@ Detect=HKLM\Software\Lyrik
 Default=False
 FileKey1=%LocalAppData%\Lyrik|*.*
 
-[Lyx Cache*]
-LangSecRef=3021
-DetectFile=%AppData%\LyX2.0
-Default=False
-FileKey1=%AppData%\LyX2.0\Cache|*.*|RECURSE
-
-[Lyx Log*]
+[Lyx*]
 LangSecRef=3021
 DetectFile=%AppData%\LyX2.0
 Default=False
 FileKey1=%AppData%\LyX2.0|*.log|RECURSE
+FileKey2=%AppData%\LyX2.0\Cache|*.*|RECURSE
 
 [Macaw Cache*]
 LangSecRef=3022
@@ -10915,17 +10274,13 @@ Default=False
 FileKey1=%CommonAppData%\Macrium\Reflect|*.html
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Macrium\Reflect|*.html
 
-[Macromedia Shockwave 8*]
+[Macromedia Shockwave*]
 LangSecRef=3023
-Detect=HKCU\Software\Macromedia\Shockwave 8
+Detect1=HKCU\Software\Macromedia\Shockwave 8
+Detect2=HKCU\Software\Macromedia\Shockwave 9
 Default=False
 RegKey1=HKCU\Software\Macromedia\Shockwave 8\movies
-
-[Macromedia Shockwave 9*]
-LangSecRef=3023
-Detect=HKCU\Software\Macromedia\Shockwave 9
-Default=False
-RegKey1=HKCU\Software\Macromedia\Shockwave 9\movies
+RegKey2=HKCU\Software\Macromedia\Shockwave 9\movies
 
 [Magicka*]
 Section=Games
@@ -10968,10 +10323,8 @@ LangSecRef=3023
 Detect1=HKCU\Software\MAGIX AG\Videodeluxe18_pro
 Detect2=HKCU\Software\MAGIX AG\Videodeluxe19_pro
 Default=False
-FileKey1=%AppData%\MAGIX\Video_Pro_X4|*.log
-FileKey2=%AppData%\MAGIX\Video Pro X5|*.log
-FileKey3=%Documents%\MAGIX\Video_Pro_X4\AudioTemp|*.*|RECURSE
-FileKey4=%Documents%\MAGIX\Video Pro X5\AudioTemp|*.*|RECURSE
+FileKey1=%AppData%\MAGIX\Video_Pro*|*.log
+FileKey2=%Documents%\MAGIX\Video_Pro*\AudioTemp|*.*|RECURSE
 RegKey1=HKCU\Software\MAGIX AG\Videodeluxe19_pro\ExportConfigurator\DialogItems|LastFile
 RegKey2=HKCU\Software\MAGIX AG\Videodeluxe19_pro\ExportConfigurator\DialogItems|LastPreset
 
@@ -10982,19 +10335,13 @@ Default=False
 FileKey1=%Documents%\makehuman\v1|makehuman.log;makehuman-debug.txt;python_err.txt;python_out.txt
 FileKey2=%Documents%\makehuman\v1\cache|*.mhc
 
-[MAL Updater Image Cache*]
+[MAL Updater*]
 LangSecRef=3023
 DetectFile=%ProgramFiles%\Mal Updater 2\MalUpdater.exe
 Default=False
-FileKey1=%AppData%\Mal Updater\AnimePics|*.*
-FileKey2=%AppData%\Mal Updater\MangaPics|*.*
-FileKey3=%AppData%\Mal Updater\SeasonData|*.*
-
-[MAL Updater Logs*]
-LangSecRef=3023
-DetectFile=%ProgramFiles%\Mal Updater 2\MalUpdater.exe
-Default=False
-FileKey1=%AppData%\Mal Updater\Users|*.log|RECURSE
+FileKey1=%AppData%\Mal Updater\*Pics|*.*
+FileKey2=%AppData%\Mal Updater\SeasonData|*.*
+FileKey3=%AppData%\Mal Updater\Users|*.log|RECURSE
 
 [Malwarebytes Anti-Exploit*]
 LangSecRef=3024
@@ -11029,17 +10376,12 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData\ManiaPlanet\Cache|*.*
 
 [ManyCam More*]
 LangSecRef=3023
-Detect=HKLM\Software\ManyCam
-Default=False
-FileKey1=%LocalAppData%\ManyCam|*.log|RECURSE
-
-[ManyCam Thumbnails*]
-LangSecRef=3023
 Detect1=HKLM\Software\ManyCam
 Detect2=HKCU\Software\ManyCam
 Default=False
-FileKey1=%AppData%\ManyCam\Settings\MoviesThumbnails|*.*|RECURSE
+FileKey1=%LocalAppData%\ManyCam|*.log|RECURSE
 FileKey2=%LocalAppData%\ManyCam\cache\gallery|*.*|RECURSE
+FileKey3=%AppData%\ManyCam\Settings\MoviesThumbnails|*.*|RECURSE
 
 [Maps*]
 DetectOS=10.0|
@@ -11047,16 +10389,13 @@ Section=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsMaps_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\TempState|*.*|RECURSE
 
 [Marine Sharpshooter 3*]
 Section=Games
@@ -11076,21 +10415,11 @@ FileKey4=%LocalAppData%\VirtualStore\Program Files*\Mass Downloader\Index|*.*|RE
 
 [Mass Effect*]
 Section=Games
-Detect=HKLM\Software\BioWare\Mass Effect
+Detect1=HKLM\Software\BioWare\Mass Effect
+Detect2=HKLM\Software\BioWare\Mass Effect 2
+Detect3=HKLM\Software\BioWare\Mass Effect 3
 Default=False
-FileKey1=%Documents%\BioWare\Mass Effect\Logs|*.*
-
-[Mass Effect 2*]
-Section=Games
-Detect=HKLM\Software\BioWare\Mass Effect 2
-Default=False
-FileKey1=%Documents%\BioWare\Mass Effect 2\BIOGame\Logs|*.*
-
-[Mass Effect 3*]
-Section=Games
-Detect=HKLM\Software\BioWare\Mass Effect 3
-Default=False
-FileKey1=%Documents%\BioWare\Mass Effect 3\BIOGame\Logs|*.*
+FileKey1=%Documents%\BioWare\Mass Effect*\Logs|*.*
 
 [MassTube*]
 LangSecRef=3024
@@ -11115,28 +10444,15 @@ DetectFile=%AppData%\Broderbund\Mavis
 Default=False
 FileKey1=%AppData%\Broderbund\Mavis|logfile.*
 
-[Maxprog iCash Dumps*]
-LangSecRef=3021
-Detect=HKCR\iCash
-Default=False
-FileKey1=%Documents%\Maxprog\iCash\XML Dumps|*.*|REMOVESELF
-
-[Maxprog iCash Logs*]
+[Maxprog iCash*]
 LangSecRef=3021
 Detect=HKCR\iCash
 Default=False
 FileKey1=%Documents%\Maxprog\iCash\Database Logs|*.*|REMOVESELF
 FileKey2=%Documents%\Maxprog\iCash\Error Logs|*.*|REMOVESELF
-FileKey3=%ProgramFiles%\iCash\vlogs|*.*|REMOVESELF
+FileKey3=%Documents%\Maxprog\iCash\XML Dumps|*.*|REMOVESELF
 FileKey4=%LocalAppData%\VirtualStore\Program Files*\iCash\vlogs|*.*|REMOVESELF
-
-[Maxthon Browser*]
-LangSecRef=3022
-Detect1=HKCU\Software\Maxthon
-Detect2=HKCU\Software\Maxthon2
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Maxthon*\Temp|*.*
-FileKey2=%ProgramFiles%\Maxthon*\Temp|*.*
+FileKey5=%ProgramFiles%\iCash\vlogs|*.*|REMOVESELF
 
 [Maxthon Browser 3 Backups*]
 LangSecRef=3022
@@ -11167,6 +10483,14 @@ LangSecRef=3022
 Detect=HKCU\Software\Maxthon3
 Default=False
 FileKey1=%AppData%\Maxthon3\Users\*\LocalStorage|*.*|RECURSE
+
+[Maxthon Browser*]
+LangSecRef=3022
+Detect1=HKCU\Software\Maxthon
+Detect2=HKCU\Software\Maxthon2
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Maxthon*\Temp|*.*
+FileKey2=%ProgramFiles%\Maxthon*\Temp|*.*
 
 [McAfee*]
 LangSecRef=3024
@@ -11229,22 +10553,19 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey7=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey8=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\PRICache|*.*
-FileKey10=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Temp|*.*
-FileKey11=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\*Microsoft.Media.PlayReadyClient_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\PRICache|*.*
+FileKey7=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Temp|*.*
+FileKey8=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\*Microsoft.Media.PlayReadyClient_*\TempState|*.*|RECURSE
 
 [Media Player Classic More*]
 LangSecRef=3023
-Detect=HKCU\Software\Gabest\Media Player Classic
+Detect1=HKCU\Software\Gabest\Media Player Classic
 Detect2=HKCU\Software\MPC-HC\MPC-HC
 Default=False
 FileKey1=%AppData%\Media Player Classic|*.dmp
@@ -11326,63 +10647,23 @@ RegKey15=HKCU\Software\JBSoftware\MemoMaster5|FileMRU15
 
 [Men of War Cache*]
 Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\7830
+Detect1=HKCU\Software\Valve\Steam\Apps\7830
+Detect2=HKCU\Software\Valve\Steam\Apps\64000
+Detect3=HKCU\Software\Valve\Steam\Apps\204860
+Detect4=HKCU\Software\Valve\Steam\Apps\3130
+Detect5=HKCU\Software\Valve\Steam\Apps\63940
 Default=False
-FileKey1=%Documents%\My Games\men of war\shader_cache|*.*|RECURSE
+FileKey1=%Documents%\My Games\men of war*\shader_cache|*.*|RECURSE
 
 [Men of War Log*]
 Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\7830
+Detect1=HKCU\Software\Valve\Steam\Apps\7830
+Detect2=HKCU\Software\Valve\Steam\Apps\64000
+Detect3=HKCU\Software\Valve\Steam\Apps\204860
+Detect4=HKCU\Software\Valve\Steam\Apps\3130
+Detect5=HKCU\Software\Valve\Steam\Apps\63940
 Default=False
-FileKey1=%Documents%\My Games\men of war\log|*.*
-
-[Men of War: Assault Squad Cache*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\64000
-Default=False
-FileKey1=%Documents%\My Games\Men of War - Assault Squad\shader_cache|*.*|RECURSE
-
-[Men of War: Assault Squad Log*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\64000
-Default=False
-FileKey1=%Documents%\My Games\Men of War - Assault Squad\Log|*.*
-
-[Men of War: Condemned Heroes Cache*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\204860
-Default=False
-FileKey1=%Documents%\My Games\mow condemned heroes\sharer_cache|*.*|RECURSE
-
-[Men of War: Condemned Heroes Log*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\204860
-Default=False
-FileKey1=%Documents%\My Games\mow condemned heroes\Log|*.*
-
-[Men of War: Red Tide Cache*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\3130
-Default=False
-FileKey1=%Documents%\My Games\mow red tide\shader_cache|*.*|RECURSE
-
-[Men of War: Red Tide Log*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\3130
-Default=False
-FileKey1=%Documents%\My Games\mow red tide\log|*.*
-
-[Men of War: Vietnam Cache*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\63940
-Default=False
-FileKey1=%Documents%\My Games\mow vietnam\shader_cache|*.*|RECURSE
-
-[Men of War: Vietnam Log*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\63940
-Default=False
-FileKey1=%Documents%\My Games\mow vietnam\log|*.*
+FileKey1=%Documents%\My Games\men of war*\log|*.*
 
 [Mention*]
 LangSecRef=3022
@@ -11397,16 +10678,13 @@ DetectOS=10.0|
 Section=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Messaging_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Messaging_*\LocalCache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Messaging_*\LocalState\Cache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.Messaging_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\Temp|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.Messaging_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Messaging_*\LocalState\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Messaging_*\TempState|*.*|RECURSE
 
 [Messenger Plus! Live Logs*]
 LangSecRef=3022
@@ -11454,21 +10732,17 @@ Default=False
 FileKey1=%AppData%\MetroTwit\*|User.cache
 FileKey2=%AppData%\MetroTwit\*\User_Images|*.*|RECURSE
 
-[Microangelo 6*]
-LangSecRef=3021
-Detect=HKCU\Software\Eclipsit\Microangelo\Toolset 6
-Default=False
-RegKey1=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Animator\MRU List
-RegKey2=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Librarian\MRU List
-RegKey3=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Studio\MRU List
-
 [Microangelo*]
 LangSecRef=3021
-Detect=HKCU\Software\Impact\Microangelo
+Detect1=HKCU\Software\Impact\Microangelo
+Detect2=HKCU\Software\Eclipsit\Microangelo\Toolset 6
 Default=False
 RegKey1=HKCU\Software\Impact\Microangelo\Animator\MRU List
 RegKey2=HKCU\Software\Impact\Microangelo\Librarian\MRU List
 RegKey3=HKCU\Software\Impact\Microangelo\Studio\MRU List
+RegKey4=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Animator\MRU List
+RegKey5=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Librarian\MRU List
+RegKey6=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Studio\MRU List
 
 [Microsoft Bing Bar*]
 LangSecRef=3021
@@ -11488,20 +10762,17 @@ LangSecRef=3022
 Detect=HKCU\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MicrosoftEdge_8wekyb3d8bbwe
 DetectFile=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!001\INetCookies|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!001\MicrosoftEdge\Cookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!002\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!002\MicrosoftEdge\Cookies|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!001\Microsoft\CryptnetUrlCache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!002\Microsoft\CryptnetUrlCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\Microsoft\CryptnetUrlCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\Cookies|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\DataStore\Indexed\Data|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\ImageStore|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\user\Default\datastore\Data\nouser1\*\DBStore|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\user\Default\datastore\Data\nouser1\*\Favorites|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AppData\User\Default\Indexed DB|*.edb;*.jfm;*.jrs;*.log
-FileKey14=%UserProfile%\MicrosoftEdgeBackups\backups\*|*.*|REMOVESELF
+FileKey1=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!00*\INetCookies|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!00*\MicrosoftEdge\Cookies|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!00*\Microsoft\CryptnetUrlCache|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\Microsoft\CryptnetUrlCache|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\Cookies|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\DataStore\Indexed\Data|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\ImageStore|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\user\Default\datastore\Data\nouser1\*\DBStore|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\user\Default\datastore\Data\nouser1\*\Favorites|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AppData\User\Default\Indexed DB|*.edb;*.jfm;*.jrs;*.log
+FileKey11=%UserProfile%\MicrosoftEdgeBackups\backups\*|*.*|REMOVESELF
 ExcludeKey1=PATH|%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\user\Default\datastore\Data\nouser1\*\DBStore\|*.edb;*.jfm
 
 [Microsoft Expression Web*]
@@ -11557,15 +10828,12 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\Microsoft.Reader_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.Reader_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Reader_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Reader_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Reader_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Reader_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Reader_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey7=%LocalAppData%\Packages\Microsoft.Reader_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey8=%LocalAppData%\Packages\Microsoft.Reader_*\AC\PRICache|*.*
-FileKey9=%LocalAppData%\Packages\Microsoft.Reader_*\AC\Temp|*.*
-FileKey10=%LocalAppData%\Packages\Microsoft.Reader_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Reader_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Reader_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Reader_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\Microsoft.Reader_*\AC\PRICache|*.*
+FileKey6=%LocalAppData%\Packages\Microsoft.Reader_*\AC\Temp|*.*
+FileKey7=%LocalAppData%\Packages\Microsoft.Reader_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Reader_8wekyb3d8bbwe\PersistedStorageItemTable\ManagedByApp
 RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Reader_8wekyb3d8bbwe\SearchHistory
 
@@ -11605,22 +10873,18 @@ FileKey1=%ProgramFiles%\Microsoft XNA\XNA Game Studio\*\Redist|*.*|REMOVESELF
 LangSecRef=3031
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.VCLibs.110.00_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.VCLibs.120.00_8wekyb3d8bbwe
-DetectFile1=%LocalAppData%\Packages\Microsoft.VCLibs.110.00_8wekyb3d8bbwe
-DetectFile2=%LocalAppData%\Packages\Microsoft.VCLibs.120.00_8wekyb3d8bbwe
+DetectFile=%LocalAppData%\Packages\Microsoft.VCLibs.1*0.00_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey7=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey8=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\PRICache|*.*
-FileKey10=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Temp|*.*
-FileKey11=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\LocalState\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\PRICache|*.*
+FileKey7=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Temp|*.*
+FileKey8=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\LocalState\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\TempState|*.*|RECURSE
 
 [Midori - Cache*]
 LangSecRef=3022
@@ -11662,14 +10926,11 @@ FileKey1=%LocalAppData%\MigWiz|*.log;miglog.xml
 LangSecRef=3021
 Detect=HKCU\Software\MiKTeX.org\MiKTeX
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\MiKTeX\miktex\config|*.log
-FileKey2=%ProgramFiles%\MiKTeX\miktex\config|*.log
-
-[Minecraft Debug*]
-Section=Games
-DetectFile=%AppData%\.minecraft
-Default=False
-FileKey1=%AppData%\.minecraft\debug|*.*
+FileKey1=%CommonAppData%\MiKTeX\*\miktex\log|*.log
+FileKey2=%LocalAppData%\MiKTeX\*\miktex\log|*.log
+FileKey3=%LocalAppData%\VirtualStore\ProgramData\MiKTeX\*\miktex\log|*.log
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\MiKTeX\miktex\config|*.log
+FileKey5=%ProgramFiles%\MiKTeX\miktex\config|*.log
 
 [Minecraft*]
 Section=Games
@@ -11677,14 +10938,9 @@ DetectFile=%AppData%\.minecraft
 Default=False
 FileKey1=%AppData%\.minecraft|*.log;*.log.*|RECURSE
 FileKey2=%AppData%\.minecraft\crash-reports|*.*
-FileKey3=%AppData%\.minecraft\stats|*.old
-FileKey4=%AppData%\java|*.*|REMOVESELF
-
-[Miranda IM Cache*]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\Miranda IM
-Default=False
-FileKey1=%AppData%\Miranda IM\Profiles|*.*|REMOVESELF
+FileKey3=%AppData%\.minecraft\debug|*.*
+FileKey4=%AppData%\.minecraft\stats|*.old
+FileKey5=%AppData%\java|*.*|REMOVESELF
 
 [Miranda IM Chat Log*]
 LangSecRef=3022
@@ -11692,11 +10948,12 @@ DetectFile=%ProgramFiles%\Miranda IM
 Default=False
 FileKey1=%AppData%\Miranda IM\Profiles\*\Logs\Chat|*.*|REMOVESELF
 
-[Miranda IM Log*]
+[Miranda IM*]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Miranda IM
 Default=False
-FileKey1=%AppData%\Miranda IM\Profiles\*\Logs\Chat|*.*|RECURSE
+FileKey1=%AppData%\Miranda IM\Profiles|*.*|REMOVESELF
+FileKey2=%AppData%\Miranda IM\Profiles\*\Logs\Chat|*.*|RECURSE
 
 [mIRC Logs*]
 LangSecRef=3022
@@ -11738,7 +10995,7 @@ FileKey1=%LocalAppData%\VirtualStore\Program Files*\SkanerOnline\Raporty|*.*
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\SkanerOnline\tmp|*.*
 FileKey3=%ProgramFiles%\SkanerOnline\Raporty|*.*
 FileKey4=%ProgramFiles%\SkanerOnline\tmp|*.*
-FileKey5=%SystemDrive%|*.cpp.log
+FileKey5=%SystemDrive%\|*.cpp.log
 
 [MMOUI Minion Logs*]
 Section=Games
@@ -11823,16 +11080,12 @@ Detect6=HKLM\Software\Mount&Blade Warband
 Detect7=HKLM\Software\Mount&Blade With Fire and Sword
 Detect8=HKLM\Software\Mount&Blade: Warband - Napoleonic Wars
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Mount&Blade|rgl_log.txt|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Mount&Blade Warband|rgl_log.txt|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Mount&Blade With Fire and Sword|rgl_log.txt|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Napoleonic Wars|rgl_log.txt|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Mount&Blade*|rgl_log.txt|RECURSE
-FileKey6=%ProgramFiles%\Steam\steamapps\common\Mount&Blade*|rgl_log.txt|RECURSE
-FileKey7=%ProgramFiles%\Mount&Blade|rgl_log.txt|RECURSE
-FileKey8=%ProgramFiles%\Mount&Blade Warband|rgl_log.txt|RECURSE
-FileKey9=%ProgramFiles%\Mount&Blade With Fire and Sword|rgl_log.txt|RECURSE
-FileKey10=%ProgramFiles%\Napoleonic Wars|rgl_log.txt|RECURSE
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Mount&Blade*|rgl_log.txt|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Napoleonic Wars|rgl_log.txt|RECURSE
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Mount&Blade*|rgl_log.txt|RECURSE
+FileKey4=%ProgramFiles%\Steam\steamapps\common\Mount&Blade*|rgl_log.txt|RECURSE
+FileKey5=%ProgramFiles%\Mount&Blade*|rgl_log.txt|RECURSE
+FileKey6=%ProgramFiles%\Napoleonic Wars|rgl_log.txt|RECURSE
 
 [Mousotron*]
 LangSecRef=3021
@@ -11899,9 +11152,8 @@ FileKey1=%LocalAppData%\MPlayer|*.cache-3
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\Microsoft Antimalware
 Default=False
-FileKey1=%SystemDrive%\Documents and Settings\NetworkService\Temp|MpCmdRun.log
-FileKey2=%SystemDrive%\Documents and Settings\NetworkService.NT*\Temp|MpCmdRun.log
-FileKey3=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Temp|MpCmdRun.log
+FileKey1=%SystemDrive%\Documents and Settings\NetworkService*\Temp|MpCmdRun.log
+FileKey2=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Temp|MpCmdRun.log
 
 [MS AntiMalware*]
 LangSecRef=3025
@@ -11985,8 +11237,8 @@ LangSecRef=3025
 DetectFile1=%SystemDrive%\msdownld.tmp
 DetectFile2=%WinDir%\msdownld.tmp
 Default=False
-FileKey1=%SystemDrive%|msdownld.tmp
-FileKey2=%WinDir%|msdownld.tmp
+FileKey1=%SystemDrive%\|msdownld.tmp
+FileKey2=%WinDir%\|msdownld.tmp
 
 [MS Imaging*]
 LangSecRef=3024
@@ -12075,7 +11327,7 @@ RegKey16=HKCU\SOFTWARE\Microsoft\Office\16.0\Word\Recent Templates
 LangSecRef=3021
 Detect=HKLM\Software\Microsoft\Office\Common\Remove Hidden Data Tool
 Default=False
-FileKey1=%SystemDrive%|propfix.log
+FileKey1=%SystemDrive%\|propfix.log
 
 [MS Office Saved CEIP Data*]
 LangSecRef=3021
@@ -12115,10 +11367,10 @@ Detect=HKLM\Software\Microsoft\PlayReady
 Default=False
 FileKey1=%CommonAppData%\Microsoft\PlayReady|*.hds
 FileKey2=%CommonAppData%\Microsoft\PlayReady\Cache|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Microsoft\PlayReady|*.hds
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Microsoft\PlayReady\Cache|*.*
-FileKey3=%WinDir%\ehome|PRDMOWrapper.log
-FileKey4=%WinDir%\System32|PRDMOWrapper.log
+FileKey3=%LocalAppData%\VirtualStore\ProgramData\Microsoft\PlayReady|*.hds
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\Microsoft\PlayReady\Cache|*.*
+FileKey5=%WinDir%\ehome|PRDMOWrapper.log
+FileKey6=%WinDir%\System32|PRDMOWrapper.log
 
 [MS Reliability Monitor*]
 LangSecRef=3025
@@ -12355,6 +11607,12 @@ DetectFile=%AppData%\Microsoft\VCExpress\10.0
 Default=False
 FileKey1=%AppData%\Microsoft\VCExpress\10.0|*.winprf_backup
 
+[MS Visual Studio 2017 Installation packages*]
+LangSecRef=3021
+Detect=HKCU\Software\Microsoft\VisualStudio
+Default=False
+FileKey1=%ProgramData%\Microsoft\VisualStudio\Packages|*.*|RECURSE
+
 [MS Visual Studio Assembly Cache*]
 LangSecRef=3021
 Detect=HKCU\Software\Microsoft\VisualStudio
@@ -12400,6 +11658,25 @@ RegKey12=HKCU\Software\Microsoft\VisualStudio\12.0\LastLoadedSolution
 RegKey13=HKCU\Software\Microsoft\VisualStudio\14.0\FileMRUList
 RegKey14=HKCU\Software\Microsoft\VisualStudio\14.0\ProjectMRUList
 RegKey15=HKCU\Software\Microsoft\VisualStudio\14.0\LastLoadedSolution
+
+[MS Visual Studio NuGet Cache*]
+LangSecRef=3021
+Detect=HKCU\Software\Microsoft\VisualStudio
+Default=False
+FileKey1=%LocalAppData%\NuGet\Cache|*.*|RECURSE
+FileKey2=%LocalAppData%\NuGet\v3-cache|*.*|REMOVESELF
+FileKey3=%UserProfile%\.nuget|*.*|RECURSE
+
+[MS Visual Studio Other Cache*]
+LangSecRef=3021
+Detect=HKCU\Software\Microsoft\VisualStudio
+Default=False
+FileKey1=%LocalAppData%\Microsoft\VisualStudio\*\Extensions|*.cache
+FileKey2=%LocalAppData%\Microsoft\VisualStudio\*\ImageLibrary|*.cache
+FileKey3=%LocalAppData%\Microsoft\VisualStudio\*\Notifications|*.cache
+FileKey4=%LocalAppData%\Microsoft\VisualStudio\*\ComponentModelCache|*.*
+FileKey5=%LocalAppData%\Microsoft\VisualStudio\*\MEFCacheBackup|*.*
+FileKey6=%LocalAppData%\Microsoft\VisualStudio\*\TextMateCache|*.*
 
 [MS Visual Studio Search History*]
 LangSecRef=3021
@@ -12567,79 +11844,54 @@ RegKey159=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Replace 16
 RegKey160=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Replace 17
 RegKey161=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Replace 18
 RegKey162=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Replace 19
-RegKey161=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find
-RegKey162=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 0
-RegKey163=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 1
-RegKey164=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 2
-RegKey165=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 3
-RegKey166=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 4
-RegKey167=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 5
-RegKey168=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 6
-RegKey169=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 7
-RegKey170=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 8
-RegKey171=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 9
-RegKey172=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 10
-RegKey173=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 11
-RegKey174=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 12
-RegKey175=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 13
-RegKey176=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 14
-RegKey177=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 15
-RegKey178=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 16
-RegKey179=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 17
-RegKey180=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 18
-RegKey181=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 19
-RegKey182=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace
-RegKey183=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 0
-RegKey184=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 1
-RegKey185=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 2
-RegKey186=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 3
-RegKey187=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 4
-RegKey188=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 5
-RegKey189=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 6
-RegKey190=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 7
-RegKey191=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 8
-RegKey192=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 9
-RegKey193=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 10
-RegKey194=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 11
-RegKey195=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 12
-RegKey196=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 13
-RegKey197=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 14
-RegKey198=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 15
-RegKey199=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 16
-RegKey200=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 17
-RegKey201=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 18
-RegKey202=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 19
+RegKey163=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find
+RegKey164=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 0
+RegKey165=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 1
+RegKey166=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 2
+RegKey167=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 3
+RegKey168=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 4
+RegKey169=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 5
+RegKey170=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 6
+RegKey171=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 7
+RegKey172=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 8
+RegKey173=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 9
+RegKey174=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 10
+RegKey175=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 11
+RegKey176=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 12
+RegKey177=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 13
+RegKey178=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 14
+RegKey179=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 15
+RegKey180=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 16
+RegKey181=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 17
+RegKey182=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 18
+RegKey183=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 19
+RegKey184=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace
+RegKey185=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 0
+RegKey186=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 1
+RegKey187=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 2
+RegKey188=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 3
+RegKey189=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 4
+RegKey190=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 5
+RegKey191=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 6
+RegKey192=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 7
+RegKey193=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 8
+RegKey194=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 9
+RegKey195=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 10
+RegKey196=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 11
+RegKey197=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 12
+RegKey198=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 13
+RegKey199=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 14
+RegKey200=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 15
+RegKey201=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 16
+RegKey202=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 17
+RegKey203=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 18
+RegKey204=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 19
 
 [MS Visual Studio Website Cache*]
 LangSecRef=3021
 Detect=HKCU\Software\Microsoft\VisualStudio
 Default=False
 FileKey1=%LocalAppData%\microsoft\websiteCache|*.*|RECURSE
-
-[MS Visual Studio 2017 Installation packages*]
-LangSecRef=3021
-Detect=HKCU\Software\Microsoft\VisualStudio
-Default=False
-FileKey1=%ProgramData%\Microsoft\VisualStudio\Packages|*.*|RECURSE
-
-[MS Visual Studio NuGet Cache*]
-LangSecRef=3021
-Detect=HKCU\Software\Microsoft\VisualStudio
-Default=False
-FileKey1=%LocalAppData%\NuGet\Cache|*.*|RECURSE
-FileKey2=%LocalAppData%\NuGet\v3-cache|*.*|REMOVESELF
-FileKey3=%UserProfile%\.nuget|*.*|RECURSE
-
-[MS Visual Studio Other Cache*]
-LangSecRef=3021
-Detect=HKCU\Software\Microsoft\VisualStudio
-Default=False
-FileKey1=%LocalAppData%\Microsoft\VisualStudio\*\Extensions|*.cache
-FileKey2=%LocalAppData%\Microsoft\VisualStudio\*\ImageLibrary|*.cache
-FileKey3=%LocalAppData%\Microsoft\VisualStudio\*\Notifications|*.cache
-FileKey4=%LocalAppData%\Microsoft\VisualStudio\*\ComponentModelCache|*.*
-FileKey5=%LocalAppData%\Microsoft\VisualStudio\*\MEFCacheBackup|*.*
-FileKey6=%LocalAppData%\Microsoft\VisualStudio\*\TextMateCache|*.*
 
 [MS Windows Game Statistics*]
 LangSecRef=3025
@@ -12698,12 +11950,6 @@ FileKey4=%ProgramFiles%\MTA San Andreas 1.3\MTA\logs|*.*
 FileKey5=%ProgramFiles%\MTA San Andreas 1.3\server\mods\deathmatch\backups|*.*
 FileKey6=%ProgramFiles%\MTA San Andreas 1.3\server\mods\deathmatch\logs|*.*
 
-[Multi-Edit 2008 Temps*]
-LangSecRef=3024
-Detect=HKCU\Software\Multi Edit Software\Multi-Edit\11.0
-Default=False
-FileKey1=%AppData%\Multi Edit Software\Multi-Edit\11\Config.04\Tmp|*.TMP
-
 [Multi-Edit 2008 Logs*]
 LangSecRef=3024
 Detect=HKCU\Software\Multi Edit Software\Multi-Edit\11.0
@@ -12715,6 +11961,12 @@ ExcludeKey3=FILE|%AppData%\Multi Edit Software\Multi-Edit\11\Config.04\|INSTALL.
 ExcludeKey4=FILE|%AppData%\Multi Edit Software\Multi-Edit\11\Config.04\|POLYSTYLE.LOG
 ExcludeKey5=FILE|%AppData%\Multi Edit Software\Multi-Edit\11\Config.04\|TMPLPANE.LOG
 ExcludeKey6=FILE|%AppData%\Multi Edit Software\Multi-Edit\11\Config.04\|WINLIST.LOG
+
+[Multi-Edit 2008 Temps*]
+LangSecRef=3024
+Detect=HKCU\Software\Multi Edit Software\Multi-Edit\11.0
+Default=False
+FileKey1=%AppData%\Multi Edit Software\Multi-Edit\11\Config.04\Tmp|*.TMP
 
 [Multi Commander*]
 LangSecRef=3024
@@ -12948,7 +12200,7 @@ RegKey1=HKCU\Software\FutureFog\MyToolkit\Options|LastUsedFolder
 LangSecRef=3024
 DetectFile=%ProgramFiles%\EgisTec\mywinlocker 3
 Default=False
-FileKey1=%LocalAppData%|mywinlockerinstaller.*
+FileKey1=%LocalAppData%\|mywinlockerinstaller.*
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\EgisTec\MyWinLocker 3\log|*.*
 FileKey3=%ProgramFiles%\EgisTec\MyWinLocker 3\log|*.*
 
@@ -12970,34 +12222,26 @@ Default=False
 FileKey1=%ProgramFiles%\Nancy Drew*|dxwebsetup.exe;*.html
 FileKey2=%ProgramFiles%\*\Nancy Drew*|dxwebsetup.exe;*.html
 
-[Natural Selection 2 Cache*]
+[Natural Selection 2*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\4920
 DetectFile=%ProgramFiles%\Steam\steamapps\common\Natural Selection 2
 Default=False
 Warning=Fixes corrupt cache & cleans cache bloat. The first game & map launch will take longer to load.
 FileKey1=%AppData%\Natural Selection 2\cache|*.*|RECURSE
-
-[Natural Selection 2 Log*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\4920
-DetectFile=%ProgramFiles%\Steam\steamapps\common\Natural Selection 2
-Default=False
-FileKey1=%AppData%\Natural Selection 2|log.txt
+FileKey2=%AppData%\Natural Selection 2|log.txt
 
 [NBC News*]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\msnbc.comDigitalNetwork.msnbc.com_amdjbdaxqsje6
 DetectFile=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_amdjbdaxqsje6
 Default=False
-FileKey1=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\PRICache|*.*
-FileKey6=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Temp|*.*
-FileKey7=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\TempState|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Microsoft\CLR_v4.0|*.log
+FileKey1=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\PRICache|*.*
+FileKey4=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Temp|*.*
+FileKey5=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\TempState|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Microsoft\CLR_v4.0|*.log
 
 [Neostar CMS Station Client Logs*]
 LangSecRef=3024
@@ -13020,10 +12264,10 @@ FileKey5=%AppData%\Nero\Nero *\Nero Recode\AnalysisData|*.dat
 FileKey6=%AppData%\Nero\Nero *\Nero Recode\Thumbs|*.*
 FileKey7=%AppData%\Nero\Nero *\Nero Vision\NVFACache|*.*
 FileKey8=%AppData%\Nero\Nero *\Nero Vision|*.txt;*.bin
-FileKey10=%AppData%\Nero\Nero *\Nero3D|*.log
-FileKey11=%LocalAppData%\Nero\Nero *\Nero Vision\Cache|*.*
-FileKey12=%LocalAppData%\Nero\Nero *\Nero Vision\Cache\GraphicObjectCache|*.*
-FileKey13=%LocalAppData%\VirtualStore\ProgramData\Nero\PeakFiles|*.tmp
+FileKey9=%AppData%\Nero\Nero *\Nero3D|*.log
+FileKey10=%LocalAppData%\Nero\Nero *\Nero Vision\Cache|*.*
+FileKey11=%LocalAppData%\Nero\Nero *\Nero Vision\Cache\GraphicObjectCache|*.*
+FileKey12=%LocalAppData%\VirtualStore\ProgramData\Nero\PeakFiles|*.tmp
 RegKey1=HKCU\Software\Nero\Nero Blu-ray Player\Settings|DefFolder
 RegKey2=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Compilation|VolumeLabelAutoTemplate
 RegKey3=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Compilation|VolumeLabelUDFTemplate
@@ -13137,18 +12381,15 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\4DF9E0F8.Netflix_mcm4njqhnhss8
 DetectFile=%LocalAppData%\Packages\4DF9E0F8.Netflix_mcm4njqhnhss8
 Default=False
-FileKey1=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\PRICache|*.*
-FileKey6=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Temp|*.*
-FileKey7=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\TempState|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState|*.tmp|RECURSE
-FileKey9=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState\LiveTile|*.*
-FileKey10=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey11=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey12=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AppData\Indexed DB|*.log
+FileKey1=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\PRICache|*.*
+FileKey4=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Temp|*.*
+FileKey5=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\TempState|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState|*.tmp|RECURSE
+FileKey7=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState\LiveTile|*.*
+FileKey8=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey9=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AppData\Indexed DB|*.log
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\4DF9E0F8.Netflix_mcm4njqhnhss8\SearchHistory
 
 [NETGEAR Genie*]
@@ -13177,13 +12418,11 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.NetworkSpeedTest_8wekyb3d8bbwe
 DetectFile=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\PRICache|*.*
-FileKey6=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Temp|*.*
-FileKey7=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\PRICache|*.*
+FileKey4=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Temp|*.*
+FileKey5=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\TempState|*.*|RECURSE
 
 [NetworkService Cached Certification Files*]
 LangSecRef=3025
@@ -13215,6 +12454,14 @@ FileKey1=%SystemDrive%\Documents and Settings\NetworkService\Local Settings\Hist
 FileKey2=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\History|*.*|RECURSE
 FileKey3=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\History|*.*|RECURSE
 
+[NetworkService Temp Files*]
+LangSecRef=3025
+Detect=HKCU\Software\Microsoft\Windows
+Default=False
+FileKey1=%SystemDrive%\Documents and Settings\NetworkService\Local Settings\Temp|*.*|RECURSE
+FileKey2=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\Temp|*.*|RECURSE
+FileKey3=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Temp|*.*|RECURSE
+
 [NetworkService Temporary Internet Files*]
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Windows
@@ -13225,14 +12472,6 @@ FileKey3=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\
 FileKey4=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\Temporary Internet Files|*.*|RECURSE
 FileKey5=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\Temporary Internet Files|*.*|RECURSE
 FileKey6=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\Content.IE5|*.*|RECURSE
-
-[NetworkService Temp Files*]
-LangSecRef=3025
-Detect=HKCU\Software\Microsoft\Windows
-Default=False
-FileKey1=%SystemDrive%\Documents and Settings\NetworkService\Local Settings\Temp|*.*|RECURSE
-FileKey2=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\Temp|*.*|RECURSE
-FileKey3=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Temp|*.*|RECURSE
 
 [Neverwinter*]
 Section=Games
@@ -13377,22 +12616,9 @@ FileKey2=%ProgramFiles%\nLite\Presets|*.*
 
 [Nokia Music Player*]
 LangSecRef=3023
-DetectFile1=%LocalAppData%\Nokia\Nokia Music
-DetectFile2=%LocalAppData%\Nokia\Nokia Music Player
+DetectFile=%LocalAppData%\Nokia\Nokia Music*
 Default=False
-FileKey1=%LocalAppData%\Nokia\Nokia Music|*.log
-FileKey2=%LocalAppData%\Nokia\Nokia Music Player|*.log
-
-[Nokia Software Updater Cache*]
-LangSecRef=3021
-Detect1=HKCU\Software\Nokia\NSU3
-Detect2=HKLM\Software\Nokia\Nokia Suite
-Default=False
-Warning=This will remove Nokia phone firmwares, applications and other files stored by Nokia Suite Updater. Files will be re-downloaded when updating phone.
-FileKey1=%LocalAppData%\Nokia\NSU3\NOSSU2|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Nokia\Nokia Suite\NOSSU2|*.*|RECURSE
-ExcludeKey1=FILE|%LocalAppData%\Nokia\NSU3\NOSSU2\|usergroups.cfg
-ExcludeKey2=PATH|%LocalAppData%\Nokia\NSU3\NOSSU2\Flash\|*.*
+FileKey1=%LocalAppData%\Nokia\Nokia Music*|*.log
 
 [Nokia Software Updater Cache - Old Versions*]
 LangSecRef=3021
@@ -13404,6 +12630,17 @@ FileKey1=%CommonAppData%\Nokia\Nokia Service Layer\A|*.*|REMOVESELF
 FileKey2=%CommonProgramFiles%\Nokia\Service Layer\A|*.*|REMOVESELF
 FileKey3=%LocalAppData%\VirtualStore\ProgramData\Nokia\Nokia Service Layer\A|*.*|REMOVESELF
 FileKey4=%LocalAppData%\VirtualStore\Program Files*\Common Files\Nokia\Service Layer\A|*.*|REMOVESELF
+
+[Nokia Software Updater Cache*]
+LangSecRef=3021
+Detect1=HKCU\Software\Nokia\NSU3
+Detect2=HKLM\Software\Nokia\Nokia Suite
+Default=False
+Warning=This will remove Nokia phone firmwares, applications and other files stored by Nokia Suite Updater. Files will be re-downloaded when updating phone.
+FileKey1=%LocalAppData%\Nokia\NSU3\NOSSU2|*.*|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\ProgramData\Nokia\Nokia Suite\NOSSU2|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Nokia\NSU3\NOSSU2\|usergroups.cfg
+ExcludeKey2=PATH|%LocalAppData%\Nokia\NSU3\NOSSU2\Flash\|*.*
 
 [Nokia Suite Installer Cache*]
 LangSecRef=3021
@@ -13576,53 +12813,11 @@ FileKey2=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps|*tr
 FileKey3=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps\ai_data|*training*|RECURSE
 FileKey4=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\sound\voices\tutorial|*.*|REMOVESELF
 
-[NVIDIA*]
-LangSecRef=3024
-Detect=HKLM\Software\NVIDIA Corporation
-Default=False
-FileKey1=%ProgramFiles%\NVIDIA Corporation\NetworkAccessManager\Apache Group\Apache2\logs|*.*
-FileKey2=%CommonAppData%\NVIDIA|*.log;*.log_backup1|RECURSE
-FileKey3=%CommonAppData%\NVIDIA\NvBackend|*.log|RECURSE
-FileKey4=%CommonAppData%\NVIDIA Corporation|*.log
-FileKey5=%CommonAppData%\NVIDIA Corporation\NvTelemetry|*.bak;*.log;*.old
-FileKey6=%CommonAppData%\NVIDIA Corporation\Nvstapisvr|*.bak;*.log;*.old
-FileKey7=%CommonAppData%\NVIDIA Corporation\nvStereoInstaller|*.log;*.old
-FileKey8=%CommonAppData%\NVIDIA Corporation\nvsdk|*.bak;*.log;*.old
-FileKey9=%CommonAppData%\NVIDIA Corporation\NetService|*.*|RECURSE
-FileKey10=%CommonAppData%\Nvidia|Resource.old
-FileKey11=%CommonAppData%\Nvidia\Updates|*.bak
-FileKey12=%CommonAppData%\Nvidia\Updatus|*.bak
-FileKey13=%CommonAppData%\Nvidia\NvBackend\Updates|*.bak
-FileKey14=%CommonAppData%\Nvidia\NvBackend\Updatus|*.bak
-FileKey15=%CommonAppData%\NVIDIA Corporation\NvVAD|*.bak;*.log;*.old
-FileKey16=%LocalAppData%\NVIDIA\NvBackend|*.log;*.bak
-FileKey17=%LocalAppData%\NVIDIA Corporation\NvNode|*.bak;*.log;*.old
-FileKey18=%LocalAppData%\NVIDIA Corporation\NvProfileUpdater|*.bak;*.log;*.old
-FileKey19=%LocalAppData%\NVIDIA Corporation\NvTelemetry|*.bak;*.log;*.old
-FileKey20=%LocalAppData%\NVIDIA Corporation\NvTmMon|*.bak;*.log;*.old
-FileKey21=%LocalAppData%\NVIDIA Corporation\NvTmRep|*.bak;*.log;*.old
-FileKey22=%LocalAppData%\NVIDIA Corporation\NvVAD|*.bak;*.log;*.old
-FileKey23=%LocalAppData%\NVIDIA Corporation\GfeSDK|*.log;*.bak
-FileKey24=%LocalAppData%\NVIDIA Corporation\*\CefCache|*.log;*.bak;Cookies;Cookies-journal;QuotaManager;QuotaManager-journal
-FileKey25=%LocalAppData%\NVIDIA Corporation\*\CefCache\Cache|*.*|RECURSE
-FileKey26=%LocalAppData%\NVIDIA Corporation\*\CefCache\GPUCache|*.*|RECURSE
-FileKey27=%LocalAppData%\VirtualStore\Program Files*\NVIDIA Corporation\NetworkAccessManager\Apache Group\Apache2\logs|*.*
-FileKey28=%LocalAppData%\VirtualStore\ProgramData*\NVIDIA|*.log;*.log_backup1|RECURSE
-FileKey29=%LocalAppData%\VirtualStore\ProgramData*\NVIDIA\NvBackend|*.log|RECURSE
-FileKey30=%LocalAppData%\VirtualStore\ProgramData*\NVIDIA Corporation\NvTelemetry|*.log;*.bak
-FileKey32=%LocalAppData%\VirtualStore\ProgramData\Nvidia|Resource.old
-FileKey33=%LocalAppData%\VirtualStore\ProgramData\Nvidia\Updates|*.bak
-FileKey34=%LocalAppData%\VirtualStore\ProgramData\Nvidia\Updatus|*.bak
-FileKey35=%LocalAppData%\VirtualStore\ProgramData\Nvidia\NvBackend\Updates|*.bak
-FileKey36=%LocalAppData%\VirtualStore\ProgramData\Nvidia\NvBackend\Updatus|*.bak
-FileKey37=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\NetService|*.*|RECURSE
-
 [NVIDIA Cache*]
 LangSecRef=3024
 Detect=HKLM\Software\NVIDIA Corporation
 Default=False
-FileKey1=%AppData%\NVIDIA\ComputeCache|*.*|RECURSE
-FileKey2=%AppData%\NVIDIA\GLCache|*.*|RECURSE
+FileKey1=%AppData%\NVIDIA\*Cache|*.*|RECURSE
 
 [NVIDIA GFExperience*]
 LangSecRef=3024
@@ -13632,29 +12827,63 @@ DetectFile2=%LocalAppData%\NVIDIA Corporation\NVIDIA GeForce Experience
 DetectFile3=%ProgramFiles%\NVIDIA Corporation\NVIDIA GeForce Experience
 Default=False
 FileKey1=%SystemDrive%\NvidiaLogging\GFExperience|GridClientLog.log*|RECURSE
-FileKey2=%CommonAppData%\NVIDIA Corporation\GfeBridges|*.log
-FileKey3=%CommonAppData%\NVIDIA Corporation\GeForce Experience\Logs|*.log
-FileKey4=%CommonAppData%\NVIDIA Corporation\GFExperience|*.log
-FileKey5=%CommonAppData%\NVIDIA Corporation\NVIDIA GeForce Experience\Logs|*.log
-FileKey6=%CommonAppData%\NVIDIA Corporation\nvstreamsvc|*.log
-FileKey7=%CommonAppData%\NVIDIA Corporation\ShadowPlay|*.log;*.bak;*.stat
-FileKey8=%CommonAppData%\NVIDIA\NvBackend\Updatus\DownloadManager|*.*
-FileKey9=%CommonAppData%\NVIDIA\Updatus\DownloadManager|*.*
-FileKey10=%CommonAppData%\NVIDIA Corporation\Downloader|*.*|RECURSE
-FileKey11=%CommonAppData%\NVIDIA Corporation\GeForce Experience\Update|*.*|RECURSE
-FileKey12=%LocalAppData%\NVIDIA Corporation\GFExperience|*.log
-FileKey13=%LocalAppData%\NVIDIA Corporation\ShadowPlay|*.bak;*.log;*.old
-FileKey14=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\NetService|*.*|RECURSE
-FileKey15=%LocalAppData%\VirtualStore\ProgramData\NVIDIA\NvBackend\Updatus\DownloadManager|*.*
-FileKey16=%LocalAppData%\VirtualStore\ProgramData\NVIDIA\Updatus\DownloadManager|*.*
-FileKey17=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\Downloader|*.*|RECURSE
-FileKey18=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\GeForce Experience\Update|*.*|RECURSE
-FileKey19=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\GfeBridges|*.log
-FileKey20=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\GeForce Experience\Logs|*.log
-FileKey21=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\GFExperience|*.log
-FileKey22=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\NVIDIA GeForce Experience\Logs|*.log
-FileKey23=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\nvstreamsvc|*.log
-FileKey24=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\ShadowPlay|*.bak;*.log;*.old;*.stat
+FileKey2=%CommonAppData%\NVIDIA Corporation\*GeForce Experience\Logs|*.log
+FileKey3=%CommonAppData%\NVIDIA Corporation\Downloader|*.*|RECURSE
+FileKey4=%CommonAppData%\NVIDIA Corporation\GeForce Experience\Update|*.*|RECURSE
+FileKey5=%CommonAppData%\NVIDIA Corporation\GfeBridges|*.log
+FileKey6=%CommonAppData%\NVIDIA Corporation\GFExperience|*.log
+FileKey7=%CommonAppData%\NVIDIA Corporation\nvstreamsvc|*.log
+FileKey8=%CommonAppData%\NVIDIA Corporation\ShadowPlay|*.log;*.bak;*.stat
+FileKey9=%CommonAppData%\NVIDIA\NvBackend\Updatus\DownloadManager|*.*
+FileKey10=%CommonAppData%\NVIDIA\Updatus\DownloadManager|*.*
+FileKey11=%LocalAppData%\NVIDIA Corporation\GFExperience|*.log
+FileKey12=%LocalAppData%\NVIDIA Corporation\ShadowPlay|*.bak;*.log;*.old
+FileKey13=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\*GeForce Experience\Logs|*.log
+FileKey14=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\Downloader|*.*|RECURSE
+FileKey15=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\GeForce Experience\Update|*.*|RECURSE
+FileKey16=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\GfeBridges|*.log
+FileKey17=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\GFExperience|*.log
+FileKey18=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\NetService|*.*|RECURSE
+FileKey19=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\nvstreamsvc|*.log
+FileKey20=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\ShadowPlay|*.bak;*.log;*.old;*.stat
+FileKey21=%LocalAppData%\VirtualStore\ProgramData\NVIDIA\NvBackend\Updatus\DownloadManager|*.*
+FileKey22=%LocalAppData%\VirtualStore\ProgramData\NVIDIA\Updatus\DownloadManager|*.*
+
+[NVIDIA*]
+LangSecRef=3024
+Detect=HKLM\Software\NVIDIA Corporation
+Default=False
+FileKey1=%CommonAppData%\NVIDIA|*.log;*.log_backup1|RECURSE
+FileKey2=%CommonAppData%\Nvidia|Resource.old
+FileKey3=%CommonAppData%\NVIDIA\NvBackend|*.log|RECURSE
+FileKey4=%CommonAppData%\Nvidia\NvBackend\Updat*s|*.bak
+FileKey5=%CommonAppData%\Nvidia\Updat*s|*.bak
+FileKey6=%CommonAppData%\NVIDIA Corporation|*.log
+FileKey7=%CommonAppData%\NVIDIA Corporation\NetService|*.*|RECURSE
+FileKey8=%CommonAppData%\NVIDIA Corporation\NvTelemetry|*.bak;*.log;*.old
+FileKey9=%CommonAppData%\NVIDIA Corporation\Nvstapisvr|*.bak;*.log;*.old
+FileKey10=%CommonAppData%\NVIDIA Corporation\nvStereoInstaller|*.log;*.old
+FileKey11=%CommonAppData%\NVIDIA Corporation\nvsdk|*.bak;*.log;*.old
+FileKey12=%CommonAppData%\NVIDIA Corporation\NvVAD|*.bak;*.log;*.old
+FileKey13=%LocalAppData%\NVIDIA\NvBackend|*.log;*.bak
+FileKey14=%LocalAppData%\NVIDIA Corporation\*\CefCache|*.log;*.bak;Cookies;Cookies-journal;QuotaManager;QuotaManager-journal
+FileKey15=%LocalAppData%\NVIDIA Corporation\*\CefCache\*Cache|*.*|RECURSE
+FileKey16=%LocalAppData%\NVIDIA Corporation\GfeSDK|*.log;*.bak
+FileKey17=%LocalAppData%\NVIDIA Corporation\NvNode|*.bak;*.log;*.old
+FileKey18=%LocalAppData%\NVIDIA Corporation\NvProfileUpdater|*.bak;*.log;*.old
+FileKey19=%LocalAppData%\NVIDIA Corporation\NvTelemetry|*.bak;*.log;*.old
+FileKey20=%LocalAppData%\NVIDIA Corporation\NvTmMon|*.bak;*.log;*.old
+FileKey21=%LocalAppData%\NVIDIA Corporation\NvTmRep|*.bak;*.log;*.old
+FileKey22=%LocalAppData%\NVIDIA Corporation\NvVAD|*.bak;*.log;*.old
+FileKey23=%LocalAppData%\VirtualStore\Program Files*\NVIDIA Corporation\NetworkAccessManager\Apache Group\Apache2\logs|*.*
+FileKey24=%LocalAppData%\VirtualStore\ProgramData*\NVIDIA|*.log;*.log_backup1|RECURSE
+FileKey25=%LocalAppData%\VirtualStore\ProgramData*\NVIDIA\NvBackend|*.log|RECURSE
+FileKey26=%LocalAppData%\VirtualStore\ProgramData*\NVIDIA Corporation\NvTelemetry|*.log;*.bak
+FileKey27=%LocalAppData%\VirtualStore\ProgramData\Nvidia|Resource.old
+FileKey28=%LocalAppData%\VirtualStore\ProgramData\Nvidia\NvBackend\Updat*s|*.bak
+FileKey29=%LocalAppData%\VirtualStore\ProgramData\Nvidia\Updat*s|*.bak
+FileKey30=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\NetService|*.*|RECURSE
+FileKey31=%ProgramFiles%\NVIDIA Corporation\NetworkAccessManager\Apache Group\Apache2\logs|*.*
 
 [O&O Defrag*]
 LangSecRef=3024
@@ -13662,9 +12891,17 @@ Detect=HKCU\Software\O&O\O&O Defrag
 Default=False
 FileKey1=%Documents%\O&O\O&O Defrag\data\reports|*.*|RECURSE
 
+[OBS Studio*]
+LangSecRef=3024
+DetectFile=%AppData%\obs-studio
+Default=False
+FileKey1=%AppData%\obs-studio\crashes|*.*
+FileKey2=%AppData%\obs-studio\logs|*.*
+FileKey3=%AppData%\obs-studio\profiler_data|*.*
+
 [OcenAudio MRU*]
 LangSecRef=3023
-Detect=HKCU\Software\OcenAudio
+Detect1=HKCU\Software\OcenAudio
 Detect2=HKLM\Software\OcenAudio
 Default=False
 FileKey1=%LocalAppData%\OcenAudio|ocen.database
@@ -13700,7 +12937,7 @@ Detect2=HKCU\Software\Microsoft\Office\14.0\Common
 Detect3=HKCU\Software\Microsoft\Office\15.0\Common
 Detect4=HKCU\Software\Microsoft\Office\16.0\Common
 Default=False
-FileKey1=%Documents%|~*.ppt;~*.pptx;~*.doc;~*.docx|RECURSE
+FileKey1=%Documents%\|~*.ppt;~*.pptx;~*.doc;~*.docx|RECURSE
 FileKey2=%LocalAppData%\Microsoft\Office\*\OfficeFileCache|*.*|RECURSE
 FileKey3=%LocalAppData%\Microsoft\Office\*|OneNoteOfflineCache.onecache
 FileKey4=%LocalAppData%\Microsoft\OneNote\*\OneNoteOfflineCache_Files|*.*|RECURSE
@@ -13734,21 +12971,16 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Office.OneNote_8wekyb3d8bbwe
 DetectFile=%LocalAppData%\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\INetCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\INetCookies|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\INetHistory|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local|msodata*.dat
+FileKey1=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\Temp|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local|msodata*.dat
+FileKey6=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0|*.onecache
+FileKey7=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0\OneNote*Cache_Files|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\Office\16.0\WebServiceCache\AllUsers\office*client.microsoft.com|*.*|RECURSE
 FileKey9=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\Office\OTele|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\Office\16.0\WebServiceCache\AllUsers\officeclient.microsoft.com|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\Office\16.0\WebServiceCache\AllUsers\office15client.microsoft.com|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0\OneNoteOfflineCache_Files|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0\OneNotePagePreviewCache_Files|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0|*.onecache
-FileKey15=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\TempState|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Office.OneNote_8wekyb3d8bbwe\SearchHistory
 
 [OneTeam Cache*]
@@ -13770,14 +13002,8 @@ LangSecRef=3024
 Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{AE695CA4-8847-4462-98CC-023874D29E72}_is1
 Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{668CC71A-C2AD-4D56-866D-CF300BD1D5BE}_is1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Kroll Ontrack\Ontrack EasyRecovery10 Enterprise|*erent_log.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Kroll Ontrack\Ontrack EasyRecovery10 Professional|*erpro_log.txt
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Kroll Ontrack\Ontrack EasyRecovery11 Enterprise|*erent_log.txt
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Kroll Ontrack\Ontrack EasyRecovery11 Professional|*erpro_log.txt
-FileKey5=%ProgramFiles%\Kroll Ontrack\Ontrack EasyRecovery10 Enterprise|*erent_log.txt
-FileKey6=%ProgramFiles%\Kroll Ontrack\Ontrack EasyRecovery10 Professional|*erpro_log.txt
-FileKey7=%ProgramFiles%\Kroll Ontrack\Ontrack EasyRecovery11 Enterprise|*erent_log.txt
-FileKey8=%ProgramFiles%\Kroll Ontrack\Ontrack EasyRecovery11 Professional|*erpro_log.txt
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Kroll Ontrack\Ontrack EasyRecovery*|*erent_log.txt;*erpro_log.txt
+FileKey2=%ProgramFiles%\Kroll Ontrack\Ontrack EasyRecovery*|*erent_log.txt;*erpro_log.txt
 
 [ooVoo Chat History*]
 LangSecRef=3022
@@ -13791,19 +13017,19 @@ DetectFile=%LocalLowAppData%\oovootoolbar
 Default=False
 FileKey1=%LocalLowAppData%\oovootoolbar|log.txt
 
-[Open Blu-ray Ripper*]
-LangSecRef=3023
-Detect=HKCU\Software\OpenCloner\BDRipper
-Default=False
-FileKey1=%AppData%\Open Blu-ray Ripper|OBR_LOG_FILE.txt
-FileKey2=%AppData%\Open Blu-ray Ripper\ReadCache|*.*|REMOVESELF
-
 [OpalCalc*]
 LangSecRef=3021
 DetectFile1=%AppData%\OpalCalc_prefs
 DetectFile2=%ProgramFiles%\OpalCalc
 Default=False
 FileKey1=%AppData%\OpalCalc_prefs|lastSession.txt
+
+[Open Blu-ray Ripper*]
+LangSecRef=3023
+Detect=HKCU\Software\OpenCloner\BDRipper
+Default=False
+FileKey1=%AppData%\Open Blu-ray Ripper|OBR_LOG_FILE.txt
+FileKey2=%AppData%\Open Blu-ray Ripper\ReadCache|*.*|REMOVESELF
 
 [Open Blu-ray to DVD*]
 LangSecRef=3023
@@ -13873,6 +13099,13 @@ Default=False
 FileKey1=%CommonAppData%\Sony Corporation\OpenMG|*.log
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Sony Corporation\OpenMG|*.log
 
+[OpenOffice.org Setup Files*]
+LangSecRef=3021
+Detect1=HKLM\Software\OpenOffice
+Detect2=HKLM\Software\OpenOffice.org
+Default=False
+FileKey1=%UserProfile%\Desktop|OpenOffice.org * Installation Files|RECURSE
+
 [OpenOffice.org*]
 LangSecRef=3021
 Detect1=HKLM\Software\OpenOffice
@@ -13884,13 +13117,6 @@ FileKey3=%AppData%\OpenOffice*\*\user\registry\cache|*.*
 FileKey4=%AppData%\OpenOffice*\*\user\registry\data\org\openoffice\Office|Views.xcu;Writer.xcu;Common.xcu;Histories.xcu
 FileKey5=%AppData%\OpenOffice*\*\user\registry\data\org\openoffice\ucb|Hierarchy.xcu;Store.xcu
 FileKey6=%ProgramFiles%\OpenOffice*\share\uno_packages\cache\uno_packages|*.tmp;*.log;log.txt
-
-[OpenOffice.org Setup Files*]
-LangSecRef=3021
-Detect1=HKLM\Software\OpenOffice
-Detect2=HKLM\Software\OpenOffice.org
-Default=False
-FileKey1=%UserProfile%\Desktop|OpenOffice.org * Installation Files|RECURSE
 
 [OpenRA Logs*]
 Section=Games
@@ -13917,32 +13143,25 @@ LangSecRef=3027
 DetectFile=%ProgramFiles%\Opera 9\Opera.exe
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Opera 9\profile|cookies4.dat;vlink4.dat;global.dat
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Opera 9\profile\cache4|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Opera 9\profile\cacheOp|*.*
-FileKey4=%ProgramFiles%\Opera 9\profile|cookies4.dat;vlink4.dat;global.dat
-FileKey5=%ProgramFiles%\Opera 9\profile\cache4|*.*
-FileKey6=%ProgramFiles%\Opera 9\profile\cacheOp|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Opera 9\profile\cache*|*.*
+FileKey3=%ProgramFiles%\Opera 9\profile|cookies4.dat;vlink4.dat;global.dat
+FileKey4=%ProgramFiles%\Opera 9\profile\cache*|*.*
 
 [Opera More*]
 LangSecRef=3027
 SpecialDetect=DET_OPERA
 Default=False
-FileKey1=%AppData%\Opera Software\Opera Stable|Bookmarks.bak
+FileKey1=%AppData%\Opera Software\Opera Stable|Bookmarks.bak;Favicons;Login Data;opera_autoupdate.log;previews_opt_out.db;ssdfp*.*
 FileKey2=%AppData%\Opera Software\Opera Stable\databases|Databases.db
 FileKey3=%AppData%\Opera Software\Opera Stable\Extension Cookies|*.*
 FileKey4=%AppData%\Opera Software\Opera Stable\Extension State|LOG.old
-FileKey5=%AppData%\Opera Software\Opera Stable|Favicons
-FileKey6=%AppData%\Opera Software\Opera Stable\File System\Origins|LOG.old
-FileKey7=%AppData%\Opera Software\Opera Stable|Login Data
-FileKey8=%AppData%\Opera Software\Opera Stable|opera_autoupdate.log
-FileKey9=%AppData%\Opera Software\Opera Stable|previews_opt_out.db
-FileKey10=%AppData%\Opera Software\Opera Stable|ssdfp*.*
-FileKey11=%LocalAppData%\Opera\Opera*\application_cache|*.*|REMOVESELF
-FileKey12=%LocalAppData%\Opera\Opera*\icons|*.*|REMOVESELF
-FileKey13=%LocalAppData%\Opera\Opera*\Logs|*.*|REMOVESELF
-FileKey14=%LocalAppData%\Opera\Opera*\temporary_downloads|*.*|REMOVESELF
-FileKey15=%LocalAppData%\Opera\Opera*\thumbnails|*.*|REMOVESELF
-FileKey16=%LocalAppData%\Opera\Opera*\vps|*.*|REMOVESELF
+FileKey5=%AppData%\Opera Software\Opera Stable\File System\Origins|LOG.old
+FileKey6=%LocalAppData%\Opera\Opera*\application_cache|*.*|REMOVESELF
+FileKey7=%LocalAppData%\Opera\Opera*\icons|*.*|REMOVESELF
+FileKey8=%LocalAppData%\Opera\Opera*\Logs|*.*|REMOVESELF
+FileKey9=%LocalAppData%\Opera\Opera*\temporary_downloads|*.*|REMOVESELF
+FileKey10=%LocalAppData%\Opera\Opera*\thumbnails|*.*|REMOVESELF
+FileKey11=%LocalAppData%\Opera\Opera*\vps|*.*|REMOVESELF
 RegKey1=HKCU\Software\Opera Software|Last CommandLine v2
 
 [Optimizer Pro*]
@@ -13978,29 +13197,25 @@ Detect2=HKCU\SOFTWARE\Robot Entertainment\Orcs Must Die! Unchained
 Default=False
 FileKey1=%Documents%\My Games\Orcs Must Die Unchained\SpitfireGame\Logs|*.log;*.dmg|RECURSE
 
-[Origin*]
-Section=Games
-Detect=HKLM\Software\Classes\Origin
-Default=False
-FileKey1=%CommonAppData%\Origin\AvatarsCache|*.*|RECURSE
-FileKey2=%CommonAppData%\Origin\DownloadCache|*.*|RECURSE
-FileKey3=%CommonAppData%\Origin\EntitlementCache|*.*|RECURSE
-FileKey4=%CommonAppData%\Origin\Logs|*.*
-FileKey5=%CommonAppData%\Origin\Telemetry|*.*
-FileKey6=%LocalAppData%\Origin\Web Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\Origin\Origin\cache|*.*|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Origin\AvatarsCache|*.*|RECURSE
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Origin\DownloadCache|*.*|RECURSE
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Origin\EntitlementCache|*.*|RECURSE
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\Origin\Logs|*.*
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\Origin\Telemetry|*.*
-FileKey13=%SystemDrive%|shared.log
-
 [Origin Installers*]
 Section=Games
 Detect=HKLM\Software\Classes\Origin
 Default=False
 FileKey1=%ProgramFiles%\Origin Games|*.cab;vc_red.msi;gfwlivesetup.exe;GamesExplorerIntegrationTool.exe;install.ini;globdata.ini;vcredist.bmp;vc_red.exe;install.exe;install.res.*.dll;eula.*.txt;vcredist_x64.exe;dotNetFx40_Full_setup.exe;dotNetFx40_Full_x86_x64.exe;xnafx40_redist.msi;DSETUP.DLL;oalinst.exe;DXSETUP.EXE;dsetup32.dll;dotnetfx3setup;vcredist_x86.exe;dxwebsetup.exe;xnafx31_redist.msi;dotNetFx35setup.exe;dotnetfx35.exe|RECURSE
+
+[Origin*]
+Section=Games
+Detect=HKLM\Software\Classes\Origin
+Default=False
+FileKey1=%CommonAppData%\Origin\*Cache|*.*|RECURSE
+FileKey2=%CommonAppData%\Origin\Logs|*.*
+FileKey3=%CommonAppData%\Origin\Telemetry|*.*
+FileKey4=%LocalAppData%\Origin\Web Cache|*.*|RECURSE
+FileKey5=%LocalAppData%\Origin\Origin\cache|*.*|RECURSE
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Origin\*Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\Origin\Logs|*.*
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\Origin\Telemetry|*.*
+FileKey9=%SystemDrive%\|shared.log
 
 [Osmos Logs*]
 Section=Games
@@ -14012,20 +13227,16 @@ FileKey1=%Documents%\Osmos|osmos.log
 Section=Games
 Detect=HKCU\Software\Osu!
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Osu!|debug-import.txt
-FileKey2=%ProgramFiles%\Osu!|debug-import.txt
+FileKey1=%LocalAppData%\osu!\logs|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Osu!|debug-import.txt
+FileKey3=%ProgramFiles%\Osu!|debug-import.txt
 
-[Outlast Crash Dumps*]
+[Outlast*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\238320
 Default=False
 FileKey1=%Documents%\My Games\Outlast\OLGame\Logs|*.dmp
-
-[Outlast Logs*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\238320
-Default=False
-FileKey1=%Documents%\My Games\Outlast\OLGame\Logs|*.log
+FileKey2=%Documents%\My Games\Outlast\OLGame\Logs|*.log
 
 [Outlook 2003*]
 LangSecRef=3021
@@ -14068,6 +13279,14 @@ Detect=HKLM\Software\Agnitum\Security Suite
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Agnitum\Outpost Security Suite Pro\log|*.log
 FileKey2=%ProgramFiles%\Agnitum\Outpost Security Suite Pro\log|*.log
+
+[Overwatch*]
+Section=Games
+DetectFile=%Documents%\Overwatch
+Default=False
+FileKey1=%Documents%\Overwatch\Logs|*.*|RECURSE
+FileKey2=%ProgramFiles%\Overwatch\WebBrowserProxy\cache\browser|*.*
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Overwatch\WebBrowserProxy\cache\browser|*.*
 
 [OVH HubiC cache*]
 LangSecRef=3021
@@ -14126,7 +13345,7 @@ Detect=HKLM\Software\Mozilla\Pale Moon
 DetectFile=%ProgramFiles%\Pale Moon\palemoon.exe
 Default=False
 FileKey1=%LocalAppData%\Moonchild Productions\Pale Moon\Profiles\*\cache2|*.*|RECURSE
- 
+
 [Pale Moon - Cookies*]
 LangSecRef=3026
 Detect=HKLM\Software\Mozilla\Pale Moon
@@ -14340,18 +13559,18 @@ Default=False
 Warning=This will cause you to redownload the Paramount Dynamic RSS file.
 FileKey1=%LocalAppData%\Microsoft\Feeds|http~c~f~fthemeserver~dmicrosoft~dcom~fdefault~daspx~mp=Paramount&c=Dynamic&m=en-US~
 
+[Paranormal Agency*]
+Section=Games
+DetectFile=%AppData%\Shape Games\Paranormal_v*
+Default=False
+FileKey1=%AppData%\Shame Games\Paranormal_v*\logs|*.*
+
 [Paranormal*]
 Section=Games
 DetectFile=%ProgramFiles%\Desura\Common\paranormal
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Desura\Common\paranormal\UDKGame\Logs|*.*
 FileKey2=%ProgramFiles%\Desura\Common\paranormal\UDKGame\Logs|*.*
-
-[Paranormal Agency*]
-Section=Games
-DetectFile=%AppData%\Shape Games\Paranormal_v*
-Default=False
-FileKey1=%AppData%\Shame Games\Paranormal_v*\logs|*.*
 
 [Partner Application*]
 LangSecRef=3022
@@ -14466,19 +13685,19 @@ Detect=HKCU\Software\Woozle\PE Module Explorer
 Default=False
 RegKey1=HKCU\Software\Woozle\PE Module Explorer\Recent Files
 
-[Peerblock*]
-LangSecRef=3024
-DetectFile=%ProgramFiles%\Peerblock
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Peerblock|*.log;History.db;*.bak;cache.p2b
-FileKey2=%ProgramFiles%\Peerblock|*.log;History.db;*.bak;cache.p2b
-
 [Peerblock Failed Lists*]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Peerblock
 Default=False
 Warning=This will delete all lists that failed to load into your peerblock
 FileKey1=%ProgramFiles%\Peerblock\lists|*.list.failed*
+
+[Peerblock*]
+LangSecRef=3024
+DetectFile=%ProgramFiles%\Peerblock
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Peerblock|*.log;History.db;*.bak;cache.p2b
+FileKey2=%ProgramFiles%\Peerblock|*.log;History.db;*.bak;cache.p2b
 
 [PeerNetworking*]
 LangSecRef=3025
@@ -14501,16 +13720,13 @@ Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.People_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\Microsoft.People_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.People_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.People_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.People_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.People_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.People_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.People_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.People_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.People_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.People_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.People_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.People_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.People_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.People_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.People_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.People_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.People_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.People_*\TempState|*.*|RECURSE
 
 [Perfect Registry*]
 LangSecRef=3024
@@ -14571,17 +13787,17 @@ FileKey6=%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor\temp|*.*|REMOV
 ExcludeKey1=PATH|%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor\jre\bin\|*.*
 ExcludeKey2=PATH|%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor\jre\lib\|*.*
 
-[phase-6*]
-LangSecRef=3021
-DetectFile=%UserProfile%\.phase-6
-Default=False
-FileKey1=%UserProfile%\.phase-6|window-position.txt|REMOVESELF
-
 [phase-6 logs*]
 LangSecRef=3021
 DetectFile=%UserProfile%\.phase-6
 Default=False
 FileKey1=%UserProfile%\.phase-6\logs|phase-6.log|REMOVESELF
+
+[phase-6*]
+LangSecRef=3021
+DetectFile=%UserProfile%\.phase-6
+Default=False
+FileKey1=%UserProfile%\.phase-6|window-position.txt|REMOVESELF
 
 [Phone*]
 DetectOS=10.0|
@@ -14589,16 +13805,13 @@ Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsPhone_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\TempState|*.*|RECURSE
 
 [Phorest*]
 LangSecRef=3024
@@ -14645,7 +13858,7 @@ FileKey7=%LocalAppData%\VirtualStore\ProgramData\Photodex\ProShow\FontCache|*.*|
 FileKey8=%LocalAppData%\VirtualStore\ProgramData\Photodex\ProShow\Styles\Cache|*.*|REMOVESELF
 FileKey9=%LocalAppData%\VirtualStore\ProgramData\Photodex\ProShow\Transitions\Cache|*.*|REMOVESELF
 FileKey10=%ProgramFiles%\Photodex\ProShow Producer|*.log|RECURSE
-FileKey11=%UserProfile%|proshow-burn.log
+FileKey11=%UserProfile%\|proshow-burn.log
 ExcludeKey1=FILE|%ProgramFiles%\Photodex\ProShow Producer\pxf\images\|xicons.txt
 
 [Photos*]
@@ -14653,15 +13866,12 @@ DetectOS=10.0|
 Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Photos_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\AC\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\LocalCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\LocalState\PhotosAppTile|*.*|RECURSE
-FileKey9=%LocalAppData%\PackagesMicrosoft.Windows.Photos_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\AC\Temp|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\LocalCache|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\LocalState\PhotosAppTile|*.*|RECURSE
+FileKey6=%LocalAppData%\PackagesMicrosoft.Windows.Photos_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Photos_8wekyb3d8bbwe\PersistedStorageItemTable\ManagedByApp
 RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Photos_8wekyb3d8bbwe\PersistedStorageItemTable\MostRecentlyUsed
 
@@ -14752,7 +13962,7 @@ LangSecRef=3022
 Detect=HKCU\Software\Pidgin
 Default=False
 FileKey1=%AppData%\.purple|*.xml~
-FileKey2=%UserProfile%|Recently-Used.xbel
+FileKey2=%UserProfile%\|Recently-Used.xbel
 
 [Pipy*]
 LangSecRef=3021
@@ -14830,17 +14040,12 @@ DetectFile=%ProgramFiles%\Pok3d
 Default=False
 FileKey1=%AppData%\Pok3d|*.log;*.dmp
 
-[PokerStars Cache*]
-Section=Games
-DetectFile=%LocalAppData%\PokerStars
-Default=False
-FileKey1=%LocalAppData%\PokerStars\ImgCache|*.*
-
-[PokerStars Logs*]
+[PokerStars*]
 Section=Games
 DetectFile=%LocalAppData%\PokerStars
 Default=False
 FileKey1=%LocalAppData%\PokeStars|*.log.*
+FileKey2=%LocalAppData%\PokerStars\ImgCache|*.*
 
 [Pokki Backups*]
 LangSecRef=3022
@@ -14976,11 +14181,9 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData\Predator-Usb\PredatorACE\data|*
 
 [Presentation Foundation Font Cache*]
 LangSecRef=3025
-DetectFile1=%WinDir%\Microsoft.Net\Framework\v3.0\WPF\PresentationFontCache.exe
-DetectFile2=%WinDir%\Microsoft.NET\Framework\v4.0.30319\WPF\WPFFontCache_v0400.exe
-DetectFile3=%WinDir%\Microsoft.Net\Framework64\v3.0\WPF\PresentationFontCache.exe
-DetectFile4=%WinDir%\Microsoft.NET\Framework64\v4.0.30319\WPF\WPFFontCache_v0400.exe
-DetectFile5=%WinDir%\winsxs\x86_wpf-presentationfontcache_31bf3856ad364e35_6.1.7600.16385_none_056fecf27381a72b\PresentationFontCache.exe
+DetectFile1=%WinDir%\Microsoft.Net\Framework*\v3.0\WPF\PresentationFontCache.exe
+DetectFile2=%WinDir%\Microsoft.NET\Framework*\v4.0.*\WPF\WPFFontCache_v0400.exe
+DetectFile3=%WinDir%\winsxs\x86_wpf-presentationfontcache_31bf3856ad364e35_6.1.7600.16385_none_056fecf27381a72b\PresentationFontCache.exe
 Default=False
 Warning=This will remove the cache commonly used font data by WPF applications.
 FileKey1=%SystemDrive%\Documents and Settings\LocalService\Local Settings\Application Data|FontCache*.dat;~FontCache*.dat;WPFFontCache_v0400-*.dat
@@ -15020,6 +14223,12 @@ Default=False
 FileKey1=%WinDir%\system32\spool|spooler.xml
 FileKey2=%SystemDrive%\spoolerlogs|spooler.xml
 
+[Prison Architect*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\233450
+Default=False
+FileKey1=%LocalAppData%\Introversion\Prison Architect|debug.txt
+
 [Privacy Eraser*]
 LangSecRef=3024
 Detect=HKCU\Software\PrivacyEraser Computing, Inc.
@@ -15042,7 +14251,7 @@ FileKey2=%LocalAppData%\VirtualStore\Program Files*\pia_manager\log|*.*
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\pia_manager\tmp|*.*
 FileKey4=%ProgramFiles%\pia_manager\log|*.*
 FileKey5=%ProgramFiles%\pia_manager\tmp|*.*
-FileKey6=%UserProfile%|.pia_manager_crash.log
+FileKey6=%UserProfile%\|.pia_manager_crash.log
 
 [Privoxy Log*]
 LangSecRef=3022
@@ -15098,9 +14307,7 @@ FileKey2=%ProgramFiles%\ProgDVB\Logs|*.*|RECURSE
 [Project64*]
 Section=Games
 Detect=HKCU\Software\N64 Emulation
-DetectFile1=%ProgramFiles%\Project64 2.0
-DetectFile2=%ProgramFiles%\Project64 2.1
-DetectFile3=%ProgramFiles%\Project64 2.2
+DetectFile=%ProgramFiles%\Project64 *
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Project64 2.*\Logs|*.*
 FileKey2=%ProgramFiles%\Project64 2.*\Logs|*.*
@@ -15158,8 +14365,7 @@ FileKey1=%AppData%\Psi+\profiles\*\history|*.*|RECURSE
 LangSecRef=3021
 DetectFile=%AppData%\Cypress_Semiconductor\PSoC_Designer_54
 Default=False
-FileKey1=%AppData%\Cypress_Semiconductor\PSoC_Designer_54|debug.log
-FileKey2=%AppData%\Cypress_Semiconductor\PSoC_Designer_54|debug.log.*
+FileKey1=%AppData%\Cypress_Semiconductor\PSoC_Designer_54|debug.log;debug.log.*
 
 [PSPad Recent Files*]
 LangSecRef=3024
@@ -15201,7 +14407,7 @@ FileKey4=%LocalAppData%\VirtualStore\ProgramData\Pure Networks\Platform|*.bak
 LangSecRef=3024
 DetectFile=%SystemDrive%\PureRa.txt
 Default=False
-FileKey1=%SystemDrive%|PureRa.txt
+FileKey1=%SystemDrive%\|PureRa.txt
 
 [Puritan File Destroyer Elite Logs*]
 LangSecRef=3023
@@ -15210,18 +14416,18 @@ Default=False
 FileKey1=%CommonAppData%\Puritan\File Destroyer Elite|*.log|RECURSE
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Puritan\File Destroyer Elite|*.log|RECURSE
 
-[Pushbullet*]
-LangSecRef=3022
-DetectFile=%AppData%\Pushbullet
-Default=False
-FileKey1=%AppData%\Pushbullet\pushbullet|*.log
-
 [Push Notifications*]
 DetectOS=6.2|
 LangSecRef=3025
 Default=False
 FileKey1=%LocalAppData%\Microsoft\Windows\Notifications|*.*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\PushNotifications\wpnidm
+
+[Pushbullet*]
+LangSecRef=3022
+DetectFile=%AppData%\Pushbullet
+Default=False
+FileKey1=%AppData%\Pushbullet\pushbullet|*.log
 
 [Pycharm Cache*]
 LangSecRef=3021
@@ -15259,11 +14465,9 @@ LangSecRef=3022
 Detect=HKCU\Software\QIP
 DetectFile=%AppData%\QIP
 Default=False
-FileKey1=%AppData%\QIP\Profiles\*\FacebookAvatars|*.*
+FileKey1=%AppData%\QIP\Profiles\*\*Avatars|*.*
 FileKey2=%AppData%\QIP\Profiles\*\Jabber|*.*
 FileKey3=%AppData%\QIP\Profiles\*\PicHashes|*.*
-FileKey4=%AppData%\QIP\Profiles\*\TwitterAvatars|*.*
-FileKey5=%AppData%\QIP\Profiles\*\VkAvatars|*.*
 
 [QIP 2012 Logs*]
 LangSecRef=3022
@@ -15346,8 +14550,7 @@ FileKey15=%ProgramFiles%\Quicken\PDFDrv|install.log;InstallPDFConverter.log
 
 [Quicken WillMaker Plus*]
 LangSecRef=3021
-DetectFile1=%LocalAppData%\Quicken WillMaker Plus 2013
-DetectFile2=%LocalAppData%\Quicken WillMaker Plus 2014
+DetectFile=%LocalAppData%\Quicken WillMaker Plus *
 Default=False
 FileKey1=%LocalAppData%\Quicken WillMaker Plus *|web update log.txt
 
@@ -15372,20 +14575,15 @@ Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\QuizUp.QuizUp_n36z36qeaxk8a
 FileKey1=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey6=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Microsoft\CLR_v4.0_32|*.log|RECURSE
-FileKey8=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Microsoft\CLR_v4.0_32\NativeImages\Temp|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Temp|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\QuizUp.QuizUp_*\LocalCache|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\QuizUp.QuizUp_*\LocalState\Cache|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\QuizUp.QuizUp_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
+FileKey4=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Temp|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\QuizUp.QuizUp_*\LocalCache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\QuizUp.QuizUp_*\LocalState\Cache|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\QuizUp.QuizUp_*\TempState|*.*|RECURSE
 
 [QupZilla Portable Cookies*]
 Section=QupZilla Portable
@@ -15526,13 +14724,7 @@ FileKey1=%CommonAppData%\FreshGames\RanchRush\*|*.log;temp_data.ssp
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ranch Rush*|*.html;*.nfo
 FileKey3=%LocalAppData%\VirtualStore\ProgramData\FreshGames\RanchRush\*|*.log;temp_data.ssp
 FileKey4=%ProgramFiles%\Ranch Rush*|*.html;*.nfo
-FileKey5=%WinDir%|Ranch Rush Setup Log.txt
-
-[Raptr Avatar Cache*]
-Section=Games
-Detect=HKCU\Software\Raptr
-Default=False
-FileKey1=%AppData%\Raptr\Avatars|*.*|RECURSE
+FileKey5=%WinDir%\|Ranch Rush Setup Log.txt
 
 [Raptr Chat History*]
 Section=Games
@@ -15540,7 +14732,7 @@ Detect=HKCU\Software\Raptr
 Default=False
 FileKey1=%AppData%\Raptr\Data\*|chat_history.db
 
-[Raptr Logs*]
+[Raptr*]
 LangSecRef=3021
 Detect=HKCU\Software\Raptr
 DetectFile=%ProgramFiles%\Raptr
@@ -15548,6 +14740,7 @@ Default=False
 FileKey1=%AppData%\Raptr|*.log|RECURSE
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Raptr|*.log
 FileKey3=%ProgramFiles%\Raptr|*.log
+FileKey4=%AppData%\Raptr\Avatars|*.*|RECURSE
 ExcludeKey1=FILE|%ProgramFiles%\Raptr\|install.log
 
 [Razer Game Booster*]
@@ -15573,12 +14766,11 @@ LangSecRef=3024
 DetectFile=%CommonAppData%\Razer\Synapse
 Default=False
 FileKey1=%CommonAppData%\Razer\InGameEngine\Logs|*.*
-FileKey2=%CommonAppData%\Razer\Services\Logs|*.*
-FileKey3=%CommonAppData%\Razer\Synapse\Logs|*.*
-FileKey4=%CommonAppData%\Razer\Synapse\Accounts\*\DataSync|SyncDate.txt
-FileKey5=%LocalAppData%\Razer\RzUninstallation\Logs|*.*
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Razer\Synapse\Logs|*.*
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Razer\Synapse\Accounts\*\DataSync|SyncDate.txt
+FileKey2=%CommonAppData%\Razer\S*e\Logs|*.*
+FileKey3=%CommonAppData%\Razer\Synapse\Accounts\*\DataSync|SyncDate.txt
+FileKey4=%LocalAppData%\Razer\RzUninstallation\Logs|*.*
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\Razer\Synapse\Logs|*.*
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Razer\Synapse\Accounts\*\DataSync|SyncDate.txt
 
 [RazerComms*]
 LangSecRef=3022
@@ -15619,7 +14811,7 @@ Detect=HKLM\Software\Realtek
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Realtek*|*.log;*.txt|RECURSE
 FileKey2=%ProgramFiles%\Realtek*|*.*log;*.txt|RECURSE
-FileKey3=%SystemDrive%|RHDSetup.log
+FileKey3=%SystemDrive%\|RHDSetup.log
 ExcludeKey1=FILE|%ProgramFiles%\Realtek\*\|InstCtrl.txt
 ExcludeKey2=FILE|%ProgramFiles%\Realtek\*\|setupctrl.txt
 
@@ -15628,11 +14820,8 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Studios.RecklessRacingUltimate_8wekyb3d8bbwe
 DetectFile=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey2=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey3=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\INetCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\INetCookies|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\INetHistory|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey2=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\INet*|*.*|RECURSE
 
 [RecollX*]
 LangSecRef=3021
@@ -15646,22 +14835,19 @@ Detect=HKCU\Software\Piriform\Recuva
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Recuva|*.log;Recuva_log*.txt
 FileKey2=%ProgramFiles%\Recuva|*.log;Recuva_log*.txt
-FileKey3=%UserProfile%|Recuva_log*.txt
+FileKey3=%UserProfile%\|Recuva_log*.txt
 
 [Reddit To Go!*]
 LangSecRef=3031
 DetectFile=%LocalAppData%\Packages\*.RedditToGo_*
 Default=False
-FileKey1=%LocalAppData%\Packages\*.RedditToGo_*\RoamingState|history.txt
-FileKey2=%LocalAppData%\Packages\*.RedditToGo_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey3=%LocalAppData%\Packages\*.RedditToGo_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
+FileKey1=%LocalAppData%\Packages\*.RedditToGo_*\AC\AppCache|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\*.RedditToGo_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\*.RedditToGo_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 FileKey4=%LocalAppData%\Packages\*.RedditToGo_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\*.RedditToGo_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\*.RedditToGo_*\AC\INetCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\*.RedditToGo_*\AC\INetCookies|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\*.RedditToGo_*\AC\INetHistory|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\*.RedditToGo_*\AC\AppCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\*.RedditToGo_*\AC\Temp|*.*
+FileKey6=%LocalAppData%\Packages\*.RedditToGo_*\AC\Temp|*.*
+FileKey7=%LocalAppData%\Packages\*.RedditToGo_*\RoamingState|history.txt
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\55382ross456.RedditToGo_02dxdbb1qg9kw\SearchHistory
 
 [Reflector Dump Files*]
@@ -15739,22 +14925,19 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\RFA *|*.diz;*.url
 FileKey2=%LocalAppData%\Microsoft\Windows|NTUSER.tmp;UsrClass.tmp
 FileKey3=%ProgramFiles%\RFA *|*.diz;*.url
-FileKey4=%UserProfile%|NTUSER.tmp;UsrClass.tmp
-FileKey5=%WinDir%\ServiceProfiles\LocalService|*.tmp;*.tmp.LOG1;*.tmp.LOG2
-FileKey6=%WinDir%\ServiceProfiles\NetworkService|*.tmp;*.tmp.LOG1;*.tmp.LOG2
-FileKey7=%WinDir%\System32\config\systemprofile|*.tmp;*.tmp.LOG1;*.tmp.LOG2
-FileKey8=%WinDir%\SysWOW64\config\systemprofile|*.tmp;*.tmp.LOG1;*.tmp.LOG2
-FileKey9=%WinDir%\System32\config|*.tmp;*.tmp.LOG1;*.tmp.LOG2
+FileKey4=%UserProfile%\|NTUSER.tmp;UsrClass.tmp
+FileKey5=%WinDir%\ServiceProfiles\*Service|*.tmp;*.tmp.LOG1;*.tmp.LOG2
+FileKey6=%WinDir%\System32\config\systemprofile|*.tmp;*.tmp.LOG1;*.tmp.LOG2
+FileKey7=%WinDir%\SysWOW64\config\systemprofile|*.tmp;*.tmp.LOG1;*.tmp.LOG2
+FileKey8=%WinDir%\System32\config|*.tmp;*.tmp.LOG1;*.tmp.LOG2
 
 [Registry Mechanic*]
 LangSecRef=3024
 Detect=HKLM\Software\PCTools\Registry Mechanic
 Default=False
 FileKey1=%AppData%\Registry Mechanic\log|*.html
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Registry Mechanic\log|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Registry Mechanic\logs|*.*
-FileKey4=%ProgramFiles%\Registry Mechanic\log|*.*
-FileKey5=%ProgramFiles%\Registry Mechanic\logs|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Registry Mechanic\log*|*.*
+FileKey3=%ProgramFiles%\Registry Mechanic\log*|*.*
 
 [RegistryFix*]
 LangSecRef=3024
@@ -15814,8 +14997,7 @@ FileKey4=%LocalAppData%\VirtualStore\ProgramData\Microsoft\RAC\PublishedData|*.l
 
 [Relic Downloader*]
 Section=Games
-DetectFile1=%Documents%\My Games\Company of Heroes
-DetectFile2=%Documents%\My Games\Company of Heroes Relaunch
+DetectFile=%Documents%\My Games\Company of Heroes*
 Default=False
 FileKey1=%Documents%\My Games\RelicDownloader|*.log
 
@@ -15824,7 +15006,7 @@ LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Terminal Server Client
 Default=False
 Warning=This will reset all Remote Desktop Connection settings.
-FileKey1=%Documents%|*.rdp
+FileKey1=%Documents%\|*.rdp
 
 [Rename Us*]
 LangSecRef=3024
@@ -15880,7 +15062,7 @@ RegKey5=HKCU\Software\Bomers\Restorator\Restorator\MRUList
 LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{CC48DE1C-8EC2-43BC-9201-29701CD9AE13}_is1
 Default=False
-FileKey1=%CommonAppData%|Restore Point Creator.log
+FileKey1=%CommonAppData%\|Restore Point Creator.log
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Restore Point Creator|*.log;*.txt
 FileKey3=%ProgramFiles%\Restore Point Creator|*.log;*.txt
 
@@ -15909,9 +15091,8 @@ LangSecRef=3024
 DetectFile=%LocalAppData%\VS Revo group
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\VS Revo Group\Revo Uninstaller Pro|*.bak
-FileKey2=%LocalAppData%\VS Revo Group\Revo Uninstaller Free\BackupsData|*.*|RECURSE
-FileKey3=%LocalAppData%\VS Revo Group\Revo Uninstaller Pro\BackupsData|*.*|RECURSE
-FileKey4=%ProgramFiles%\VS Revo Group\Revo Uninstaller Pro|*.bak
+FileKey2=%LocalAppData%\VS Revo Group\Revo Uninstaller*\BackupsData|*.*|RECURSE
+FileKey3=%ProgramFiles%\VS Revo Group\Revo Uninstaller Pro|*.bak
 
 [Ride!*]
 Section=Games
@@ -15922,7 +15103,7 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Ride!|*.log;*.txt|RECURSE
 FileKey2=%ProgramFiles%\Ride!|*.log;*.txt|RECURSE
 FileKey3=%ProgramFiles%\Ride!\DirectX9|*.*|REMOVESELF
-FileKey4=%WinDir%|DirectX.log
+FileKey4=%WinDir%\|DirectX.log
 
 [Riding Academy 3D*]
 Section=Games
@@ -15936,7 +15117,7 @@ Detect=HKLM\Software\DTP\Riding Star 3
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Riding Star 3|INSTALL.LOG;log.txt
 FileKey2=%ProgramFiles%\Riding Star 3|INSTALL.LOG;log.txt
-FileKey3=%WinDir%|DirectX.log
+FileKey3=%WinDir%\|DirectX.log
 
 [RIFT*]
 Section=Games
@@ -16020,6 +15201,12 @@ Default=False
 FileKey1=%ProgramFiles%\ATLUS\Rock of Ages\Prerequisites|*.*|REMOVESELF
 FileKey2=%ProgramFiles%\Steam\steamapps\common\Rock of Ages\Prerequisites|*.*|REMOVESELF
 
+[Rocket League*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\252950
+Default=False
+FileKey1=%Documents%\My Games\Rocket League\TAGame\Logs|*.*
+
 [RollBack Rx Logs*]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Shield
@@ -16061,12 +15248,11 @@ LangSecRef=3021
 Detect=HKCU\Software\Roxio
 Default=False
 FileKey1=%AppData%\Roxio Log Files|*.*|RECURSE
-FileKey2=%AppData%\Roxio\Dragon\3.x\DeviceDetectionLogs|*.log
-FileKey3=%AppData%\Roxio\Dragon\3.x\WriteLogs|*.log
-FileKey4=%CommonAppData%\Roxio|*.log;cardinfo.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Roxio|*.log;cardinfo.*
-FileKey6=%WinDir%\System32\config\systemprofile\AppData\Roaming\Roxio Log Files|*.*|RECURSE
-FileKey7=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\Roxio Log Files|*.*|RECURSE
+FileKey2=%AppData%\Roxio\Dragon\3.x\*Logs|*.log
+FileKey3=%CommonAppData%\Roxio|*.log;cardinfo.*
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\Roxio|*.log;cardinfo.*
+FileKey5=%WinDir%\System32\config\systemprofile\AppData\Roaming\Roxio Log Files|*.*|RECURSE
+FileKey6=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\Roxio Log Files|*.*|RECURSE
 
 [Roxio Temp Files*]
 LangSecRef=3021
@@ -16074,7 +15260,7 @@ Detect=HKCU\Software\Roxio
 Default=False
 FileKey1=%AppData%\Roxio\Dragon\3.x\DiscInfoCache|*.tmp
 FileKey2=%AppData%\Roxio Burn\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%|rx_audio.Cache;rx_image32.Cache
+FileKey3=%LocalAppData%\|rx_audio.Cache;rx_image32.Cache
 
 [RssBandit*]
 LangSecRef=3022
@@ -16086,7 +15272,7 @@ FileKey1=%AppData%\RssBandit|*.bak;*.log
 LangSecRef=3024
 DetectFile=%UserProfile%\.swfinfo
 Default=False
-FileKey1=%UserProfile%|.swfinfo
+FileKey1=%UserProfile%\|.swfinfo
 
 [Rust*]
 Section=Games
@@ -16126,7 +15312,7 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData\Sage Software\Simply Accounting
 LangSecRef=3021
 DetectFile=%ProgramFiles%\SageThumbs\64\SageThumbs.dll
 Default=False
-FileKey1=%LocalAppData%|SageThumbs.*
+FileKey1=%LocalAppData%\|SageThumbs.*
 
 [SAM Broadcaster*]
 LangSecRef=3023
@@ -16168,16 +15354,15 @@ LangSecRef=3021
 Detect=HKLM\Software\Samsung Magician
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Samsung\Samsung Magician|*.log;*.txt|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Samsung\Samsung Magician\Logs|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Samsung\Samsung Magician\Log*|*.*
 FileKey3=%ProgramFiles%\Samsung Magician\Logs|*.*
-FileKey4=%ProgramFiles%\Samsung\Samsung Magician\Logs|*.*
-FileKey5=%ProgramFiles%\Samsung\Samsung Magician\Log|*.*
+FileKey4=%ProgramFiles%\Samsung\Samsung Magician\Log*|*.*
 
 [Samsung SmarThru 4 Logs*]
 LangSecRef=3023
 Detect=HKLM\Software\Samsung\SmarThru 4
 Default=False
-FileKey1=%WinDir%|smarthru.log
+FileKey1=%WinDir%\|smarthru.log
 
 [Sanctum*]
 Section=Games
@@ -16240,16 +15425,13 @@ Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsScan_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsScan_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.WindowsScan_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WindowsScan_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.WindowsScan_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsScan_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsScan_*\TempState|*.*|RECURSE
 
 [ScanDefrag*]
 LangSecRef=3024
@@ -16273,18 +15455,18 @@ Default=False
 Warning=This Resets Screenshot Naming Back To "Screenshot (1).png"
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer|ScreenshotIndex
 
-[Scribe*]
-LangSecRef=3021
-Detect=HKCU\Software\NCH Software\Scribe
-Default=False
-FileKey1=%AppData%\NCH Software\Scribe\Logs|*.*
-
 [Scribe Finished Jobs*]
 LangSecRef=3021
 Detect=HKCU\Software\NCH Software\Scribe
 Default=False
 Warning=This will delete copies of files related you have run through Scribe.
 FileKey1=%AppData%\NCH Software\Scribe\Done|*.*
+
+[Scribe*]
+LangSecRef=3021
+Detect=HKCU\Software\NCH Software\Scribe
+Default=False
+FileKey1=%AppData%\NCH Software\Scribe\Logs|*.*
 
 [Scribus*]
 LangSecRef=3023
@@ -16318,29 +15500,22 @@ FileKey3=%ProgramFiles%\Seagate\SeaTools for Windows|*.log
 LangSecRef=3026
 DetectFile=%AppData%\Mozilla\SeaMonkey
 Default=False
-FileKey1=%AppData%\Mozilla\SeaMonkey\Profiles\*\adblock*|patterns-backup*.ini;*.tmp
-FileKey2=%AppData%\Mozilla\SeaMonkey\Profiles\*\datareporting\archived|*.jsonlz4|REMOVESELF
-FileKey3=%AppData%\Mozilla\SeaMonkey\Profiles\*\bookmarkbackups|*.json*
-FileKey4=%AppData%\Mozilla\SeaMonkey\Profiles\*\chatzilla|inputHistory.txt
-FileKey5=%AppData%\Mozilla\SeaMonkey\Profiles|*.corrupt|RECURSE
-FileKey6=%AppData%\Mozilla\SeaMonkey\Crash Reports|*.*|REMOVESELF
-FileKey7=%AppData%\Mozilla\SeaMonkey\Profiles\*\storage|*.*|REMOVESELF
-FileKey8=%AppData%\Mozilla\SeaMonkey\Profiles\*|FlashGot.log;FlashGot.log.bak*
-FileKey9=%AppData%\Mozilla\SeaMonkey\Profiles\*|lazarus.sqlite;lazarus-backup.sqlite
-FileKey10=%AppData%\Mozilla\SeaMonkey\Profiles\*|*.lock
+FileKey1=%AppData%\Mozilla\SeaMonkey\Crash Reports|*.*|REMOVESELF
+FileKey2=%AppData%\Mozilla\SeaMonkey\Profiles|TestPilotErrorLog.*;*.corrupt|RECURSE
+FileKey3=%AppData%\Mozilla\SeaMonkey\Profiles\*|seer.sqlite;netpredictions.sqlite;sessionstore.bak;FlashGot.log;FlashGot.log.bak*;lazarus.sqlite;lazarus-backup.sqlite;Telemetry*.*;webappsstore.sqlite;*.lock
+FileKey4=%AppData%\Mozilla\SeaMonkey\Profiles\*\adblock*|patterns-backup*.ini;*.tmp
+FileKey5=%AppData%\Mozilla\SeaMonkey\Profiles\*\bookmarkbackups|*.json*
+FileKey6=%AppData%\Mozilla\SeaMonkey\Profiles\*\chatzilla|inputHistory.txt
+FileKey7=%AppData%\Mozilla\SeaMonkey\Profiles\*\datareporting\archived|*.jsonlz4|REMOVESELF
+FileKey8=%AppData%\Mozilla\SeaMonkey\Profiles\*\saved-telemetry-pings|*.*
+FileKey9=%AppData%\Mozilla\SeaMonkey\Profiles\*\sessions\Deleted Sessions|*.session
+FileKey10=%AppData%\Mozilla\SeaMonkey\Profiles\*\storage|*.*|REMOVESELF
 FileKey11=%AppData%\Mozilla\SeaMonkey\Profiles\*\minidumps|*.*
-FileKey12=%AppData%\Mozilla\SeaMonkey\Profiles\*|seer.sqlite;netpredictions.sqlite
-FileKey13=%AppData%\Mozilla\SeaMonkey\Profiles\*|sessionstore.bak*
-FileKey14=%AppData%\Mozilla\SeaMonkey\Profiles\*\sessions\Deleted Sessions|*.session
-FileKey15=%AppData%\Mozilla\SeaMonkey\Profiles\*\weave\logs|*.*
-FileKey16=%LocalAppData%\Mozilla\SeaMonkey\Profiles\*\shortcutCache|*.*
-FileKey17=%LocalAppData%\Mozilla\SeaMonkey\Profiles\*\startupCache|*.*
-FileKey18=%AppData%\Mozilla\SeaMonkey\Profiles\*|Telemetry*.*
-FileKey19=%AppData%\Mozilla\SeaMonkey\Profiles\*\saved-telemetry-pings|*.*
-FileKey20=%AppData%\Mozilla\SeaMonkey\Profiles|TestPilotErrorLog.*|RECURSE
-FileKey21=%LocalAppData%\Mozilla\SeaMonkey\*\updates|*.*|RECURSE
-FileKey22=%LocalAppData%\Mozilla\SeaMonkey\Profiles\*|urlclassifier3.sqlite
-FileKey23=%AppData%\Mozilla\SeaMonkey\Profiles\*|webappsstore.sqlite
+FileKey12=%AppData%\Mozilla\SeaMonkey\Profiles\*\weave\logs|*.*
+FileKey13=%LocalAppData%\Mozilla\SeaMonkey\*\updates|*.*|RECURSE
+FileKey14=%LocalAppData%\Mozilla\SeaMonkey\Profiles\*\shortcutCache|*.*
+FileKey15=%LocalAppData%\Mozilla\SeaMonkey\Profiles\*\startupCache|*.*
+FileKey16=%LocalAppData%\Mozilla\SeaMonkey\Profiles\*|urlclassifier3.sqlite
 ExcludeKey1=PATH|%AppData%\Mozilla\SeaMonkey\Profiles\*\storage\default\moz-extension*\|*.*
 
 [Search History*]
@@ -16351,12 +15526,6 @@ Default=False
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\SearchHistory
 RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Search\RecentApps
 
-[Second Copy*]
-LangSecRef=3024
-DetectFile=%LocalAppData%\Centered Systems\Second Copy
-Default=False
-FileKey1=%LocalAppData%\Centered Systems\Second Copy|log*.*
-
 [Second Copy 2000*]
 LangSecRef=3021
 Detect=HKCU\Software\Centered Systems\Second Copy 2000
@@ -16365,14 +15534,19 @@ FileKey1=%LocalAppData%\VirtualStore\Program Files*\SecCopy|log.rtf;log-old.rtf
 FileKey2=%ProgramFiles%\SecCopy|log.rtf;log-old.rtf
 RegKey1=HKCU\Software\Centered Systems\Second Copy 2000\MRU
 
+[Second Copy*]
+LangSecRef=3024
+DetectFile=%LocalAppData%\Centered Systems\Second Copy
+Default=False
+FileKey1=%LocalAppData%\Centered Systems\Second Copy|log*.*
+
 [SecondLife Cache*]
 LangSecRef=3021
 DetectFile=%AppData%\SecondLife
 Default=False
 FileKey1=%AppData%\SecondLife\*\Browser_Profile\Cache|*.*|RECURSE
 FileKey2=%AppData%\SecondLife\*\cache|*.*|RECURSE
-FileKey3=%AppData%\SecondLife\Browser_Profile\Cache|*.*|RECURSE
-FileKey4=%AppData%\SecondLife\cache|*.*|RECURSE
+FileKey3=%AppData%\SecondLife\cache|*.*|RECURSE
 
 [SecondLife Logs*]
 LangSecRef=3021
@@ -16415,42 +15589,29 @@ Default=False
 FileKey1=%CommonAppData%\Sendori|*.log
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Sendori|*.log
 
-[Serious Sam - The Second Encounter Logs*]
+[Serious Sam - The Second Encounter*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\41014
 DetectFile=%ProgramFiles%\Croteam\Serious Sam - The Second Encounter
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Croteam\Serious Sam - The Second Encounter|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Serious Sam - The Second Encounter|*.log
-FileKey3=%ProgramFiles%\Croteam\Serious Sam - The Second Encounter|*.log
-FileKey4=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam - The Second Encounter|*.log
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Croteam\Serious Sam - The Second Encounter\temp|*.*
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Serious Sam - The Second Encounter|*.log
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Serious Sam - The Second Encounter\temp|*.*
+FileKey5=%ProgramFiles%\Croteam\Serious Sam - The Second Encounter|*.log
+FileKey6=%ProgramFiles%\Croteam\Serious Sam - The Second Encounter\temp|*.*
+FileKey7=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam - The Second Encounter|*.log
+FileKey8=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam - The Second Encounter\temp|*.*
 
-[Serious Sam - The Second Encounter Temporary Files*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\41014
-DetectFile=%ProgramFiles%\Croteam\Serious Sam - The Second Encounter
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Croteam\Serious Sam - The Second Encounter\temp|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Serious Sam - The Second Encounter\temp|*.*
-FileKey3=%ProgramFiles%\Croteam\Serious Sam - The Second Encounter\temp|*.*
-FileKey4=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam - The Second Encounter\temp|*.*
-
-[Serious Sam 3: BFE Logs*]
+[Serious Sam 3: BFE*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\41070
 DetectFile=%ProgramFiles%\Steam\steamapps\common\Serious Sam 3
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Serious Sam 3\Log|*.*|RECURSE
-FileKey2=%ProgramFiles%\Steam\steamapps\common\Serious Sam 3\Log|*.*|RECURSE
-
-[Serious Sam 3: BFE Temps*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\41070
-DetectFile=%ProgramFiles%\Steam\steamapps\common\Serious Sam 3
-Default=False
-Warning=Slows down the first game launch.
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Serious Sam 3\Temp|*.*|RECURSE
-FileKey2=%ProgramFiles%\Steam\steamapps\common\Serious Sam 3\Temp|*.*|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Serious Sam 3\Temp|*.*|RECURSE
+FileKey3=%ProgramFiles%\Steam\steamapps\common\Serious Sam 3\Log|*.*|RECURSE
+FileKey4=%ProgramFiles%\Steam\steamapps\common\Serious Sam 3\Temp|*.*|RECURSE
 
 [Serious Sam Fusion 2017 Logs*]
 Section=Games
@@ -16550,11 +15711,8 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\GAMELOFTSA.SharkDashByGameloft_0pp20fcewvvtj
 DetectFile=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_0pp20fcewvvtj
 Default=False
-FileKey1=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey2=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey3=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\INetCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\INetCookies|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\INetHistory|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey2=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\INet*|*.*|RECURSE
 
 [Shatter*]
 Section=Games
@@ -16563,19 +15721,13 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Shatter|log.txt
 FileKey2=%ProgramFiles%\Steam\steamapps\common\Shatter|log.txt
 
-[Shattered Horizon Cache*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\18110
-DetectFile=%LocalAppData%\Futuremark\Shattered Horizon
-Default=False
-FileKey1=%LocalAppData%\Futuremark\Shattered Horizon\cache|*.*|REMOVESELF
-
 [Shattered Horizon Crash files*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\18110
 DetectFile=%LocalAppData%\Futuremark\Shattered Horizon
 Default=False
-FileKey1=%LocalAppData%\Futuremark\Shattered Horizon\crash_dumps|*.*
+FileKey1=%LocalAppData%\Futuremark\Shattered Horizon\cache|*.*|REMOVESELF
+FileKey2=%LocalAppData%\Futuremark\Shattered Horizon\crash_dumps|*.*
 
 [Shell Experience Host*]
 DetectOS=10.0|
@@ -16583,16 +15735,13 @@ Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.ShellExperienceHost_cw5n1h2txyewy
 FileKey1=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\TempState|*.*|RECURSE
 
 [Shipping Assistant*]
 LangSecRef=3021
@@ -16619,11 +15768,8 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ShuffleParty_8wekyb3d8bbwe
 DetectFile=%LocalAppData%\Packages\Microsoft.ShuffleParty_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey2=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey3=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\INetCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\INetCookies|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\INetHistory|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey2=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\INet*|*.*|RECURSE
 
 [Sidebar Cache*]
 LangSecRef=3025
@@ -16636,7 +15782,7 @@ DetectOS=|5.1
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%WinDir%|SIGVERIF.TXT
+FileKey1=%WinDir%\|SIGVERIF.TXT
 
 [SigParser*]
 LangSecRef=3024
@@ -16670,17 +15816,12 @@ Detect2=HKLM\Software\Electronic Arts\SimCity Societies (tm) Destinations
 Default=False
 FileKey1=%Documents%\SimCity Societies\Logs|*.*
 
-[Similarity Cache*]
+[Similarity*]
 LangSecRef=3023
 DetectFile=%AppData%\Similarity
 Default=False
 FileKey1=%AppData%\Similarity|cache.dat
-
-[Similarity Logs*]
-LangSecRef=3023
-DetectFile=%AppData%\Similarity
-Default=False
-FileKey1=%AppData%\Similarity\logs|*.*|RECURSE
+FileKey2=%AppData%\Similarity\logs|*.*|RECURSE
 
 [SIMS RACER Logs*]
 Section=Games
@@ -16689,10 +15830,9 @@ DetectFile2=%ProgramFiles%\SIMS\RACER
 DetectFile3=%SystemDrive%\SIMS\RACER
 Default=False
 FileKey1=%CommonAppData%\SIMS\RACER|QLOG.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\SIMS\RACER|QLOG.txt
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\SIMS\RACER|QLOG.txt
-FileKey4=%ProgramFiles%\SIMS\RACER|QLOG.txt
-FileKey5=%SystemDrive%\SIMS\RACER|QLOG.txt
+FileKey2=%LocalAppData%\VirtualStore\Program*\SIMS\RACER|QLOG.txt
+FileKey3=%ProgramFiles%\SIMS\RACER|QLOG.txt
+FileKey4=%SystemDrive%\SIMS\RACER|QLOG.txt
 
 [SiSense Logs*]
 LangSecRef=3021
@@ -16726,24 +15866,14 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\microsoft.microsoftskydrive_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey7=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey8=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\PRICache|*.*
-FileKey9=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Temp|*.*
-FileKey10=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\PRICache|*.*
+FileKey6=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Temp|*.*
+FileKey7=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.microsoftskydrive_8wekyb3d8bbwe\PersistedPickerData\microsoft.microsoftskydrive_8wekyb3d8bbwe!Microsoft.MicrosoftSkyDrive\DefaultOpenFileMultiple|LastLocation
 RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.microsoftskydrive_8wekyb3d8bbwe\SearchHistory
-
-[Skype For Salesforce*]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\Skype For Salesforce
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Skype For Salesforce|*.log
-FileKey2=%ProgramFiles%\Skype For Salesforce|*.log
 
 [Skype Installers*]
 LangSecRef=3022
@@ -16764,50 +15894,35 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.SkypeApp_kzf8qxf38zg5c
 DetectFile=%LocalAppData%\Packages\Microsoft.SkypeApp_kzf8qxf38zg5c
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey2=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\PRICache|*.*
-FileKey3=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.SkypeApp_*\TempState|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\INetCache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\INetCookies|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\INetHistory|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
+FileKey3=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\PRICache|*.*
+FileKey4=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.SkypeApp_*\TempState|*.*|RECURSE
 
 [Skype More*]
 LangSecRef=3022
 Detect=HKCU\Software\Skype
+DetectFile=%ProgramFiles%\Skype For Salesforce
 Default=False
-FileKey1=%AppData%\Skype|*.lck;*.lock;cookies.dat|RECURSE
+FileKey1=%AppData%\Skype|*.tmp;*.db-journal;*.lck;*.lock;cookies.dat|RECURSE
 FileKey2=%AppData%\Skype\*\*cache|*.*|RECURSE
-
-[Skype Temporary Files*]
-LangSecRef=3022
-Detect=HKCU\Software\Skype
-Default=False
-FileKey1=%AppData%\Skype\DbTemp|*.*|RECURSE
-FileKey2=%AppData%\Skype|*.tmp;*.db-journal|RECURSE
-FileKey3=%AppData%\Skype\DataRv|*.*
-FileKey4=%AppData%\Skype\*\ecache|*.*
-FileKey5=%AppData%\Skype\*\httpfe|*.*
-FileKey6=%AppData%\Skype\*\logs|*.*
-FileKey7=%AppData%\Skype\*\media_messaging\media_cache|*.*
+FileKey3=%AppData%\Skype\DbTemp|*.*|RECURSE
+FileKey4=%AppData%\Skype\DataRv|*.*
+FileKey5=%AppData%\Skype\*\*cache|*.*
+FileKey6=%AppData%\Skype\*\httpfe|*.*
+FileKey7=%AppData%\Skype\*\logs|*.*
 FileKey8=%AppData%\Skype\*\media_messaging\media_cache*|*.*
-FileKey9=%AppData%\Skype\*\media_messaging\storage_db\asyncdb\tmp|*.*
-FileKey10=%AppData%\Skype\*\media_messaging\media_cache\asyncdb\tmp|*.*
-FileKey11=%AppData%\Skype\*\qikdb\tmp|*.*
-FileKey12=%AppData%\Skype\*\simcache|*.*
-FileKey13=%UserProfile%\Tracing\WPPMedia|*.*|RECURSE
+FileKey9=%AppData%\Skype\*\media_messaging\*\asyncdb\tmp|*.*
+FileKey10=%AppData%\Skype\*\qikdb\tmp|*.*
+FileKey11=%AppData%\SkypePM|*.ezlog
+FileKey12=%UserProfile%\Tracing\WPPMedia|*.*|RECURSE
 
 [SkypeAlyzer*]
 LangSecRef=3024
 Detect=HKCU\Software\Raize\CodeSite
 Default=False
 FileKey1=%LocalAppData%\Raize\CodeSite\5.0|CSDispatcherLog.txt
-
-[SkypePM Logs*]
-LangSecRef=3022
-Detect=HKCU\Software\Skype
-Default=False
-FileKey1=%AppData%\SkypePM|*.ezlog
 
 [Sleeping Dogs*]
 Section=Games
@@ -16834,24 +15949,17 @@ Default=False
 FileKey1=%AppData%\SlimBrowser|freqsite.txt;RecentCloseW.ini;freqform.txt
 FileKey2=%AppData%\SlimBrowser\iconcache|*.*|RECURSE
 
-[SlimCleaner Plus*]
+[SlimCleaner*]
 LangSecRef=3024
 Detect=HKCU\Software\SlimWare Utilities Inc\SlimCleaner Plus
 Default=False
-FileKey1=%CommonAppData%\SlimWare Utilities Inc\Services\SlimService\Logs|*.log
-FileKey2=%CommonAppData%\SlimWare Utilities Inc\Services\SlimServiceFactory\Logs|*.log
-FileKey3=%LocalAppData%\SlimWare Utilities Inc\SlimCleaner Plus\Cache|*.*|RECURSE
-FileKey4=%LocalAppData%\SlimWare Utilities Inc\SlimCleaner Plus\Logs|*.log
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\SlimCleaner Plus|*.txt
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\SlimWare Utilities Inc\Services\SlimService\Logs|*.log
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\SlimWare Utilities Inc\Services\SlimServiceFactory\Logs|*.log
-FileKey8=%ProgramFiles%\SlimCleaner Plus|*.txt
-
-[SlimCleaner*]
-LangSecRef=3024
-Detect=HKCU\Software\SlimWare Utilities Inc\SlimCleaner
-Default=False
-FileKey1=%LocalAppData%\SlimWare Utilities Inc\SlimCleaner\Logs|*.*|RECURSE
+FileKey1=%CommonAppData%\SlimWare Utilities Inc\Services\SlimService*\Logs|*.log
+FileKey2=%LocalAppData%\SlimWare Utilities Inc\SlimCleaner*\Cache|*.*|RECURSE
+FileKey3=%LocalAppData%\SlimWare Utilities Inc\SlimCleaner*\Logs|*.log
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\SlimCleaner*|*.txt
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\SlimWare Utilities Inc\Services\SlimService*\Logs|*.log
+FileKey6=%ProgramFiles%\SlimCleaner*|*.txt
+lities Inc\SlimCleaner\Logs|*.*|RECURSE
 
 [SlimComputer Logs*]
 LangSecRef=3024
@@ -16989,10 +16097,9 @@ LangSecRef=3024
 Detect1=HKCU\Software\TechSmith\Snagit\13
 Detect2=HKCU\Software\TechSmith\Snagit\18
 Default=False
-FileKey1=%LocalAppData%\TechSmith\Snagit\DataStore\AppIcons|*.ico
-FileKey2=%LocalAppData%\TechSmith\Snagit\DataStore\WebSiteIcons|*.ico
-FileKey3=%LocalAppData%\TechSmith\Snagit\Thumbnails|*.*
-FileKey4=%LocalAppData%\TechSmith\Snagit|Tray.bin
+FileKey1=%LocalAppData%\TechSmith\Snagit\DataStore\*Icons|*.ico
+FileKey2=%LocalAppData%\TechSmith\Snagit\Thumbnails|*.*
+FileKey3=%LocalAppData%\TechSmith\Snagit|Tray.bin
 RegKey1=HKCU\Software\TechSmith\Snagit\13\Recent Captures
 RegKey2=HKCU\Software\TechSmith\Snagit\13\SnagitEditor\Recent File List
 RegKey3=HKCU\Software\TechSmith\Snagit\18\Recent Captures
@@ -17009,7 +16116,7 @@ LangSecRef=3024
 Detect=HKCU\Software\TechSmith\Snagit
 Default=False
 Warning=This will delete the backups of the captures.
-FileKey1=%Documents%|SnagitDebug.log
+FileKey1=%Documents%\|SnagitDebug.log
 FileKey2=%LocalAppData%\TechSmith\Logs|*.log
 FileKey3=%LocalAppData%\TechSmith\Snagit\DataStore|*.SNAG;*.SNAGundo;*.MP4
 FileKey4=%LocalAppData%\TechSmith\Snagit\TrackerbirdFiles|*.log
@@ -17255,19 +16362,11 @@ Default=False
 FileKey1=%AppData%\Sony|*.log
 FileKey2=%LocalAppData%\Sony\Vegas Pro\*|*.log
 
-[Soulseek*]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\Soulseek\slsk.exe
+[Sorcery! Parts 1 And 2*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\105430
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Soulseek|search.cfg
-FileKey2=%ProgramFiles%\Soulseek|search.cfg
-
-[Soulseek Beta*]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\Soulseek-Test\slsk.exe
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Soulseek-Test|search.cfg
-FileKey2=%ProgramFiles%\Soulseek-Test|search.cfg
+FileKey1=%LocalAppData%\inkle\Sorcery|*.log
 
 [Soulseek NS*]
 LangSecRef=3022
@@ -17277,14 +16376,20 @@ Warning=This will delete your chat history.
 FileKey1=%Documents%\Soulseek Chat Logs\Private|*.txt
 RegKey1=HKCU\Software\Soulseek2\config|search
 
+[Soulseek*]
+LangSecRef=3022
+DetectFile=%ProgramFiles%\Soulseek\slsk.exe
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Soulseek*|search.cfg
+FileKey2=%ProgramFiles%\Soulseek*|search.cfg
+
 [SoulseekQt*]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\SoulseekQt\SoulseekQt.exe
 Detect=HKLM\Software\SoulseekQt
 Default=False
 Warning=This will delete your chat history.
-FileKey1=%LocalAppData%\Soulseek Chat Logs\Users|*.log
-FileKey2=%LocalAppData%\Soulseek Chat Logs\Rooms|*.log
+FileKey1=%LocalAppData%\Soulseek Chat Logs\*|*.log
 
 [Sound Recorder*]
 DetectOS=10.0|
@@ -17292,16 +16397,13 @@ Section=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsSoundRecorder_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\TempState|*.*|RECURSE
 
 [SoundMAX*]
 LangSecRef=3023
@@ -17329,23 +16431,24 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\SpeedFan|debug.nfo;SFLog*.csv
 FileKey2=%ProgramFiles%\SpeedFan|debug.nfo;SFLog*.csv
 
+[SpeedRunners*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\207140
+Default=False
+FileKey1=%AppData%\|SpeedRunnersLog.txt;TargetInvocationLog.txt
+
 [SpeedyComputer*]
 LangSecRef=3024
 DetectFile=%AppData%\SpeedyComputer
 Default=False
 FileKey1=%AppData%\SpeedyComputer\Log|*.*|RECURSE
 
-[SpiderOak Cache*]
+[SpiderOak*]
 LangSecRef=3024
 DetectFile=%AppData%\SpiderOak
 Default=False
 FileKey1=%AppData%\SpiderOak\download_cache|*.*
-
-[SpiderOak Logs*]
-LangSecRef=3024
-DetectFile=%AppData%\SpiderOak
-Default=False
-FileKey1=%AppData%\SpiderOak|*.log|RECURSE
+FileKey2=%AppData%\SpiderOak|*.log|RECURSE
 
 [Spiral Knights*]
 Section=Games
@@ -17357,7 +16460,7 @@ FileKey1=%ProgramFiles%\Steam\SteamApps\common\Spiral Knights|*.log
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\209790
 Default=False
-FileKey1=%Documents%|GALog.txt
+FileKey1=%Documents%\|GALog.txt
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\splice|output_log.txt
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Splice\Splice_Data|output_log.txt
 FileKey4=%ProgramFiles%\Steam\steamapps\common\splice|output_log.txt
@@ -17428,12 +16531,10 @@ Detect=HKLM\Software\Safer Networking Limited\SpybotSnD
 Default=False
 FileKey1=%CommonAppData%\Spybot – Search & Destroy\Backups|*.*|RECURSE
 FileKey2=%CommonAppData%\Spybot – Search & Destroy\Recovery|*.*|RECURSE
-FileKey3=%CommonAppData%\Spybot – Search & Destroy\Snapshots|*.*|RECURSE
-FileKey4=%CommonAppData%\Spybot – Search & Destroy\Snapshots2|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Spybot – Search & Destroy\Backups|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Spybot – Search & Destroy\Recovery|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Spybot – Search & Destroy\Snapshots|*.*|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Spybot – Search & Destroy\Snapshots2|*.*|RECURSE
+FileKey3=%CommonAppData%\Spybot – Search & Destroy\Snapshots*|*.*|RECURSE
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\Spybot – Search & Destroy\Backups|*.*|RECURSE
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\Spybot – Search & Destroy\Recovery|*.*|RECURSE
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Spybot – Search & Destroy\Snapshots*|*.*|RECURSE
 
 [Spybot Search and Destroy Hosts Backups*]
 LangSecRef=3024
@@ -17541,29 +16642,17 @@ Detect=HKCU\Software\Valve\Steam\Apps\267130
 Default=False
 FileKey1=%Documents%\Star Swarm|output*.txt
 
-[Star Trek Online Cache*]
+[Star Trek Online*]
 Section=Games
 Detect1=HKCU\Software\Cryptic\Star Trek Online
 Detect2=HKCU\Software\Valve\Steam\Apps\9900
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\star trek online\Star Trek Online\Live\cache|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Star Trek Online\Star Trek Online\PlayTest\Cache|*.*
-FileKey3=%ProgramFiles%\Steam\Steamapps\Common\star trek online\Star Trek Online\Live\cache|*.*
-FileKey4=%ProgramFiles%\Steam\Steamapps\Common\Star Trek Online\Star Trek Online\PlayTest\Cache|*.*
-FileKey5=%Public%\Games\Cryptic Studios\Star Trek Online\Live\Cache|*.*
-FileKey6=%Public%\Games\Cryptic Studios\Star Trek Online\PlayTest\Cache|*.*
-
-[Star Trek Online Logs*]
-Section=Games
-Detect1=HKCU\Software\Cryptic\Star Trek Online
-Detect2=HKCU\Software\Valve\Steam\Apps\9900
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\steam\steamapps\common\star trek online\star trek online\live\logs\GameClient|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\steam\steamapps\common\star trek online\star trek online\playtest\logs\GameClient|*.*
-FileKey3=%ProgramFiles%\steam\steamapps\common\star trek online\star trek online\live\logs\GameClient|*.*
-FileKey4=%ProgramFiles%\steam\steamapps\common\star trek online\star trek online\playtest\logs\GameClient|*.*
-FileKey5=%Public%\Games\Cryptic Studios\Star Trek Online\Live\Logs\GameClient|*.*
-FileKey6=%Public%\Games\Cryptic Studios\Star Trek Online\Playtest\Logs\GameClient|*.*
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\star trek online\Star Trek Online\*\cache|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\steam\steamapps\common\star trek online\star trek online\*\logs\GameClient|*.*
+FileKey3=%ProgramFiles%\Steam\Steamapps\Common\star trek online\Star Trek Online\*\cache|*.*
+FileKey4=%ProgramFiles%\steam\steamapps\common\star trek online\star trek online\*\logs\GameClient|*.*
+FileKey5=%Public%\Games\Cryptic Studios\Star Trek Online\*\Cache|*.*
+FileKey6=%Public%\Games\Cryptic Studios\Star Trek Online\*\Logs\GameClient|*.*
 
 [Star Wars Battlefront II*]
 Section=Games
@@ -17574,8 +16663,7 @@ FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Star Wars BattleFront II|update*.
 
 [Star Wars The Force Unleashed Crash Logs*]
 Section=Games
-DetectFile1=%LocalAppData%\LucasArts\Star Wars The Force Unleashed
-DetectFile2=%LocalAppData%\LucasArts\Star Wars The Force Unleashed 2
+DetectFile1=%LocalAppData%\LucasArts\Star Wars The Force Unleashed*
 Default=False
 FileKey1=%LocalAppData%\LucasArts\Star Wars The Force Unleashed*|*.*
 
@@ -17583,21 +16671,20 @@ FileKey1=%LocalAppData%\LucasArts\Star Wars The Force Unleashed*|*.*
 Section=Games
 Detect=HKLM\Software\BioWare\Star Wars-The Old Republic
 Default=False
-FileKey1=%Documents%|Install STAR WARS The Old Republic.log
-FileKey2=%Documents%|Uninstall STAR WARS The Old Republic.log
-FileKey3=%LocalAppData%\SWTOR\CrashDump\swtor|*.*
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Electronic Arts\BioWare\Star Wars-The Old Republic\betatest\retailclient\Temp|*.log
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Electronic Arts\BioWare\Star Wars-The Old Republic\logs|*.log
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Electronic Arts\BioWare\Star Wars-The Old Republic\swtor\retailclient\swtor\logs|*.log
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Origin Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\Origin Games\Star Wars - The Old Republic\logs|*.*
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\Origin Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
-FileKey10=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\betatest\retailclient\Temp|*.log
-FileKey11=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\logs|*.log
-FileKey12=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\swtor\retailclient\swtor\logs|*.log
-FileKey13=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
-FileKey14=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\logs|*.*
-FileKey15=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
+FileKey1=%Documents%\|*Install STAR WARS The Old Republic.log
+FileKey2=%LocalAppData%\SWTOR\CrashDump\swtor|*.*
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Electronic Arts\BioWare\Star Wars-The Old Republic\betatest\retailclient\Temp|*.log
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\Electronic Arts\BioWare\Star Wars-The Old Republic\logs|*.log
+FileKey5=%LocalAppData%\VirtualStore\Program Files*\Electronic Arts\BioWare\Star Wars-The Old Republic\swtor\retailclient\swtor\logs|*.log
+FileKey6=%LocalAppData%\VirtualStore\Program Files*\Origin Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
+FileKey7=%LocalAppData%\VirtualStore\Program Files*\Origin Games\Star Wars - The Old Republic\logs|*.*
+FileKey8=%LocalAppData%\VirtualStore\Program Files*\Origin Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
+FileKey9=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\betatest\retailclient\Temp|*.log
+FileKey10=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\logs|*.log
+FileKey11=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\swtor\retailclient\swtor\logs|*.log
+FileKey12=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
+FileKey13=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\logs|*.*
+FileKey14=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
 
 [StarCraft II Editor Recent Files*]
 Section=Games
@@ -17605,24 +16692,19 @@ Detect=HKLM\SOFTWARE\Blizzard Entertainment\StarCraft II Editor
 Default=False
 RegKey1=HKCU\Software\Blizzard Entertainment\StarCraft II Editor\Recent Files
 
-[StarCraft II Logs*]
-Section=Games
-Detect=HKLM\SOFTWARE\Blizzard Entertainment\StarCraft II
-Default=False
-FileKey1=%Documents%\StarCraft II\EditorLogs|*.*|RECURSE
-FileKey2=%Documents%\StarCraft II\GameLogs|*.*|RECURSE
-FileKey3=%Documents%\StarCraft II\UserLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Starcraft II\Logs|*.*
-FileKey5=%ProgramFiles%\Starcraft II\Logs|*.*
-
-[StarCraft II Map Cache*]
+[StarCraft II*]
 Section=Games
 Detect=HKLM\SOFTWARE\Blizzard Entertainment\StarCraft II
 Default=False
 FileKey1=%CommonAppData%\Blizzard Entertainment\Starcraft II\Maps\Cache|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Blizzard Entertainment\Starcraft II\Maps\Cache|*.*|RECURSE
+FileKey2=%Documents%\StarCraft II\EditorLogs|*.*|RECURSE
+FileKey3=%Documents%\StarCraft II\GameLogs|*.*|RECURSE
+FileKey4=%Documents%\StarCraft II\UserLogs|*.*|RECURSE
+FileKey5=%LocalAppData%\VirtualStore\Program Files*\Starcraft II\Logs|*.*
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Blizzard Entertainment\Starcraft II\Maps\Cache|*.*|RECURSE
+FileKey7=%ProgramFiles%\Starcraft II\Logs|*.*
 
-[StarCraft II Misc*]
+[StarCraft II More*]
 Section=Games
 Detect=HKLM\SOFTWARE\Blizzard Entertainment\StarCraft II
 Default=False
@@ -17633,7 +16715,7 @@ FileKey3=%Documents%\StarCraft II\Screenshots|*.*|RECURSE
 
 [Stardock Fences*]
 LangSecRef=3024
-Detect=HKLM\Software\Stardock\Misc\Fences
+Detect1=HKLM\Software\Stardock\Misc\Fences
 Detect2=HKLM\Software\Stardock\Misc\Fences2
 Default=False
 FileKey1=%AppData%\Stardock\Fences\TroubleshootingLog|*.txt
@@ -17652,19 +16734,14 @@ FileKey5=%LocalAppData%\VirtualStore\ProgramData\Stardock|*.*|RECURSE
 
 [StarMoney*]
 LangSecRef=3021
-DetectFile1=%CommonAppData%\StarMoney 7.0
-DetectFile2=%CommonAppData%\StarMoney 8.0
-DetectFile3=%CommonAppData%\StarMoney 9.0
-DetectFile4=%CommonAppData%\StarMoney Business 4.0
-DetectFile5=%CommonAppData%\StarMoney Business 5.0
+DetectFile=%CommonAppData%\StarMoney*
 Default=False
 FileKey1=%CommonAppData%\StarMoney *|*.log|RECURSE
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\StarMoney *|*.log|RECURSE
 
 [StarOffice*]
 LangSecRef=3021
-DetectFile1=%ProgramFiles%\Sun\StarOffice 8\program\soffice.exe
-DetectFile2=%ProgramFiles%\Sun\StarOffice 9\program\soffice.exe
+DetectFile=%ProgramFiles%\Sun\StarOffice*\program\soffice.exe
 Default=False
 FileKey1=%AppData%\StarOffice*\user\registry\data\org\openoffice\Office|Common.xcu
 
@@ -17730,14 +16807,12 @@ FileKey1=%LocalAppData%\Steam\htmlcache|*.*|RECURSE
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\appcache\httpcache|*.*|RECURSE
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\config\cookies|*.*|RECURSE
 FileKey4=%LocalAppData%\VirtualStore\Program Files*\Steam\config\htmlcache|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Steam\config\overlaycookies|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Steam\config\overlayhtmlcache|*.*|RECURSE
-FileKey7=%ProgramFiles%\Steam\appcache\httpcache|*.*|RECURSE
-FileKey8=%ProgramFiles%\Steam\config\cookies|*.*|RECURSE
-FileKey9=%ProgramFiles%\Steam\config\htmlcache|*.*|RECURSE
-FileKey10=%ProgramFiles%\Steam\config\overlaycookies|*.*|RECURSE
-FileKey11=%ProgramFiles%\Steam\config\overlayhtmlcache|*.*|RECURSE
-FileKey12=%ProgramFiles%\Steam\userdata\*\ugcmsgcache|*.*|RECURSE
+FileKey5=%LocalAppData%\VirtualStore\Program Files*\Steam\config\overlay*|*.*|RECURSE
+FileKey6=%ProgramFiles%\Steam\appcache\httpcache|*.*|RECURSE
+FileKey7=%ProgramFiles%\Steam\config\cookies|*.*|RECURSE
+FileKey8=%ProgramFiles%\Steam\config\htmlcache|*.*|RECURSE
+FileKey9=%ProgramFiles%\Steam\config\overlay*|*.*|RECURSE
+FileKey10=%ProgramFiles%\Steam\userdata\*\ugcmsgcache|*.*|RECURSE
 
 [Steam DepotCache*]
 Section=Games
@@ -17827,8 +16902,7 @@ FileKey1=%AppData%\Stellarium|log.txt
 
 [StepMania 4 Logs*]
 Section=Games
-DetectFile1=%AppData%\StepMania
-DetectFile2=%AppData%\StepMania 4
+DetectFile=%AppData%\StepMania*
 Default=False
 FileKey1=%AppData%\Stepmania*\Logs|*.*
 
@@ -17861,30 +16935,19 @@ Section=3031
 Default=False
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\WinStore_cw5n1h2txyewy
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsStore_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\WinStore_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\WinStore_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\WinStore_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\WinStore_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\WinStore_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\WinStore_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\WinStore_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\WinStore_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\WinStore_*\AC\Microsoft\Windows Store\Cache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\WinStore_*\AC\Microsoft\Windows Store\Data|history.dat
-FileKey11=%LocalAppData%\Packages\WinStore_*\AC\PRICache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\WinStore_*\AC\Temp|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\WinStore_*\LocalState\Cache|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\WinStore_*\LocalState\LiveTile|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\WinStore_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.WindowsStore_*\AC\AppCache|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.WindowsStore_*\AC\INetCache|*.*|RECURSE
-FileKey18=%LocalAppData%\Packages\Microsoft.WindowsStore_*\AC\INetHistory|*.*|RECURSE
-FileKey19=%LocalAppData%\Packages\Microsoft.WindowsStore_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey20=%LocalAppData%\Packages\Microsoft.WindowsStore_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey21=%LocalAppData%\Packages\Microsoft.WindowsStore_*\AC\Temp|*.*|RECURSE
-FileKey22=%LocalAppData%\Packages\Microsoft.WindowsStore_*\LocalCache\*|*.*|RECURSE
-FileKey23=%LocalAppData%\Packages\Microsoft.WindowsStore_*\LocalState\Cache|*.*|RECURSE
-FileKey24=%LocalAppData%\Packages\Microsoft.WindowsStore_*\AC\INetCookies|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\*Win*Store_*\AC\AppCache|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\*Win*Store_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\*Win*Store_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\*Win*Store_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\*Win*Store_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\*Win*Store_*\AC\Microsoft\Windows Store\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\*Win*Store_*\AC\Microsoft\Windows Store\Data|history.dat
+FileKey8=%LocalAppData%\Packages\*Win*Store_*\AC\PRICache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\*Win*Store_*\AC\Temp|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\*Win*Store_*\LocalState\Cache|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\WinStore_*\LocalState\LiveTile|*.*|RECURSE
+FileKey12=%LocalAppData%\Packages\*Win*Store_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.WindowsStore_*\LocalCache\*|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\WinStore_cw5n1h2txyewy\SearchHistory
 
 [Stored Media Player Paths*]
@@ -17905,17 +16968,12 @@ Detect=HKCU\Software\Trolltech
 Default=False
 RegKey1=HKCU\Software\Trolltech\OrganizationDefaults
 
-[Stranglehold Cache*]
+[Stranglehold*]
 Section=Games
 DetectFile=%LocalAppData%\Midway\Stranglehold
 Default=False
 FileKey1=%LocalAppData%\Midway\Stranglehold\Cache|*.*|REMOVESELF
-
-[Stranglehold Logs*]
-Section=Games
-DetectFile=%LocalAppData%\Midway\Stranglehold
-Default=False
-FileKey1=%LocalAppData%\Midway\Stranglehold|*.log|RECURSE
+FileKey2=%LocalAppData%\Midway\Stranglehold|*.log|RECURSE
 
 [Stream-Cloner*]
 LangSecRef=3023
@@ -17952,9 +17010,7 @@ FileKey1=%AppData%\Style Jukebox Settings|*.bmp|RECURSE
 
 [Sublime Text Session*]
 LangSecRef=3024
-DetectFile1=%AppData%\Sublime Text
-DetectFile2=%AppData%\Sublime Text 2
-DetectFile3=%AppData%\Sublime Text 3
+DetectFile1=%AppData%\Sublime Text*
 Default=False
 FileKey1=%AppData%\Sublime Text\Options|*.*
 FileKey2=%AppData%\Sublime Text 2\Settings|*.sublime_session
@@ -17972,29 +17028,17 @@ DetectFile=%AppData%\SumatraPDF
 Default=False
 FileKey1=%AppData%\SumatraPDF\sumatrapdfcache|*.*
 
-[SUMo Cache*]
-LangSecRef=3024
-Detect=HKCU\Software\KC Softwares\SUMo
-Default=False
-FileKey1=%AppData%\KC Softwares\SUMo|SUMo.cache
-
 [SUMo Database*]
 LangSecRef=3024
 Detect=HKCU\Software\KC Softwares\SUMo
 Default=False
 FileKey1=%AppData%\KC Softwares\SUMo|db.sumo
 
-[SUMo Log*]
-LangSecRef=3024
-Detect=HKCU\Software\KC Softwares\SUMo
-Default=False
-FileKey1=%AppData%\KC Softwares\SUMo|*.log;errlst.txt
-
 [SUMo*]
 LangSecRef=3024
 Detect=HKCU\Software\KC Softwares\SUMo
 Default=False
-FileKey1=%AppData%\KC Softwares\SUMo|db.bak
+FileKey1=%AppData%\KC Softwares\SUMo|db.bak;SUMo.cache;*.log;errlst.txt
 
 [SUPERAntiSpyware More*]
 LangSecRef=3024
@@ -18069,17 +17113,12 @@ DetectFile=%LocalAppData%\Chat Republic Games\Superstar Racing
 Default=False
 FileKey1=%LocalAppData%\Chat Republic Games\Superstar Racing|log*.*
 
-[SuperSync Logs*]
+[SuperSync*]
 LangSecRef=3023
 DetectFile=%AppData%\SuperSync
 Default=False
 FileKey1=%AppData%\SuperSync\logs|*.*
-
-[SuperSync Temporary Files*]
-LangSecRef=3023
-DetectFile=%AppData%\SuperSync
-Default=False
-FileKey1=%AppData%\SuperSync\tmp|*.*|RECURSE
+FileKey2=%AppData%\SuperSync\tmp|*.*|RECURSE
 
 [SuperWinMenu*]
 LangSecRef=3024
@@ -18093,46 +17132,26 @@ Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Office.Sway_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.Office.Sway_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Office.Sway_*\TempState|*.*|RECURSE
 
-[Swift Avatars*]
+[Swift*]
 LangSecRef=3022
 Detect=HKCU\Software\Swift
 Default=False
 FileKey1=%AppData%\Swift\Avatars|*.*|RECURSE
+FileKey2=%AppData%\Swift\Crashes|*.*|RECURSE
 
-[Swift Crashes*]
-LangSecRef=3022
-Detect=HKCU\Software\Swift
-Default=False
-FileKey1=%AppData%\Swift\Crashes|*.*|RECURSE
-
-[Syberfix Helpdesk Client*]
+[Syberfix Helpdesk Logs*]
 LangSecRef=3021
-DetectFile=%LocalAppData%\Syberfix\UserSaved\Helpdesk Client
+DetectFile=%LocalAppData%\Syberfix\UserSaved\Helpdesk*
 Default=False
-FileKey1=%LocalAppData%\SyberFix\UserSaved\Helpdesk Client|*.log
-
-[Syberfix Helpdesk Manager*]
-LangSecRef=3024
-DetectFile=%LocalAppData%\Syberfix\UserSaved\Helpdesk Manager
-Default=False
-FileKey1=%LocalAppData%\Syberfix\UserSaved\Helpdesk Manager|*.log
-
-[Syberfix Support Engineer*]
-LangSecRef=3024
-DetectFile=%LocalAppData%\Syberfix\UserSaved\Support Engineer
-Default=False
-FileKey1=%LocalAppData%\Syberfix\UserSaved\Support Engineer|*.log
+FileKey1=%LocalAppData%\SyberFix\UserSaved\Helpdesk *|*.log
 
 [Sylpheed*]
 LangSecRef=3022
@@ -18269,7 +17288,7 @@ LangSecRef=3024
 Detect=HKCU\Software\TCP Optimizer
 Default=False
 Warning=This will delete you SG TCP Optimizer backup files in their normal order.
-FileKey1=%Documents%|*.spg
+FileKey1=%Documents%\|*.spg
 FileKey2=%Documents%\downloads|*.spg
 
 [Team Crossword*]
@@ -18277,17 +17296,14 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.TeamCrossword_8wekyb3d8bbwe
 DetectFile=%LocalAppData%\Packages\Microsoft.TeamCrossword_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\Microsoft\CLR_v4.0_32\UsageLogs|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey6=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey7=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\PRICache|*.*
-FileKey8=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\Temp|*.*
-FileKey9=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\Microsoft\CLR_v4.0_32\UsageLogs|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey4=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\PRICache|*.*
+FileKey5=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\Temp|*.*
+FileKey6=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\TempState|*.*|RECURSE
 
-[Team Fortress 2 Cache and Cookies*]
+[Team Fortress 2*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\440
 Default=False
@@ -18337,41 +17353,26 @@ RegKey2=HKCU\Software\TeamViewer\Version5.1|Last_Machine_Connections
 RegKey3=HKCU\Software\TeamViewer\Version6|Last_Machine_Connections
 RegKey4=HKCU\Software\TeamViewer\Version7|Last_Machine_Connections
 
-[Technic Launcher*]
-Section=Games
-DetectFile1=%AppData%\.techniclauncher
-DetectFile2=%AppData%\.techniclauncher
-Default=False
-FileKey1=%AppData%\.technic|*.old;*.log;*.tmp|RECURSE
-FileKey2=%AppData%\.technic\*\logs|*.*|RECURSE
-FileKey3=%AppData%\.technic\temp|*.*|RECURSE
-FileKey4=%AppData%\.techniclauncher|*.old;*.log;*.tmp|RECURSE
-FileKey5=%AppData%\.technicLauncher\*\logs|*.*|RECURSE
-FileKey6=%AppData%\.techniclauncher\temp|*.*|RECURSE
-
 [Technic Launcher Backups*]
 Section=Games
-DetectFile1=%AppData%\.techniclauncher
-DetectFile2=%AppData%\.technic
+DetectFile=%AppData%\.technic*
 Default=False
-FileKey1=%AppData%\.technicLauncher\*\Backups|*.*|RECURSE
-FileKey2=%AppData%\.technic\*\Backups|*.*|RECURSE
-
-[Technic Launcher Cache*]
-Section=Games
-DetectFile1=%AppData%\.techniclauncher
-DetectFile2=%AppData%\.techniclauncher
-Default=False
-FileKey1=%AppData%\.technic\cache|*.*
-FileKey2=%AppData%\.techniclauncher\cache|*.*
+FileKey1=%AppData%\.technic*\*\Backups|*.*|RECURSE
 
 [Technic Launcher Screenshots*]
 Section=Games
-DetectFile1=%AppData%\.techniclauncher
-DetectFile2=%AppData%\.technic
+DetectFile1=%AppData%\.technic*
 Default=False
-FileKey1=%AppData%\.techniclauncher\*\Screenshots|*.*
-FileKey2=%AppData%\.technic\*\Screenshots|*.*
+FileKey1=%AppData%\.technic*\*\Screenshots|*.*
+
+[Technic Launcher*]
+Section=Games
+DetectFile=%AppData%\.technic*
+Default=False
+FileKey1=%AppData%\.technic*|*.old;*.log;*.tmp|RECURSE
+FileKey2=%AppData%\.technic*\*\logs|*.*|RECURSE
+FileKey3=%AppData%\.technic*\temp|*.*|RECURSE
+FileKey4=%AppData%\.technic*\cache|*.*
 
 [TechSmith DubIt*]
 LangSecRef=3023
@@ -18529,19 +17530,14 @@ DetectFile=%UserProfile%\.gimp-2.2\gimprc
 Default=False
 FileKey1=%UserProfile%\.gimp-2.2|documents
 
-[The Mighty Quest for Epic Loot Crash Reports*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\239220
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\CrashReport|*.*
-FileKey2=%ProgramFiles%\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\CrashReport|*.*
-
 [The Mighty Quest for Epic Loot*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\239220
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\Log|*.*
-FileKey2=%ProgramFiles%\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\Log|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\CrashReport|*.*
+FileKey3=%ProgramFiles%\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\Log|*.*
+FileKey4=%ProgramFiles%\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\CrashReport|*.*
 
 [The Mystery of the Mary Celeste*]
 Section=Games
@@ -18555,15 +17551,12 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\57100Goheer.TheQuran_s6gg0ptmhrgye
 Default=False
 FileKey1=%LocalAppData%\Packages\*TheQuran_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\*TheQuran_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\*TheQuran_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\*TheQuran_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\*TheQuran_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey6=%LocalAppData%\Packages\*TheQuran_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey7=%LocalAppData%\Packages\*TheQuran_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey8=%LocalAppData%\Packages\*TheQuran_*\AC\PRICache|*.*
-FileKey9=%LocalAppData%\Packages\*TheQuran_*\AC\Temp|*.*
-FileKey10=%LocalAppData%\Packages\*TheQuran_*\LocalState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\*TheQuran_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\*TheQuran_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
+FileKey4=%LocalAppData%\Packages\*TheQuran_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\*TheQuran_*\AC\PRICache|*.*
+FileKey6=%LocalAppData%\Packages\*TheQuran_*\AC\Temp|*.*
+FileKey7=%LocalAppData%\Packages\*TheQuran_*\LocalState|*.*|RECURSE
 
 [The Rise of Atlantis*]
 Section=Games
@@ -18580,12 +17573,6 @@ FileKey1=%Documents%\Electronic Arts\The Sims 3|socialCache.package;CASPartCache
 FileKey2=%Documents%\Electronic Arts\The Sims 3\Thumbnails|*.*
 FileKey3=%Documents%\Electronic Arts\The Sims 3\WorldCaches|*.*
 
-[The Sims 3 Crash Files*]
-Section=Games
-Detect=HKCU\Software\Electronic Arts\Sims 3
-Default=False
-FileKey1=%Documents%\Electronic Arts\The Sims 3|*.mdmp;xcpt*.txt|RECURSE
-
 [The Sims 3 DCBackup Files*]
 Section=Games
 Detect=HKCU\Software\Electronic Arts\Sims 3
@@ -18594,11 +17581,11 @@ Warning=This may make premium content buggy if deleted.
 FileKey1=%Documents%\Electronic arts\The sims 3\DCBackup|*.package
 ExcludeKey1=FILE|%Documents%\electronic arts\The sims 3\DCBackup\|ccmerged.package
 
-[The Sims 3 Logs*]
+[The Sims 3*]
 Section=Games
 Detect=HKCU\Software\Electronic Arts\Sims 3
 Default=False
-FileKey1=%Documents%\Electronic Arts\The Sims 3|*.log|RECURSE
+FileKey1=%Documents%\Electronic Arts\The Sims 3|*.log;*.mdmp;xcpt*.txt|RECURSE
 
 [The Sims Medieval Logs*]
 Section=Games
@@ -18619,18 +17606,29 @@ Detect=HKCU\Software\Valve\Steam\Apps\257510
 Default=False
 FileKey1=%ProgramFiles%\Steam\steamapps\common\The Talos Principle\Log|*.*|RECURSE
 
+[The Tiny Bang Story*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\96000
+Default=False
+FileKey1=%AppData%\Colibri Games\The Tiny Bang Story|logfile.txt
+
 [The Weather Channel*]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\TheWeatherChannel_t3yemqpq4kp7p
 DetectFile=%LocalAppData%\Packages\Weather.TheWeatherChannel_t3yemqpq4kp7p
 Default=False
-FileKey1=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.log|RECURSE
-FileKey5=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\AC\Temp|*.*
-FileKey6=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\LocalState|*.tmp
-FileKey7=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\TempState\Bing.Maps\Cache|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.log|RECURSE
+FileKey3=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\AC\Temp|*.*
+FileKey4=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\LocalState|*.tmp
+FileKey5=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\TempState\Bing.Maps\Cache|*.*|RECURSE
+
+[The Witcher*]
+Section=Games
+Detect1=HKCU\Software\Valve\Steam\Apps\20900
+Detect2=HKCU\Software\Valve\Steam\Apps\105430
+Default=False
+FileKey1=%LocalAppData%\The Witcher\logs|*.*
 
 [The Women's Murder Club 3: Twice in a Blue Moon*]
 Section=Games
@@ -18714,19 +17712,14 @@ DetectFile=%LocalAppData%\Namco Networks\Tinseltown Dreams
 Default=False
 FileKey1=%LocalAppData%\Namco Networks\Tinseltown Dreams|errors*.*;log.txt
 
-[Tipard Total Media Converter Platinum*]
-LangSecRef=3023
-Detect=HKCU\Software\Tipard Studio\Tipard Total Media Converter Platinum
-Default=False
-FileKey1=%LocalAppData%\Tipard Studio\Tipard Total Media Converter Platinum|*.txt
-RegKey1=HKCU\Software\Tipard Studio\Tipard Total Media Converter Platinum\Edit|LastVideoFilePath
-
 [Tipard Total Media Converter*]
 LangSecRef=3023
-Detect=HKCU\Software\Tipard Studio\Tipard Total Media Converter
+Detect1=HKCU\Software\Tipard Studio\Tipard Total Media Converter
+Detect2=HKCU\Software\Tipard Studio\Tipard Total Media Converter Platinum
 Default=False
-FileKey1=%LocalAppData%\Tipard Studio\Tipard Total Media Converter|*.txt
+FileKey1=%LocalAppData%\Tipard Studio\Tipard Total Media*|*.txt
 RegKey1=HKCU\Software\Tipard Studio\Tipard Total Media Converter\Edit|LastVideoFilePath
+RegKey2=HKCU\Software\Tipard Studio\Tipard Total Media Converter Platinum\Edit|LastVideoFilePath
 
 [Tipard Video Converter Ultimate*]
 LangSecRef=3023
@@ -18771,12 +17764,6 @@ FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Tom Clancy's Rainbow
 FileKey3=%ProgramFiles%\Steam\SteamApps\Common\Tom Clancy's Rainbow Six Vegas 2|CrashReport*.*;*.log|RECURSE
 FileKey4=%ProgramFiles%\Ubisoft\Tom Clancy's Rainbow Six Vegas 2|CrashReport*.*;*.log|RECURSE
 
-[Tomahawk Log*]
-LangSecRef=3023
-Detect=HKCU\Software\Tomahawk
-Default=False
-FileKey1=%LocalAppData%\Tomahawk|*.log
-
 [Tomahawk PDF+*]
 LangSecRef=3021
 Detect=HKCU\Software\NativeWinds\Tomahawk
@@ -18787,25 +17774,21 @@ RegKey1=HKCU\Software\NativeWinds\Tomahawk\MRU
 LangSecRef=3023
 Detect=HKCU\Software\Tomahawk
 Default=False
-FileKey1=%LocalAppData%\Tomahawk\Tomahawk\Cache|*.*|RECURSE
+FileKey1=%LocalAppData%\Tomahawk|*.log
+FileKey2=%LocalAppData%\Tomahawk\Tomahawk\Cache|*.*|RECURSE
 
 [Tomb Raider*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\203160
 Default=False
-FileKey1=%Documents%|TombRaider.log
+FileKey1=%Documents%\|TombRaider.log
 
-[Tomboy Cache*]
-LangSecRef=3021
-DetectFile=%LocalAppData%\Tomboy
-Default=False
-FileKey1=%LocalAppData%\Tomboy\Cache|*.*|RECURSE
-
-[Tomboy Log*]
+[Tomboy*]
 LangSecRef=3021
 DetectFile=%LocalAppData%\Tomboy
 Default=False
 FileKey1=%LocalAppData%\Tomboy|*.log
+FileKey2=%LocalAppData%\Tomboy\Cache|*.*|RECURSE
 
 [TomTom*]
 LangSecRef=3021
@@ -18884,13 +17867,6 @@ Detect=HKCU\Software\Torch
 Default=False
 FileKey1=%LocalAppData%\Torch\User Data\*|Current Tabs;Current session;Last Tabs;Last Session
 
-[Torchlight*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\41500
-DetectFile=%AppData%\Runic Games\Torchlight
-Default=False
-FileKey1=%AppData%\Runic Games\Torchlight|*.log
-
 [Torchlight 2*]
 Section=Games
 Detect1=HKCU\Software\Valve\Steam\Apps\200710
@@ -18898,6 +17874,13 @@ Detect2=HKLM\Software\Runic Games\Torchlight II
 Default=False
 FileKey1=%Documents%\My Games\Runic Games\Torchlight 2\logs|*.*
 FileKey2=%Documents%\My Games\runic games\torchlight 2|ogre.log
+
+[Torchlight*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\41500
+DetectFile=%AppData%\Runic Games\Torchlight
+Default=False
+FileKey1=%AppData%\Runic Games\Torchlight|*.log
 
 [Torrent Search Log*]
 LangSecRef=3022
@@ -18932,17 +17915,12 @@ Detect=HKLM\Software\Toshiba\BluetoothStack
 Default=False
 FileKey1=%LocalAppData%\Toshiba\BluetoothStack\V1.0\tosOBEX\Temp|*.*
 
-[Toshiba Book Place Cache*]
+[Toshiba Book Place*]
 LangSecRef=3021
 DetectFile=%AppData%\Book Place
 Default=False
 FileKey1=%AppData%\Book Place\Cache|*.*|RECURSE
-
-[Toshiba Book Place Log*]
-LangSecRef=3021
-DetectFile=%AppData%\Book Place
-Default=False
-FileKey1=%AppData%\Book Place\log|*.*|RECURSE
+FileKey2=%AppData%\Book Place\log|*.*|RECURSE
 
 [Toshiba FlashCards*]
 LangSecRef=3021
@@ -18964,28 +17942,11 @@ RegKey7=HKCU\Software\HighCriteria\TotalRecorder\Recent File list|File7
 RegKey8=HKCU\Software\HighCriteria\TotalRecorder\Recent File list|File8
 RegKey9=HKCU\Software\HighCriteria\TotalRecorder\Recent File list|File9
 
-[Total Uninstall*]
-LangSecRef=3024
-Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 5_is1
-Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 6_is1
-Default=False
-FileKey1=%CommonAppData%\Martau\Total Uninstall*|*.Folders;*.cache|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Total Uninstall*|*.rtf;*.txt|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*|*.Folders;*.cache|RECURSE
-FileKey4=%ProgramFiles%\Total Uninstall*|*.rtf;*.txt|RECURSE
-
 [Total Uninstall Backups*]
 LangSecRef=3024
-Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 5_is1
-Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 6_is1
-Default=False
-Warning=This will delete analyzed programs, Snapshots, and Backups.
-FileKey1=%CommonAppData%\Martau\Total Uninstall*|*.tlg;*.zsns;*.zip|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*|*.tlg;*.zsns;*.zip|RECURSE
-
-[Total Uninstall Free Backups*]
-LangSecRef=3024
-Detect=HKCU\Software\MartS\Total Uninstall
+Detect1=HKCU\Software\MartS\Total Uninstall
+Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 5_is1
+Detect3=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 6_is1
 Default=False
 Warning=This will delete analyzed programs and backups.
 FileKey1=%CommonAppData%\Martau\Total Uninstall*\Analyzed Programs|*.*
@@ -18994,13 +17955,19 @@ FileKey3=%CommonAppData%\Martau\Total Uninstall*\System Snapshots|*.zsns
 FileKey4=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*\Analyzed Programs|*.*
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*\Backup|*.zip
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*\System Snapshots|*.zsns
+FileKey7=%CommonAppData%\Martau\Total Uninstall*|*.tlg;*.zsns;*.zip|RECURSE
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*|*.tlg;*.zsns;*.zip|RECURSE
 
-[Total Uninstall Free Logs*]
+[Total Uninstall*]
 LangSecRef=3024
-Detect=HKCU\Software\MartS\Total Uninstall
+Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 5_is1
+Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 6_is1
 Default=False
-FileKey1=%ProgramFiles%\Total Uninstall|Log.txt;*.GID
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Total Uninstall|Log.txt;*.GID
+FileKey1=%CommonAppData%\Martau\Total Uninstall*|*.Folders;*.cache|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Total Uninstall*|*.rtf;*.txt|RECURSE
+FileKey3=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*|*.Folders;*.cache|RECURSE
+FileKey4=%ProgramFiles%\Total Uninstall*|*.rtf;*.txt;*.GID|RECURSE
+FileKey5=%LocalAppData%\VirtualStore\Program Files*\Total Uninstall|Log.txt;*.GID
 
 [Towns*]
 Section=Games
@@ -19066,15 +18033,10 @@ FileKey2=%ProgramFiles%\Trademanager|OneClickEnd.log
 
 [Treesize Free*]
 LangSecRef=3024
-Detect=HKCU\Software\JAM Software\TreeSize Free
+Detect1=HKCU\Software\JAM Software\TreeSize Free
+Detect2=HKCU\Software\JAM Software\TreeSize Professional
 Default=False
-FileKey1=%AppData%\JAM Software\TreeSize Free|GlobalOptions.bak0
-
-[Treesize Pro*]
-LangSecRef=3024
-Detect=HKCU\Software\JAM Software\TreeSize Professional
-Default=False
-FileKey1=%AppData%\JAM Software\Treesize Pro|GlobalOptions.Bak0
+FileKey1=%AppData%\JAM Software\TreeSize *|GlobalOptions.bak0
 
 [Trend Micro AntiRansomware Tool*]
 LangSecRef=3021
@@ -19105,12 +18067,13 @@ Default=False
 FileKey1=%Documents%\My Games\Tribes Ascend\TribesGame\Logs|*.*
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\tribes\Binaries\Logs|*.*
 FileKey3=%ProgramFiles%\Steam\steamapps\common\tribes\Binaries\Logs|*.*
+FileKey4=%CommonAppData%\Hi-Rez Studios\BrowserCacheTribes\Default\Cache|*.*|RECURSE
 
-[Tribes: Ascend Cache*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\17080
+[Trillian Logs*]
+LangSecRef=3022
+Detect=HKLM\Software\Clients\IM\Trillian
 Default=False
-FileKey1=%CommonAppData%\Hi-Rez Studios\BrowserCacheTribes\Default\Cache|*.*|RECURSE
+FileKey1=%AppData%\Trillian\users\*\logs|*.*|RECURSE
 
 [Trillian*]
 LangSecRef=3022
@@ -19128,23 +18091,15 @@ FileKey9=%ProgramFiles%\Trillian\Crash Files|*.*|RECURSE
 FileKey10=%ProgramFiles%\Trillian\Users\Default\buddyicons|*.*|RECURSE
 FileKey11=%ProgramFiles%\Trillian\Users\Default\instantlookup|*.*
 
-[Trillian Logs*]
-LangSecRef=3022
-Detect=HKLM\Software\Clients\IM\Trillian
-Default=False
-FileKey1=%AppData%\Trillian\users\*\logs|*.*|RECURSE
-
 [Trine*]
 Section=Games
 Detect1=HKCU\Software\Valve\Steam\Apps\35700
 Detect2=HKCU\Software\Valve\Steam\Apps\35720
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\Trine\_enchanted_edition_\log|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Trine\logs|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Trine 2\log|*.*
-FileKey4=%ProgramFiles%\Steam\SteamApps\common\Trine\_enchanted_edition_\log|*.*
-FileKey5=%ProgramFiles%\Steam\SteamApps\Common\Trine\logs|*.*
-FileKey6=%ProgramFiles%\Steam\SteamApps\Common\Trine 2\log|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Trine*\log*|*.*
+FileKey3=%ProgramFiles%\Steam\SteamApps\common\Trine\_enchanted_edition_\log|*.*
+FileKey4=%ProgramFiles%\Steam\SteamApps\Common\Trine*\log*|*.*
 
 [TrojanHunter Debug Logs*]
 LangSecRef=3024
@@ -19165,8 +18120,8 @@ Section=Games
 Detect1=HKLM\Software\Haemimont Games\Tropico3
 Detect2=HKCU\Software\Haemimont Games\Tropico 4
 Default=False
-FileKey1=%AppData%\Tropico *\logs|*.*|REMOVESELF
-FileKey2=%AppData%\Tropico *\ShaderCache|*.*|REMOVESELF
+FileKey1=%AppData%\Tropico*\logs|*.*|REMOVESELF
+FileKey2=%AppData%\Tropico*\ShaderCache|*.*|REMOVESELF
 FileKey3=%ProgramFiles%\Kalypso Media\*|dotnetfx3.exe;dotnetfx35.exe
 FileKey4=%ProgramFiles%\Kalypso Media\*\DirectXRedist|*.*|REMOVESELF
 
@@ -19217,17 +18172,12 @@ DetectFile=%ProgramFiles%\TV-Browser\tvbrowser.exe
 Default=False
 FileKey1=%AppData%\TV-Browser\*|java.searchplugin.SearchPlugin.dat*
 
-[TV_Net Cache*]
+[TV_Net*]
 LangSecRef=3023
 DetectFile=%LocalLowAppData%\TV_Net
 Default=False
 FileKey1=%LocalLowAppData%\TV_Net\CacheIcons|*.*|RECURSE
-
-[TV_Net Logs*]
-LangSecRef=3023
-DetectFile=%LocalLowAppData%\TV_Net
-Default=False
-FileKey1=%LocalLowAppData%\TV_Net\Logs|*.*|RECURSE
+FileKey2=%LocalLowAppData%\TV_Net\Logs|*.*|RECURSE
 
 [TVersity*]
 LangSecRef=3023
@@ -19318,26 +18268,16 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\9E2F88E3.Twitter_wgeqdkkx372wm
 DetectFile=%LocalAppData%\Packages\9E2F88E3.Twitter_wgeqdkkx372wm
 Default=False
-FileKey1=%LocalAppData%\Packages\*Twitter_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\*Twitter_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\*Twitter_*\AC\Microsoft\*|*.LOG|RECURSE
-FileKey4=%LocalAppData%\Packages\*Twitter_*\AC\PRICache|*.*
-FileKey5=%LocalAppData%\Packages\*Twitter_*\LocalState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\*Twitter_*\AC\INetC*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\*Twitter_*\AC\Microsoft\*|*.LOG|RECURSE
+FileKey3=%LocalAppData%\Packages\*Twitter_*\AC\PRICache|*.*
+FileKey4=%LocalAppData%\Packages\*Twitter_*\LocalState|*.*|RECURSE
 
 [Two Worlds Epic Edition*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\1930
 Default=False
 FileKey1=%Documents%\TwoWorlds Files\FontsCache|*.tmp
-
-[Ubisoft Game Launcher Cache*]
-Section=Games
-DetectFile=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Ubisoft Game Launcher\Cache\assets|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Ubisoft Game Launcher\Cache\http*|*.*|RECURSE
-FileKey3=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\assets|*.*
-FileKey4=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\http*|*.*|RECURSE
 
 [Ubisoft Game Launcher Installers*]
 Section=Games
@@ -19346,14 +18286,18 @@ Default=False
 Warning=Make sure to launch all of your installed UPlay games at least once before running this, or they may not launch properly.
 FileKey1=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\Installers|*.*|REMOVESELF
 
-[Ubisoft Game Launcher Logs*]
+[Ubisoft Game Launcher*]
 Section=Games
 DetectFile=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Ubisoft Game Launcher|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Ubisoft Game Launcher\Logs|*.*
-FileKey3=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher|*.log
-FileKey4=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Logs|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Ubisoft Game Launcher\Cache\assets|*.*
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Ubisoft Game Launcher\Cache\http*|*.*|RECURSE
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Ubisoft Game Launcher\Logs|*.*
+FileKey5=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher|*.log
+FileKey6=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\assets|*.*
+FileKey7=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\http*|*.*|RECURSE
+FileKey8=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Logs|*.*
 
 [Ulead GIF Animator 5.05*]
 LangSecRef=3024
@@ -19457,8 +18401,7 @@ FileKey2=%ProgramFiles%\Uninstall Tool|*.dmp
 LangSecRef=3023
 Detect=HKCU\Software\Unity\WebPlayer
 Default=False
-FileKey1=%LocalLowAppData%\Unity\Web Player\Cache|*.*|RECURSE
-FileKey2=%LocalLowAppData%\Unity\WebPlayer\Cache|*.*|RECURSE
+FileKey1=%LocalLowAppData%\Unity\*Player\Cache|*.*|RECURSE
 
 [Universal Share Downloader*]
 LangSecRef=3022
@@ -19508,15 +18451,13 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\USATODAY.USATODAY_wy7mw3214mat8
 DetectFile=%LocalAppData%\Packages\USATODAY.USATODAY_wy7mw3214mat8
 Default=False
-FileKey1=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\PRICache|*.*
-FileKey7=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Temp|*.*
-FileKey8=%LocalAppData%\Packages\USATODAY.USATODAY_*\TempState|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\CLR_v4.0|*.log
+FileKey1=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\PRICache|*.*
+FileKey5=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Temp|*.*
+FileKey6=%LocalAppData%\Packages\USATODAY.USATODAY_*\TempState|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\CLR_v4.0|*.log
 
 [USB Disk Security*]
 LangSecRef=3024
@@ -19544,7 +18485,7 @@ FileKey4=%ProgramFiles%\USB Safely Remove|*.DIZ;*.rtf;*.url
 LangSecRef=3021
 DetectFile=%CommonAppData%\USBChargerPlus
 Default=False
-FileKey1=%CommonAppData%|AsACPLog.*
+FileKey1=%CommonAppData%\|AsACPLog.*
 FileKey2=%LocalAppData%\VirtualStore\ProgramData|AsACPLog.*
 
 [UsbFix*]
@@ -19562,12 +18503,6 @@ DetectFile=%ProgramFiles%\User Benchmark\UserBenchMark.exe
 Default=False
 FileKey1=%SystemDrive%\UserBenchmark|*.*|REMOVESELF
 
-[uTorrent Bar Logs*]
-LangSecRef=3022
-Detect=HKCU\Software\BitTorrent\uTorrent
-Default=False
-FileKey1=%LocalLowAppData%\uTorrentBar\Logs|*.*
-
 [uTorrent ipfilter backup*]
 LangSecRef=3022
 DetectFile=%AppData%\uTorrent
@@ -19582,6 +18517,7 @@ FileKey1=%AppData%\utorrent|*.log;*.dmp;*.bad;*.older;*.benc
 FileKey2=%AppData%\utorrent\updates|*.exe
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\uTorrent|*.tmp;*.old
 FileKey4=%ProgramFiles%\uTorrent|*.tmp;*.old
+FileKey5=%LocalLowAppData%\uTorrentBar\Logs|*.*
 
 [V&V Messenger Chat History*]
 LangSecRef=3022
@@ -19609,8 +18545,7 @@ FileKey1=%LocalAppData%\V Cast Media Manager|*.tmp|RECURSE
 
 [VCRedist Temp Setup Files*]
 LangSecRef=3021
-DetectFile1=%SystemDrive%\VC_RED.cab
-DetectFile2=%SystemDrive%\VC_RED.MSI
+DetectFile1=%SystemDrive%\VC_RED.*
 Default=False
 FileKey1=%SystemDrive%|eula.1028.txt;eula.1031.txt;eula.1033.txt;eula.1036.txt;eula.1040.txt;eula.1041.txt;eula.1042.txt;eula.2052.txt;eula.3082.txt;globdata.ini;install.exe;install.ini;install.res.1028.dll;install.res.1031.dll;install.res.1033.dll;install.res.1036.dll;install.res.1040.dll;install.res.1041.dll;install.res.1042.dll;install.res.2052.dll;install.res.3082.dll;VC_RED.cab;VC_RED.MSI;vcredist.bmp
 
@@ -19630,8 +18565,7 @@ FileKey1=%AppData%\ventrilo\chatlogs|*.*|REMOVESELF
 LangSecRef=3022
 DetectFile=%LocalAppData%\SupportSoft\Verizondm
 Default=False
-FileKey1=%LocalAppData%\SupportSoft\verizondm\*\verizondm\logs|*.*
-FileKey2=%LocalAppData%\SupportSoft\verizondm\*\state\logs|*.*
+FileKey1=%LocalAppData%\SupportSoft\verizondm\*\*\logs|*.*
 
 [Verizon In Home Assistant*]
 LangSecRef=3021
@@ -19664,7 +18598,7 @@ FileKey1=%AppData%\KC Softwares\VideoInspector|*.log
 LangSecRef=3023
 Detect=HKCU\Software\Gromada\VideoMach
 Default=False
-FileKey1=%Documents%|VideoMach_Log.txt
+FileKey1=%Documents%\|VideoMach_Log.txt
 
 [Vim History*]
 LangSecRef=3021
@@ -20011,6 +18945,14 @@ FileKey6=%ProgramFiles%\War Thunder\_debuginfo|*.clog
 FileKey7=%ProgramFiles%\Steam\SteamApps\common\War Thunder\.launcher_log|*.txt
 FileKey8=%ProgramFiles%\Steam\SteamApps\common\War Thunder\_debuginfo|*.clog
 
+[Warcraft III Backup Files*]
+Section=Games
+Detect=HKLM\Software\Blizzard Entertainment\Warcraft III
+Default=False
+Warning=This will delete all your Warcraft III backup files. You won't be able to restore from them if something goes wrong.
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Warcraft III|*.bak;*.old|RECURSE
+FileKey2=%ProgramFiles%\Warcraft III|*.bak;*.old|RECURSE
+
 [Warcraft III*]
 Section=Games
 Detect=HKLM\Software\Blizzard Entertainment\Warcraft III
@@ -20021,14 +18963,6 @@ FileKey2=%LocalAppData%\VirtualStore\Program Files*\Warcraft III\Errors|*.dmp;*.
 FileKey3=%ProgramFiles%\Warcraft III|*.log;*.html
 FileKey4=%ProgramFiles%\Warcraft III\Errors|*.dmp;*.txt
 ExcludeKey1=PATH|%ProgramFiles%\Warcraft III\|*CustomKeyInfo.txt;*CustomKeysSample.txt
-
-[Warcraft III Backup Files*]
-Section=Games
-Detect=HKLM\Software\Blizzard Entertainment\Warcraft III
-Default=False
-Warning=This will delete all your Warcraft III backup files. You won't be able to restore from them if something goes wrong.
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Warcraft III|*.bak;*.old|RECURSE
-FileKey2=%ProgramFiles%\Warcraft III|*.bak;*.old|RECURSE
 
 [Warframe*]
 Section=Games
@@ -20117,24 +19051,13 @@ Detect=HKCU\Software\VB and VBA Program Settings\Weather Watcher Live
 Default=False
 FileKey1=%AppData%\WeatherWatcherLive\Temp|*.*
 
-[Web Sling Player Cache*]
-LangSecRef=3023
-DetectFile=%AppData%\Sling Media\WebSlingPlayer
-Default=False
-FileKey1=%AppData%\Sling Media\WebSlingPlayer\analytics_cache|*.*|RECURSE
-FileKey2=%AppData%\Sling Media\WebSlingPlayer\fault_cache|*.*|RECURSE
-
-[Web Sling Player Logs*]
+[Web Sling Player*]
 LangSecRef=3023
 DetectFile=%AppData%\Sling Media\WebSlingPlayer
 Default=False
 FileKey1=%AppData%\Sling Media\WebSlingPlayer|*.txt;*.log
-
-[Web Sling Player Temporary Files*]
-LangSecRef=3023
-DetectFile=%AppData%\Sling Media\WebSlingPlayer
-Default=False
-FileKey1=%AppData%\Sling Media\WebSlingPlayer\temp|*.*|RECURSE
+FileKey2=%AppData%\Sling Media\WebSlingPlayer\*_cache|*.*|RECURSE
+FileKey3=%AppData%\Sling Media\WebSlingPlayer\temp|*.*|RECURSE
 
 [WebConnect*]
 LangSecRef=3023
@@ -20220,11 +19143,10 @@ Default=False
 FileKey1=%AppData%\Western Digital\WD SmartWare\Logs|*.*
 FileKey2=%CommonAppData%\Western Digital\WD SmartWare|*.log
 FileKey3=%CommonAppData%\Western Digital\WDFME|*.*
-FileKey4=%CommonAppData%\Western Digital\Logs\WD SmartWare\*|*.log
-FileKey5=%CommonAppData%\Western Digital\Logs\WD QuickView\*|*.log
-FileKey6=%LocalAppData%\Western Digital\WD SmartWare|*log.txt
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Western Digital\WD SmartWare|*.log
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Western Digital\WDFME|*.*
+FileKey4=%CommonAppData%\Western Digital\Logs\WD *\*|*.log
+FileKey5=%LocalAppData%\Western Digital\WD SmartWare|*log.txt
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Western Digital\WD SmartWare|*.log
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\Western Digital\WDFME|*.*
 
 [WhatPulse Backups*]
 LangSecRef=3021
@@ -20296,18 +19218,21 @@ Default=False
 FileKey1=%LocalAppData%\Comms\Temp|*.*|RECURSE
 FileKey2=%LocalAppData%\Comms\Unistore\data|AggregateCache.uca
 FileKey3=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\AppCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\INetCache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\INetCookies|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\INetHistory|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\PRICache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\Temp|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\TempState|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\LocalState\LiveComm\*\*\DBStore\LogFiles|edbtmp.log
+FileKey4=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\INet*|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\PRICache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\Temp|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\TempState|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\LocalState\LiveComm\*\*\DBStore\LogFiles|edbtmp.log
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.windowscommunicationsapps_8wekyb3d8bbwe\SearchHistory
+
+[Windows Connected Devices Platform*]
+LangSecRef=3025
+DetectFile=%LocalAppData%\ConnectedDevicesPlatform
+Default=False
+FileKey1=%LocalAppData\ConnectedDevicesPlatform|*.log
 
 [Windows Defender More*]
 LangSecRef=3024
@@ -20373,22 +19298,16 @@ Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsFeedback_cw5n1h2txyewy
 FileKey1=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0|*.log
-FileKey6=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0_32|*.log
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0_32\NativeImages\Temp|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0_32\UsageLogs|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Temp|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\LocalCache|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\LocalState\Cache|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*|*.log
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Temp|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\LocalCache|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\LocalState\Cache|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\TempState|*.*|RECURSE
 
 [Windows Image Acquisition*]
 LangSecRef=3025
@@ -20471,14 +19390,11 @@ LangSecRef=3022
 Detect1=HKLM\Software\Microsoft\Windows Live
 Detect2=HKCU\Software\Microsoft\Windows Live Mail
 Default=False
-FileKey1=%CommonAppData%\Microsoft\WLSetup\Cablogs|*.*|RECURSE
-FileKey2=%CommonAppData%\Microsoft\WLSetup\Logs|*.*|RECURSE
-FileKey3=%CommonAppData%\WLInstaller|*.log
-FileKey4=%LocalAppData%\Microsoft\WLSetup\Cablogs|*.*|RECURSE
-FileKey5=%LocalAppData%\Microsoft\WLSetup\Logs|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Microsoft\WLSetup\Cablogs|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Microsoft\WLSetup\Logs|*.*|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\WLInstaller|*.log
+FileKey1=%CommonAppData%\Microsoft\WLSetup\*logs|*.*|RECURSE
+FileKey2=%CommonAppData%\WLInstaller|*.log
+FileKey3=%LocalAppData%\Microsoft\WLSetup\*logs|*.*|RECURSE
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\Microsoft\WLSetup\*logs|*.*|RECURSE
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\WLInstaller|*.log
 
 [Windows Live Setup Temp Files*]
 LangSecRef=3022
@@ -20582,21 +19498,16 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\microsoft.windowsphotos_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\BackgroundTransferApi|*.down_data
-FileKey3=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\BackgroundTransferApi|*.up_meta
-FileKey4=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\INetCache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\INetCookies|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\INetHistory|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey9=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey10=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\PRICache|*.*
-FileKey12=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Temp|*.*
-FileKey13=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState\bici|*.sqm
-FileKey14=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState|*.log
-FileKey15=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState|*.jpg
-FileKey16=%LocalAppData%\Packages\microsoft.windowsphotos_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\BackgroundTransferApi|*.down_data;*.up_meta
+FileKey3=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\INet*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey6=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\PRICache|*.*
+FileKey8=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Temp|*.*
+FileKey9=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState\bici|*.sqm
+FileKey10=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState|*.log;*.jpg
+FileKey11=%LocalAppData%\Packages\microsoft.windowsphotos_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.windowsphotos_8wekyb3d8bbwe\SearchHisto
 
 [Windows Registry Recovery*]
@@ -20716,22 +19627,18 @@ RegKey10=HKCU\Software\WinImage|PathExtract
 LangSecRef=3031
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WinJS.1.0_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WinJS.2.0_8wekyb3d8bbwe
-DetectFile1=%LocalAppData%\Packages\Microsoft.WinJS.1.0_8wekyb3d8bbwe
-DetectFile2=%LocalAppData%\Packages\Microsoft.WinJS.2.0_8wekyb3d8bbwe
+DetectFile=%LocalAppData%\Packages\Microsoft.WinJS.*.0_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey7=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey8=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\PRICache|*.*
-FileKey10=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Temp|*.*
-FileKey11=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\LocalState\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\PRICache|*.*
+FileKey7=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Temp|*.*
+FileKey8=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\LocalState\*Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\TempState|*.*|RECURSE
 
 [WinMerge*]
 LangSecRef=3024
@@ -20917,8 +19824,7 @@ Default=False
 FileKey1=%CommonAppData%\Wondershare\DrFoneiOS\DBCache\NormalMode|*.*|RECURSE
 FileKey2=%CommonAppData%\Wondershare\DrFoneiOS\log|*.*|RECURSE
 FileKey3=%CommonAppData%\Wondershare\WAF\Log|*.*|RECURSE
-FileKey4=%CommonAppData%\Wondershare\WAF\ProductFeatures\LocalLogs|*.*|RECURSE
-FileKey5=%CommonAppData%\Wondershare\WAF\ProductFeatures\RemoteLogs|*.*|RECURSE
+FileKey4=%CommonAppData%\Wondershare\WAF\ProductFeatures\*Logs|*.*|RECURSE
 
 [Wondershare Helper Compact*]
 LangSecRef=3021
@@ -20943,19 +19849,16 @@ FileKey1=%AppData%\se_tmp|*.*|REMOVESELF
 FileKey2=%AppData%\Wondershare\DataEraser|*.log
 FileKey3=%AppData%\Wondershare\Dr.FoneTool\log|*.log
 FileKey4=%AppData%\Wondershare\DrFoneAndroidTool\log|*.log
-FileKey5=%AppData%\Wondershare\MirrorGo|*.log
+FileKey5=%AppData%\Wondershare\*Go*|*.log
 FileKey6=%AppData%\Wondershare\MirrorGo\ImageCache\ADImage|*.*|RECURSE
-FileKey7=%AppData%\Wondershare\MobileGo|*.log
-FileKey8=%AppData%\Wondershare\MobileGo\DeviceImageCache|*.*|RECURSE
-FileKey9=%AppData%\Wondershare\MobileGo\iOSTemp|*.*|REMOVESELF
-FileKey10=%AppData%\Wondershare\MobileGo\Logs\DeviceConnection|*.*|RECURSE
-FileKey11=%AppData%\Wondershare\MobileGo for iOS|*.log
-FileKey12=%AppData%\Wondershare\MobileTransTool|*.log
-FileKey13=%AppData%\Wondershare\WsRoot\Logs|*.*|RECURSE
-FileKey14=%CommonAppData%\Wondershare\Dr.FoneTool\Log|*.txt
-FileKey15=%CommonAppData%\Wondershare\WAF\ProductFeatures\LocalLogs|*.*|RECURSE
-FileKey16=%CommonAppData%\Wondershare\WAF\ProductFeatures\RemoteLogs|*.*|RECURSE
-FileKey17=%ProgramFiles%\Wondershare\MobileGo|*.log
+FileKey7=%AppData%\Wondershare\MobileGo\DeviceImageCache|*.*|RECURSE
+FileKey8=%AppData%\Wondershare\MobileGo\iOSTemp|*.*|REMOVESELF
+FileKey9=%AppData%\Wondershare\MobileGo\Logs\DeviceConnection|*.*|RECURSE
+FileKey10=%AppData%\Wondershare\MobileTransTool|*.log
+FileKey11=%AppData%\Wondershare\WsRoot\Logs|*.*|RECURSE
+FileKey12=%CommonAppData%\Wondershare\Dr.FoneTool\Log|*.txt
+FileKey13=%CommonAppData%\Wondershare\WAF\ProductFeatures\*Logs|*.*|RECURSE
+FileKey14=%ProgramFiles%\Wondershare\MobileGo|*.log
 
 [Wondershare PDF Editor*]
 LangSecRef=3021
@@ -20982,9 +19885,8 @@ FileKey9=%SystemDrive%\se_tmp|*.*|REMOVESELF
 LangSecRef=3023
 Detect=HKLM\SOFTWARE\Wondershare\Wondershare Video Converter Ultimate
 Default=False
-FileKey1=%CommonAppData%\Wondershare\ProductFeatures\LocalLogs|*.*|RECURSE
-FileKey2=%CommonAppData%\Wondershare\ProductFeatures\RemoteLogs|*.*|RECURSE
-FileKey3=%Documents%\Wondershare MediaServer\log|*.*|RECURSE
+FileKey1=%CommonAppData%\Wondershare\ProductFeatures\*Logs|*.*|RECURSE
+FileKey2=%Documents%\Wondershare MediaServer\log|*.*|RECURSE
 
 [Wordweb*]
 LangSecRef=3021
@@ -21011,23 +19913,18 @@ FileKey2=%ProgramFiles%\World of Warcraft\Cache|*.*|REMOVESELF
 FileKey3=%Public%\Games\World of Warcraft\Cache|*.*|REMOVESELF
 FileKey4=%SystemDrive%\World of Warcraft\Cache|*.*|REMOVESELF
 
-[World of Warcraft Error Files*]
-Section=Games
-Detect=HKCU\Software\Blizzard Entertainment\World of Warcraft
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\World of Warcraft\Errors|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\World of Warcraft\Errors|*.*|REMOVESELF
-FileKey3=%Public%\games\World of Warcraft\Errors|*.*|REMOVESELF
-FileKey4=%SystemDrive%\World of Warcraft\Errors|*.*|REMOVESELF
-
 [World of Warcraft Logs*]
 Section=Games
 Detect=HKCU\Software\Blizzard Entertainment\World of Warcraft
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\World of Warcraft\Logs|*.log
-FileKey2=%ProgramFiles%\World of Warcraft\Logs|*.log
-FileKey3=%Public%\games\World of Warcraft\Logs|*.log
-FileKey4=%SystemDrive%\World of Warcraft\Logs|*.log
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\World of Warcraft\Errors|*.*|REMOVESELF
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\World of Warcraft\Logs|*.log
+FileKey3=%ProgramFiles%\World of Warcraft\Errors|*.*|REMOVESELF
+FileKey4=%ProgramFiles%\World of Warcraft\Logs|*.log
+FileKey5=%Public%\games\World of Warcraft\Errors|*.*|REMOVESELF
+FileKey6=%Public%\games\World of Warcraft\Logs|*.log
+FileKey7=%SystemDrive%\World of Warcraft\Errors|*.*|REMOVESELF
+FileKey8=%SystemDrive%\World of Warcraft\Logs|*.log
 
 [WorldWide Telescope*]
 LangSecRef=3021
@@ -21119,20 +20016,15 @@ DetectOS=10.0|
 Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxIdentityProvider_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Microsoft\CLR_v4.0|*.log
-FileKey5=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Microsoft\CLR_v4.0_32|*.log
-FileKey8=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Microsoft\CLR_v4.0_32\NativeImages\Temp|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Microsoft\CLR_v4.0_32\UsageLogs|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Temp|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\LocalCache|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\LocalState\Cache|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Microsoft\CLR_v4.0*|*.log
+FileKey3=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Temp|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\LocalCache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\LocalState\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\TempState|*.*|RECURSE
 
 [Xbox LIVE Games*]
 LangSecRef=3031
@@ -21140,20 +20032,16 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\Microsoft\CryptnetUrlCache\Content|*.*
-FileKey7=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*
-FileKey8=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\PRICache|*.*
-FileKey10=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\Temp|*.*
-FileKey11=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\LocalState\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\LocalState\ImageCache|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\LocalState\PlayReady|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\PRICache|*.*
+FileKey7=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\Temp|*.*
+FileKey8=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\LocalState\*Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\LocalState\PlayReady|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxLIVEGames_8wekyb3d8bbwe\SearchHistory
 
 [XboxApp*]
@@ -21161,18 +20049,15 @@ DetectOS=10.0|
 Section=3031
 Default=False
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxApp_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\INetCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\INetCookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\INetHistory|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalCache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalState|*.log;*.log*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalState\SmartGlass|*.log
-FileKey12=%LocalAppData%\Packages\Microsoft.XboxApp_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\Temp|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalState|*.log;*.log*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalState\*Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalState\SmartGlass|*.log
+FileKey9=%LocalAppData%\Packages\Microsoft.XboxApp_*\TempState|*.*|RECURSE
 
 [Xenocode Sandbox Cache*]
 LangSecRef=3021
@@ -21420,18 +20305,12 @@ Detect=HKCU\Software\KC Softwares\Zer0
 Default=False
 FileKey1=%AppData%\KC Softwares\Zer0|*.log
 
-[Zimbra Desktop Cache*]
+[Zimbra Desktop*]
 LangSecRef=3022
 Detect=HKCU\Software\Zimbra
 Default=False
 FileKey1=%LocalAppData%\Zimbra\Zimbra Desktop\data\tmp\diskcache|*.*|RECURSE
-
-[Zimbra Desktop Logs*]
-LangSecRef=3022
-Detect=HKCU\Software\Zimbra
-Default=False
-FileKey1=%LocalAppData%\Zimbra\Zimbra Desktop\data\log|*.*
-FileKey2=%LocalAppData%\Zimbra\Zimbra Desktop\data\redolog|*.*
+FileKey2=%LocalAppData%\Zimbra\Zimbra Desktop\data\*log|*.*
 
 [ZipGenius*]
 LangSecRef=3024
@@ -21453,6 +20332,14 @@ DetectFile=%ProgramFiles%\Gasanov.net\ZoneIDTrimmer\ZoneIDTrimmer.Tool.exe
 Default=False
 FileKey1=%AppData%\ZoneIDTrimmer\Logs|ZoneIDTrimmer.log
 
+[Zoner Photo Studio AutoSave*]
+LangSecRef=3023
+Detect1=HKCU\Software\ZONER\Zoner Photo Studio 15
+Detect2=HKCU\Software\ZONER\Zoner Photo Studio 16
+Detect3=HKCU\Software\ZONER\Zoner Photo Studio 18
+Default=False
+FileKey1=%LocalAppData%\Zoner\OriginalsRepository|*.JPG.info;*.JPG.original|RECURSE
+
 [Zoner Photo Studio*]
 LangSecRef=3022
 DetectFile=%LocalAppData%\Zoner\ZPS 14
@@ -21465,13 +20352,25 @@ FileKey2=%LocalAppData%\Zoner\ZPS *\CEF|*.log
 FileKey3=%LocalAppData%\Zoner\ZPS *\ZPSCache.dat|*.*
 FileKey4=%Pictures%|*.uid-zps
 
-[Zoner Photo Studio AutoSave*]
-LangSecRef=3023
-Detect1=HKCU\Software\ZONER\Zoner Photo Studio 15
-Detect2=HKCU\Software\ZONER\Zoner Photo Studio 16
-Detect3=HKCU\Software\ZONER\Zoner Photo Studio 18
+[Zune Music*]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneMusic_8wekyb3d8bbwe
+DetectFile=%LocalAppData%\Packages\Microsoft.ZuneMusic_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Zoner\OriginalsRepository|*.JPG.info;*.JPG.original|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\AppCache|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\PRICache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Temp|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\*Cache*|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\Database\*|*.log
+FileKey11=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\PlayReady|*.*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\TempState|*.*|RECURSE
+RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneMusic_8wekyb3d8bbwe\SearchHistory
 
 [Zune Transcoded Files Cache*]
 LangSecRef=3023
@@ -21479,52 +20378,24 @@ Detect=HKCU\Software\Microsoft\Zune
 Default=False
 FileKey1=%LocalAppData%\Microsoft\Zune\Transcoded Files Cache|*.*
 
-[Zune Music*]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneMusic_8wekyb3d8bbwe
-DetectFile=%LocalAppData%\Packages\Microsoft.ZuneMusic_8wekyb3d8bbwe
-Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\PRICache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Temp|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\Cache|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\Database\*|*.log
-FileKey14=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageCache|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\PlayReady|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\TempState|*.*|RECURSE
-RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneMusic_8wekyb3d8bbwe\SearchHistory
-
 [Zune Video*]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneVideo_8wekyb3d8bbwe
 DetectFile=%LocalAppData%\Packages\Microsoft.ZuneVideo_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\INetCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\INetCookies|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\INetHistory|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\PRICache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Temp|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\Cache|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageCache|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\PlayReady|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\TempState|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\Database\anonymous|*.log
+FileKey2=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\PRICache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Temp|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\TokenBroker\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\*Cache*|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\PlayReady|*.*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\TempState|*.*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\Database\anonymous|*.log
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneVideo_8wekyb3d8bbwe\SearchHistory
 
 [Zuse Logs*]

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -324,9 +324,9 @@ ExcludeKey6=PATH|%LocalAppData%\Chrome Plus\User Data\*\File System\|*.*
 ExcludeKey7=PATH|%LocalAppData%\Chrome Plus\User Data\*\Local App Settings\|*.*
 ExcludeKey8=PATH|%LocalAppData%\Chrome Plus\User Data\*\Local Extension Settings\|*.*
 ExcludeKey9=PATH|%LocalAppData%\Chromium\User Data\*\Extensions\|*.*
-ExcludeKey10=PATH|%LocalAppData%\Chromium\User Data\*\Local App Settings\|*.*
-ExcludeKey11=PATH|%LocalAppData%\Chromium\User Data\*\Local Extension Settings\|*.*
-ExcludeKey12=PATH|%LocalAppData%\Chromium\User Data\*\File System\|*.*
+ExcludeKey10=PATH|%LocalAppData%\Chromium\User Data\*\File System\|*.*
+ExcludeKey11=PATH|%LocalAppData%\Chromium\User Data\*\Local App Settings\|*.*
+ExcludeKey12=PATH|%LocalAppData%\Chromium\User Data\*\Local Extension Settings\|*.*
 ExcludeKey13=PATH|%LocalAppData%\Flock\User Data\*\Extensions\|*.*
 ExcludeKey14=PATH|%LocalAppData%\Flock\User Data\*\File System\|*.*
 ExcludeKey15=PATH|%LocalAppData%\Flock\User Data\*\Local App Settings\|*.*
@@ -618,8 +618,8 @@ FileKey1=%AppData%\Mozilla\Firefox\Profiles\*|seer.sqlite;netpredictions.sqlite
 
 [Nightly Backups*]
 LangSecRef=3026
-DetectFile1=%ProgramFiles%\Nightly
-DetectFile2=%ProgramFiles%\Mozilla\Nightly
+DetectFile1=%ProgramFiles%\Mozilla\Nightly
+DetectFile2=%ProgramFiles%\Nightly
 Default=False
 FileKey1=%ProgramFiles%\Mozilla\Nightly.bak|*.*|REMOVESELF
 FileKey2=%ProgramFiles%\Nightly.bak|*.*|REMOVESELF
@@ -1267,7 +1267,7 @@ Detect=HKCU\Software\Microsoft\Windows
 Default=False
 FileKey1=%LocalAppData%\Microsoft\Windows\ActionCenterCache|*.*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Action Center\Providers\EventLog
-RegKey2=HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Security and Maintenance\Providers\EventLog
+RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Security and Maintenance\Providers\EventLog
 
 [Active Setup Temp Folder*]
 LangSecRef=3025
@@ -1357,9 +1357,9 @@ FileKey3=%WinDir%\System32\config\systemprofile\AppData\LocalLow\Adblock Plus fo
 
 [Add New Hardware Wizard MRU*]
 LangSecRef=3025
-Detect=HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup
+Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Setup
 Default=False
-RegKey1=HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup|Installation Sources
+RegKey1=HKLM\Software\Microsoft\Windows\CurrentVersion\Setup|Installation Sources
 
 [Adobe Acrobat DC*]
 LangSecRef=3021
@@ -1575,8 +1575,8 @@ FileKey5=%Documents%\Adobe\Premiere Pro\2.0\Media Cache Files|*.*
 
 [Adobe Premiere Pro CC More*]
 LangSecRef=3023
-Detect1=HKLM\SOFTWARE\Adobe\Premiere Pro\7.0
-Detect2=HKCU\Software\Adobe\Premiere Pro\7.0
+Detect1=HKCU\Software\Adobe\Premiere Pro\7.0
+Detect2=HKLM\Software\Adobe\Premiere Pro\7.0
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Adobe\Adobe Premiere Pro CC\cache|*-*-*.cache
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Adobe\Adobe Premiere Pro CC\Required\data\cache|*.pcache
@@ -1608,7 +1608,7 @@ RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 
 [Adobe Reader XI More*]
 LangSecRef=3021
-Detect=HKCU\SOFTWARE\Adobe\Acrobat Reader\11.0
+Detect=HKCU\Software\Adobe\Acrobat Reader\11.0
 Default=False
 RegKey1=HKCU\Software\Adobe\Acrobat Reader\11.0\AVConversionFromPDF
 RegKey2=HKCU\Software\Adobe\Acrobat Reader\11.0\AVConversionToPDF
@@ -1830,7 +1830,7 @@ FileKey1=%Documents%\AIDA64 Reports|*.*|REMOVESELF
 
 [Aignes Website-Watcher*]
 LangSecRef=3023
-Detect=HKCU\SOFTWARE\aignes\wswatch
+Detect=HKCU\Software\aignes\wswatch
 Default=False
 FileKey1=%AppData%\aignes\WebSite-Watcher\config\favicons|*.*
 FileKey2=%AppData%\aignes\website-watcher\config\log|*.*
@@ -1840,7 +1840,7 @@ FileKey4=%AppData%\aignes\website-watcher\config\temp|*.*
 [Aignes Website-Watcher AutoBackup*]
 LangSecRef=3023
 Warning=This will delete your AutoBackup of your site.
-Detect=HKCU\SOFTWARE\aignes\wswatch
+Detect=HKCU\Software\aignes\wswatch
 Default=False
 FileKey1=%AppData%\aignes\website-watcher\config\autobackup|*.*
 
@@ -1867,7 +1867,7 @@ FileKey2=%ProgramFiles%\Aimersoft\DRM Media Converter\Log|*.*|REMOVESELF
 
 [Aimersoft Helper Compact*]
 LangSecRef=3021
-Detect=HKLM\SOFTWARE\Aimersoft\Aimersoft Helper Compact
+Detect=HKLM\Software\Aimersoft\Aimersoft Helper Compact
 Default=False
 FileKey1=%CommonProgramFiles%\Aimersoft\Aimersoft Helper Compact|ProductUpdateLists.xml;ASHelper.exe_temp;ASHelperSetup.exe_temp
 FileKey2=%CommonProgramFiles%\Aimersoft\Aimersoft Helper Compact\DATADICT|*.*|RECURSE
@@ -1876,8 +1876,8 @@ FileKey4=%CommonProgramFiles%\Aimersoft\Aimersoft Helper Compact\Temp|*.*|RECURS
 FileKey5=%LocalAppData%\VirtualStore\Program Files*\Common Files\Aimersoft\Aimersoft Helper Compact|ProductUpdateLists.xml;ASHelper.exe_temp;ASHelperSetup.exe_temp
 FileKey6=%LocalAppData%\VirtualStore\Program Files*\Common Files\Aimersoft\Aimersoft Helper Compact\Log|*.*|RECURSE
 FileKey7=%LocalAppData%\VirtualStore\Program Files*\Common Files\Aimersoft\Aimersoft Helper Compact\Temp|*.*|RECURSE
-RegKey1=HKLM\SOFTWARE\Aimersoft\Aimersoft Helper Compact
-RegKey2=HKLM\SOFTWARE\Wow6432Node\Aimersoft\Aimersoft Helper Compact
+RegKey1=HKLM\Software\Aimersoft\Aimersoft Helper Compact
+RegKey2=HKLM\Software\Wow6432Node\Aimersoft\Aimersoft Helper Compact
 
 [Aimersoft Video Converter Ultimate More*]
 LangSecRef=3023
@@ -1890,8 +1890,8 @@ FileKey4=%ProgramFiles%\Aimersoft\Video Converter Ultimate\TempThumbDir|*.*|RECU
 
 [AIMP*]
 LangSecRef=3023
-DetectFile1=%ProgramFiles%\AIMP*\AIMP*.exe
-DetectFile2=%ProgramFiles%\AIMP Classic\cAIMP.exe
+DetectFile1=%ProgramFiles%\AIMP Classic\cAIMP.exe
+DetectFile2=%ProgramFiles%\AIMP*\AIMP*.exe
 Default=False
 FileKey1=%AppData%\AIMP|*.bak
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\AIMP2\Data|*.bak|RECURSE
@@ -2005,7 +2005,7 @@ FileKey1=%AppData%\AllDup|*.log
 
 [Alternate File Shredder Logs*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Alternate File Shredder_is1
+Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Alternate File Shredder_is1
 Default=False
 FileKey1=%AppData%\Alternate\FileShredder|FileShredderLog*.txt
 
@@ -2300,9 +2300,9 @@ FileKey6=%LocalAppData%\VirtualStore\ProgramData\AOL Downloads|*.*|RECURSE
 FileKey7=%LocalAppData%\VirtualStore\ProgramData\AOL\C_AOL*|*.tmp|RECURSE
 FileKey8=%LocalAppData%\VirtualStore\ProgramData\AOL\C_AOL*\bart|*.*|RECURSE
 FileKey9=%LocalAppData%\VirtualStore\ProgramData\AOL\C_AOL*\spool|*.*|RECURSE
-RegKey1=HKCU\Software\America Online\AOL Instant Messenger â„¢\CurrentVersion\recent IM ScreenNames
-RegKey2=HKCU\Software\America Online\AOL Instant Messenger â„¢\CurrentVersion\recent ScreenNames
-RegKey3=HKCU\Software\America Online\AOL Instant Messenger â„¢\CurrentVersion\Users
+RegKey1=HKCU\Software\America Online\AOL Instant Messenger ™\CurrentVersion\recent IM ScreenNames
+RegKey2=HKCU\Software\America Online\AOL Instant Messenger ™\CurrentVersion\recent ScreenNames
+RegKey3=HKCU\Software\America Online\AOL Instant Messenger ™\CurrentVersion\Users
 
 [APC PowerChute Personal Edition*]
 LangSecRef=3024
@@ -2341,8 +2341,8 @@ FileKey1=%LocalAppData%\ApplicationHistory|*.*|RECURSE
 [Apps CrashDumps*]
 DetectOS=6.2|
 Section=3031
-Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\WinStore_cw5n1h2txyewy
-Detect2=HKCU\SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsStore_8wekyb3d8bbwe
+Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsStore_8wekyb3d8bbwe
+Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\WinStore_cw5n1h2txyewy
 Default=False
 Warning=This deletes crash dumps from Windows Store Apps.
 FileKey1=%LocalAppData%\CrashDumps|*.*|RECURSE
@@ -2420,16 +2420,16 @@ LangSecRef=3021
 Detect1=HKCU\Software\Ashampoo\Ashampoo Burning Studio 5
 Detect2=HKCU\Software\Ashampoo\Ashampoo Burning Studio 6
 Detect3=HKCU\Software\Ashampoo\Ashampoo Burning Studio 7
-Detect4=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2007
-Detect5=HKCU\Software\Ashampoo\Ashampoo Burning Studio 8
-Detect6=HKLM\Software\Ashampoo\Ashampoo Burning Studio 2009
-Detect7=HKCU\Software\Ashampoo\Ashampoo Burning Studio 12
-Detect8=HKCU\Software\Ashampoo\Ashampoo Burning Studio 14
-Detect9=HKCU\Software\Ashampoo\Ashampoo Burning Studio 15
-Detect10=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16
+Detect4=HKCU\Software\Ashampoo\Ashampoo Burning Studio 8
+Detect5=HKCU\Software\Ashampoo\Ashampoo Burning Studio 12
+Detect6=HKCU\Software\Ashampoo\Ashampoo Burning Studio 14
+Detect7=HKCU\Software\Ashampoo\Ashampoo Burning Studio 15
+Detect8=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16
+Detect9=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18
+Detect10=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2007
 Detect11=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016
-Detect12=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18
-Detect13=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017
+Detect12=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017
+Detect13=HKLM\Software\Ashampoo\Ashampoo Burning Studio 2009
 Default=False
 FileKey1=%AppData%\Ashampoo|*.xml;*.txt|RECURSE
 FileKey2=%LocalAppData%\ashampoo\BaNT\product|*.*|RECURSE
@@ -2552,9 +2552,9 @@ FileKey2=%AppData%\AstroGrep\Log|*.log
 
 [ASUS Logs*]
 LangSecRef=3024
-DetectFile1=%ProgramFiles%\ASUS\AI Suite
+DetectFile1=%AppData%\ASUS WebStorage
 DetectFile2=%CommonAppData%\Asus
-DetectFile3=%AppData%\ASUS WebStorage
+DetectFile3=%ProgramFiles%\ASUS\AI Suite
 Default=False
 FileKey1=%AppData%\ASUS WebStorage\Logs|*.*
 FileKey2=%CommonAppData%\Asus\AsusAppStore|*.log|RECURSE
@@ -2579,7 +2579,7 @@ Default=False
 FileKey1=%AppData%\CrashRpt\UnsentCrashReports|*.dmp;*.log;*.xml|RECURSE
 FileKey2=%CommonAppData%\RapidSolution\Audials_2013\ChildMSILogs|*.txt
 FileKey3=%LocalAppData%\RapidSolution\Audials_2013\Log|*.log;*.txt|RECURSE
-FileKey4=%LocalAppData%\RapidSolution\Audials_SOFTWARE\RapidSolution\Audials_2013\Log|*.log;*.txt|RECURSE
+FileKey4=%LocalAppData%\RapidSolution\Audials_Software\RapidSolution\Audials_2013\Log|*.log;*.txt|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\RapidSolution\Audials_2013\ChildMSILogs|*.txt
 
 [Audio Sliders*]
@@ -2631,23 +2631,23 @@ RegKey19=HKLM\Software\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.Err
 RegKey20=HKLM\Software\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
 RegKey21=HKLM\Software\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.ErrorsRemovedTotal
 RegKey22=HKLM\Software\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.LastScan
-RegKey23=HKLM\SOFTWARE\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|DiskDefrag.DisksList.SelectedDrives
-RegKey24=HKLM\SOFTWARE\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|DiskDefrag.LastDefragment.DateTime
-RegKey25=HKLM\SOFTWARE\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|DiskDefrag.LastDefragment.DisksList
-RegKey26=HKLM\SOFTWARE\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|DiskDefrag.LastDefragment.FilesCount
-RegKey27=HKLM\SOFTWARE\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.ErrorsFailed
-RegKey28=HKLM\SOFTWARE\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.ErrorsFound
-RegKey29=HKLM\SOFTWARE\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
-RegKey30=HKLM\SOFTWARE\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.ErrorsRemovedTotal
-RegKey31=HKLM\SOFTWARE\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.LastScan
+RegKey23=HKLM\Software\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|DiskDefrag.DisksList.SelectedDrives
+RegKey24=HKLM\Software\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|DiskDefrag.LastDefragment.DateTime
+RegKey25=HKLM\Software\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|DiskDefrag.LastDefragment.DisksList
+RegKey26=HKLM\Software\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|DiskDefrag.LastDefragment.FilesCount
+RegKey27=HKLM\Software\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.ErrorsFailed
+RegKey28=HKLM\Software\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.ErrorsFound
+RegKey29=HKLM\Software\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
+RegKey30=HKLM\Software\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.ErrorsRemovedTotal
+RegKey31=HKLM\Software\Wow6432Node\Auslogics\BoostSpeed\7.x\Settings|RegCleaner.AppLogic.LastScan
 
 [Auslogics Disk Defrag*]
 LangSecRef=3024
-Detect1=HKLM\SOFTWARE\Auslogics\DiskDefrag
-Detect2=HKCU\Software\Auslogics\Disk Defrag Portable
-Detect3=HKLM\Software\Auslogics\DiskDefrag Portable
-Detect4=HKLM\Software\Auslogics\Disk Defrag Portable
-Detect5=HKLM\SOFTWARE\Auslogics\Disk Defrag Professional
+Detect1=HKCU\Software\Auslogics\Disk Defrag Portable
+Detect2=HKLM\Software\Auslogics\Disk Defrag Portable
+Detect3=HKLM\Software\Auslogics\Disk Defrag Professional
+Detect4=HKLM\Software\Auslogics\DiskDefrag
+Detect5=HKLM\Software\Auslogics\DiskDefrag Portable
 Default=False
 FileKey1=%AppData%\Auslogics\Disk*Defrag*\Logs|*.*|RECURSE
 FileKey2=%AppData%\Auslogics\Disk*Defrag*\Reports|*.*|RECURSE
@@ -2802,7 +2802,7 @@ RegKey1=HKCU\Software\AVAST Software\Avast Browser Cleanup
 
 [AVG*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\AVG
+Detect=HKLM\Software\AVG
 Default=False
 FileKey1=%CommonAppData%\Avg\AV\Antispam|*.tmp;*.tmp1;*.tmp2;*.gz
 FileKey2=%CommonAppData%\Avg\AV\SetupBackup|*.*|REMOVESELF
@@ -2825,30 +2825,24 @@ FileKey18=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Avg\log\av16|hist
 FileKey19=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Avg\log\fmw1|*.log;*.log.*;*.log.lock
 FileKey20=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\AvgSetupLog|*.*|REMOVESELF
 
-[AVG PC TuneUp & Utilities CrashDumps*]
+[AVG PC TuneUp & Utilities*]
 LangSecRef=3024
-Detect1=HKCU\Software\TuneUp
-Detect2=HKCU\Software\AVG\AWL\RegistryCleaner
+Detect1=HKCU\Software\AVG\AWL\RegistryCleaner
+Detect2=HKCU\Software\TuneUp
 Default=False
 FileKey1=%AppData%\AVG\AWL*\CrashDumps|*.*
 FileKey2=%AppData%\TuneUp Software\TuneUp Utilities\CrashDumps|*.*
-FileKey3=%LocalAppData%\Avg\dumps\fmw1|*.*
-
-[AVG PC TuneUp & Utilities Logs*]
-LangSecRef=3024
-Detect1=HKCU\Software\TuneUp
-Detect2=HKCU\Software\AVG\AWL\RegistryCleaner
-Default=False
-FileKey1=%CommonAppData%\TuneUp Software\TuneUp Utilities *|*.log|RECURSE
-FileKey2=%LocalAppData%\Avg\AWL*\Log|*.log
-FileKey3=%LocalAppData%\Avg\Log|*.log;zappapi.log.1|RECURSE
-FileKey4=%LocalAppData%\Avg\log\fmw1|*.*
-FileKey5=%LocalAppData%\Avg\log\tu16|*.log
-FileKey6=%LocalAppData%\AvgSetupLog|*.*|REMOVESELF
-FileKey7=%LocalAppData%\TuneUp Software|*.log|RECURSE
-FileKey8=%SystemDrive%\Users\Default\AppData\Local\Avg\Log\tu16|*.log
-FileKey9=%WinDir%\System32\config\systemprofile\AppData\Local\Avg\Log\fmw1|*.log
-FileKey10=%WinDir%\System32\config\systemprofile\AppData\Local\Avg\Log\tu16|*.log
+FileKey3=%CommonAppData%\TuneUp Software\TuneUp Utilities *|*.log|RECURSE
+FileKey4=%LocalAppData%\Avg\AWL*\Log|*.log
+FileKey5=%LocalAppData%\Avg\dumps\fmw1|*.*
+FileKey6=%LocalAppData%\Avg\Log|*.log;zappapi.log.1|RECURSE
+FileKey7=%LocalAppData%\Avg\log\fmw1|*.*
+FileKey8=%LocalAppData%\Avg\log\tu16|*.log
+FileKey9=%LocalAppData%\AvgSetupLog|*.*|REMOVESELF
+FileKey10=%LocalAppData%\TuneUp Software|*.log|RECURSE
+FileKey11=%SystemDrive%\Users\Default\AppData\Local\Avg\Log\tu16|*.log
+FileKey12=%WinDir%\System32\config\systemprofile\AppData\Local\Avg\Log\fmw1|*.log
+FileKey13=%WinDir%\System32\config\systemprofile\AppData\Local\Avg\Log\tu16|*.log
 
 [AVG PC TuneUp & Utilities Reg Defrag Cleanup*]
 LangSecRef=3024
@@ -2869,7 +2863,7 @@ FileKey8=%WinDir%\ServiceProfiles\LocalService|NTUSER.DAT_tureg_new.LOG*;NTUSER.
 FileKey9=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows|USRCLASS.DAT_tureg_old;USRCLASS.DAT_tureg_new.LOG*
 FileKey10=%WinDir%\ServiceProfiles\NetworkService|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
 FileKey11=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows|USRCLASS.DAT_tureg_old;USRCLASS.DAT_tureg_new.LOG*
-FileKey12=%WinDir%\System32\config|COMPONENTS_tureg_new.LOG*;COMPONENTS_tureg_old;DEFAULT_tureg_new.LOG*;DEFAULT_tureg_old;SAM_tureg_new.LOG*;SAM_tureg_old;SECURITY_tureg_new.LOG*;SECURITY_tureg_old;SOFTWARE_tureg_new.LOG*;SOFTWARE_tureg_old;SYSTEM_tureg_new.LOG*;SYSTEM_tureg_old;DRIVERS_tureg_new.LOG*;DRIVERS_tureg_old;SOFTWARE_tureg_new;SYSTEM_tureg_new
+FileKey12=%WinDir%\System32\config|COMPONENTS_tureg_new.LOG*;COMPONENTS_tureg_old;DEFAULT_tureg_new.LOG*;DEFAULT_tureg_old;SAM_tureg_new.LOG*;SAM_tureg_old;SECURITY_tureg_new.LOG*;SECURITY_tureg_old;Software_tureg_new.LOG*;Software_tureg_old;SYSTEM_tureg_new.LOG*;SYSTEM_tureg_old;DRIVERS_tureg_new.LOG*;DRIVERS_tureg_old;Software_tureg_new;SYSTEM_tureg_new
 
 [Avi-Mux GUI*]
 LangSecRef=3023
@@ -2908,16 +2902,16 @@ FileKey2=%LocalAppData%\VirtualStore\Program Files*\Avidemux*|admlog.txt
 
 [Avira AntiVir Desktop IPM*]
 LangSecRef=3024
-Detect1=HKLM\Software\Avira\AntiVir Desktop
-Detect2=HKCU\SOFTWARE\Avira\Antivirus
+Detect1=HKCU\Software\Avira\Antivirus
+Detect2=HKLM\Software\Avira\AntiVir Desktop
 Default=False
 FileKey1=%CommonAppData%\Avira\AntiVir*\IPM|*.*|RECURSE
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Avira\AntiVir*\IPM|*.*|RECURSE
 
 [Avira AntiVir Desktop Reports*]
 LangSecRef=3024
-Detect1=HKLM\Software\Avira\AntiVir Desktop
-Detect2=HKCU\SOFTWARE\Avira\Antivirus
+Detect1=HKCU\Software\Avira\Antivirus
+Detect2=HKLM\Software\Avira\AntiVir Desktop
 Default=False
 FileKey1=%CommonAppData%\Avira\AntiVir*\REPORTS|*.*
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Avira\AntiVir*\REPORTS|*.*
@@ -2937,8 +2931,8 @@ FileKey1=%CommonAppData%\Avira\VPN|*.log
 
 [Avira System Speedup*]
 LangSecRef=3024
-Detect1=HKLM\Software\AviraSpeedup
-Detect2=HKLM\Software\Avira\Speedup
+Detect1=HKLM\Software\Avira\Speedup
+Detect2g=HKLM\Software\AviraSpeedup
 Default=False
 FileKey1=%CommonAppData%\Avira\Launcher\Logfiles|*.log
 FileKey2=%CommonAppData%\Avira\SystemSpeedup\Errors|*.*
@@ -3101,9 +3095,9 @@ FileKey1=%Documents%\*\Batman Arkham Asylum*\BmGame|*.log|RECURSE
 
 [Batman: Arkham City*]
 Section=Games
-Detect1=HKLM\Software\Warner Bros\Batman Arkham City
-Detect2=HKCU\Software\Valve\Steam\Apps\200260
-Detect3=HKCU\Software\Valve\Steam\Apps\57400
+Detect1=HKCU\Software\Valve\Steam\Apps\200260
+Detect2=HKCU\Software\Valve\Steam\Apps\57400
+Detect3=HKLM\Software\Warner Bros\Batman Arkham City
 Default=False
 FileKey1=%Documents%\WB Games\Batman Arkham City*\BmGame\Logs|*.*
 
@@ -3185,7 +3179,7 @@ FileKey7=%WinDir%\system32\MTSLog|*.*|REMOVESELF
 
 [Beckhoff TwinCat Logs*]
 LangSecRef=3021
-Detect=HKCU\SOFTWARE\Beckhoff
+Detect=HKCU\Software\Beckhoff
 Default=False
 FileKey1=%HomeDrive%\TwinCAT\3.1\Components\TcEventLogger\EventConfigurator|~evtCfgTmp*.html
 FileKey2=%UserProfile%\|*TwinCat*.log;TC*.log;TF*.log
@@ -3263,7 +3257,7 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData\BigFishCache|*.exe|RECURSE
 
 [Binding of Isaac Afterbirth+*]
 Section=Games
-Detect=HKCU\SOFTWARE\Valve\Steam\Apps\570660
+Detect=HKCU\Software\Valve\Steam\Apps\570660
 DetectFile=%Documents%\My Games\Binding of Isaac Afterbirth+
 Default=False
 FileKey1=%Documents%\My Games\Binding of Isaac Afterbirth+|*.dmp;isaacv*.txt;log.txt
@@ -3407,16 +3401,16 @@ FileKey1=%LocalAppData%\BIT.TRIP RUNNER|*.txt
 LangSecRef=3022
 Detect1=HKCU\Software\Bitcoin
 Detect2=HKCU\Software\Bitcoin Core
-Detect3=HKLM\SOFTWARE\Bitcoin Core
+Detect3=HKLM\Software\Bitcoin Core
 Default=False
 FileKey1=%AppData%\Bitcoin|*.log;*.old
 
 [Bitdefender Logs*]
 LangSecRef=3024
-Detect1=HKLM\Software\Softwin\Bitdefender Antivirus
+Detect1=HKLM\Software\Bitdefender\Bitdefender Internet Security
 Detect2=HKLM\Software\Bitdefender\Bitdefender Total Security
 Detect3=HKLM\Software\Bitdefender\Bitdefender Total Security 2015
-Detect4=HKLM\Software\Bitdefender\Bitdefender Internet Security
+Detect4=HKLM\Software\Softwin\Bitdefender Antivirus
 Default=False
 FileKey1=%AppData%\Bitdefender\Desktop\profiles\Logs\*|*.xml
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Softwin\Bitdefender*\Logs|*.*
@@ -3710,7 +3704,7 @@ FileKey1=%LocalAppData%\Brother\P-touch Update Software|*.log
 
 [Brother Printer Debug Logs*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\Brother
+Detect=HKLM\Software\Brother
 DetectFile=%CommonAppData%\Brother
 Default=False
 FileKey1=%CommonAppData%\Brother\BrLog|*.log
@@ -3984,8 +3978,8 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData\CanonBJ\IJPrinter\CNMWindows|dr
 [Canon Zoom Browser*]
 LangSecRef=3021
 Detect=HKCU\Software\Canon\ZoomBrowser Ex
-DetectFile1=%Pictures%\ZbThumbnail.info
-DetectFile2=%AppData%\ZoomBrowser EX
+DetectFile1=%AppData%\ZoomBrowser EX
+DetectFile2=%Pictures%\ZbThumbnail.info
 Default=False
 FileKey1=%Pictures%\|ZbThumbnail.info|RECURSE
 
@@ -4182,10 +4176,10 @@ FileKey4=%ProgramFiles%\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url
 [Christmas Wonderland*]
 Section=Games
 Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonderland 2
-Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonderland 21.0
-Detect3=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonderland 31.0
-Detect4=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonderland 3 1.0
-Detect5=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonderland 4 1.0.4
+Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonderland 3 1.0
+Detect3=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonderland 4 1.0.4
+Detect4=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonderland 21.0
+Detect5=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonderland 31.0
 Detect6=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonderland 41.1
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Christmas Wonderland 3|*.nfo;*.url|RECURSE
@@ -4270,8 +4264,8 @@ FileKey1=%Documents%\My Games\Sid Meier's Civilization 5\Saves\*\auto\prev|*.Civ
 
 [Civilization Cache*]
 Section=Games
-Detect1=HKLM\Software\Firaxis Games
-Detect2=HKCU\Software\Firaxis\Civilization5
+Detect1=HKCU\Software\Firaxis\Civilization5
+Detect2=HKLM\Software\Firaxis Games
 Default=False
 FileKey1=%AppData%\My Games\Beyond the Sword\cache|*.dat
 FileKey2=%AppData%\My Games\Sid Meier's Civilization *\cache|*.dat
@@ -4283,8 +4277,8 @@ FileKey7=%LocalAppData%\My Games\Warlords\cache|*.dat
 
 [Civilization Logs*]
 Section=Games
-Detect1=HKLM\Software\Firaxis Games
-Detect2=HKCU\Software\Firaxis\Civilization5
+Detect1=HKCU\Software\Firaxis\Civilization5
+Detect2=HKLM\Software\Firaxis Games
 Default=False
 FileKey1=%Documents%\My Games\Beyond the Sword\Logs|*.*
 FileKey2=%Documents%\My Games\Sid Meier's Civilization *\Logs|*.*
@@ -4306,8 +4300,8 @@ FileKey3=%ProgramFiles%\ClamSentinel|*.txt
 
 [ClamWin*]
 LangSecRef=3021
-Detect1=HKLM\Software\ClamWin
-Detect2=HKCU\Software\ClamWin
+Detect1=HKCU\Software\ClamWin
+Detect2=HKLM\Software\ClamWin
 Default=False
 FileKey1=%AllUsersProfile%\.clamwin\log|*.*|RECURSE
 FileKey2=%AppData%\.clamwin\log|*.*|RECURSE
@@ -4388,16 +4382,16 @@ FileKey8=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\TempSta
 
 [Cloudfogger*]
 LangSecRef=3023
-Detect1=HKCU\SOFTWARE\Cloudfogger
-Detect2=HKCU\SOFTWARE\Cloudfogger.com
+Detect1=HKCU\Software\Cloudfogger
+Detect2=HKCU\Software\Cloudfogger.com
 Default=False
 FileKey1=%AppData%\Cloudfogger|*.log|RECURSE
 FileKey2=%LocalAppData%\CrashRpt|*.log|RECURSE
 
 [Cloudfogger Keys*]
 LangSecRef=3023
-Detect1=HKCU\SOFTWARE\Cloudfogger
-Detect2=HKCU\SOFTWARE\Cloudfogger.com
+Detect1=HKCU\Software\Cloudfogger
+Detect2=HKCU\Software\Cloudfogger.com
 Default=False
 FileKey1=%AppData%\Cloudfogger\Keys|*.*|RECURSE
 
@@ -4808,7 +4802,7 @@ FileKey1=%LocalAppData%\Coowon\Coowon\User Data\*|Current Tabs;Current session;L
 
 [Copernic DesktopSearch4 Logs*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\Copernic\DesktopSearch4
+Detect=HKLM\Software\Copernic\DesktopSearch4
 Default=False
 FileKey1=%AppData%\Copernic\DesktopSearch4\Logs|*.*|REMOVESELF
 FileKey2=%LocalAppData%\Copernic\DesktopSearch4\Logs|*.*|REMOVESELF
@@ -4894,12 +4888,12 @@ FileKey2=%LocalAppData%\Corel\AfterShot Pro *\Cache|*.*|RECURSE
 
 [Corel PaintShop Pro*]
 LangSecRef=3023
-Detect1=HKCU\Software\Corel\PhotoDownloader\2
-Detect2=HKCU\Software\Corel\PaintShop Pro\X4
-Detect3=HKCU\Software\Corel\PaintShop Pro\X5
-Detect4=HKCU\Software\Corel\PaintShop Pro\X6
-Detect5=HKCU\Software\Corel\PaintShop Pro\X7
-Detect6=HKCU\Software\Corel\PaintShop Pro\X10
+Detect1=HKCU\Software\Corel\PaintShop Pro\X4
+Detect2=HKCU\Software\Corel\PaintShop Pro\X5
+Detect3=HKCU\Software\Corel\PaintShop Pro\X6
+Detect4=HKCU\Software\Corel\PaintShop Pro\X7
+Detect5=HKCU\Software\Corel\PaintShop Pro\X10
+Detect6=HKCU\Software\Corel\PhotoDownloader\2
 Default=False
 FileKey1=%AppData%\Corel\PaintShop Photo Pro\13\Cache|*.*|RECURSE
 FileKey2=%LocalAppData%\Corel|*.db;*.PspCache
@@ -4942,7 +4936,7 @@ RegKey4=HKCU\Software\Ulead Systems\Corel VideoStudio Pro\17.0\HerRFL
 
 [CorelDRAW Graphics Suite X7*]
 LangSecRef=3021
-Detect=HKCU\SOFTWARE\Corel\CorelDRAW\17.0
+Detect=HKCU\Software\Corel\CorelDRAW\17.0
 Default=False
 FileKey1=%CommonAppData%\Bitstream\Font Navigator\6.0\Cache|*.*|RECURSE
 FileKey2=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Config|corelpdf.ini;capture.ini
@@ -5513,11 +5507,11 @@ FileKey1=%SystemDrive%\dell|*.*|REMOVESELF
 
 [Dell Logs*]
 LangSecRef=3024
-DetectFile1=%CommonAppData%\Dell
-DetectFile2=%LocalAppData%\Dell\
-DetectFile3=%ProgramFiles%\Dell*\
+DetectFile1=%AppData%\Creative\DELL Webcam Center
+DetectFile2=%CommonAppData%\Dell
+DetectFile3=%LocalAppData%\Dell\
 DetectFile4=%LocalAppData%\SupportSoft\DellSupportCenter
-DetectFile5=%AppData%\Creative\DELL Webcam Center
+DetectFile5=%ProgramFiles%\Dell*\
 Default=False
 FileKey1=%AppData%\Creative\DELL Webcam Center|MO_Log.txt
 FileKey2=%AppData%\PCDr\*\Logs|*.*
@@ -5642,7 +5636,7 @@ FileKey1=%AppData%\DeviceDoctorSoftware\DeviceDoctor\Logs|*.*
 
 [Devolo Cockpit*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\devolo\dLAN
+Detect=HKLM\Software\devolo\dLAN
 Default=False
 FileKey1=%ProgramFiles%\devolo\dlan|dlanhistory.*txt;dlanstats.*xml;support.html;support.zip
 FileKey2=%ProgramFiles%\devolo\dlan\updates|*.*|RECURSE
@@ -5719,8 +5713,8 @@ FileKey2=%LocalAppData%\GPSoftware\Directory Opus\Thumbnail Cache|*.*|RECURSE
 
 [Discord*]
 LangSecRef=3022
-Detect1=HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\Discord
-Detect2=HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\Discordcanary
+Detect1=HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\Discord
+Detect2=HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\Discordcanary
 Default=False
 FileKey1=%AppData%\discord*|modules.log
 FileKey2=%AppData%\discord*\Cache|*.*|RECURSE
@@ -5776,8 +5770,8 @@ FileKey3=%LocalAppData%\VirtualStore\ProgramData\DivX|*.log|RECURSE
 
 [DivX Movies Cache*]
 LangSecRef=3023
-Detect1=HKLM\Software\DivXNetworks
-Detect2=HKCU\Software\DivX
+Detect1=HKCU\Software\DivX
+Detect2=HKLM\Software\DivXNetworks
 Default=False
 FileKey1=%Video%\DivX Movies|*.*|RECURSE
 RegKey1=HKCU\Software\DivXNetworks\DivXBrowserPlugin|cacheEntry1
@@ -5911,7 +5905,7 @@ Default=False
 FileKey1=%LocalAppData%\DownTango|application.log
 FileKey2=%LocalAppData%\DownTango\Logs|log.txt
 
-[Dr. Despicableâ€™s Dastardly Deeds*]
+[Dr. Despicable’s Dastardly Deeds*]
 Section=Games
 DetectFile=%AppData%\HitPoint Studios\DrD
 Default=False
@@ -5939,7 +5933,7 @@ FileKey1=%UserProfile%\Doctor Web|*.log
 [DraftSight*]
 LangSecRef=3021
 Detect1=HKCU\Software\Dassault Systemes\DraftSight
-Detect2=HKLM\SOFTWARE\Dassualt Systemes\DraftSight
+Detect2=HKLM\Software\Dassualt Systemes\DraftSight
 Default=False
 FileKey1=%AppData%\DraftSight\*|history.txt;plot.log
 FileKey2=%LocalAppData%\Dassault Systemes\DraftSight\cache|*.*|RECURSE
@@ -5955,7 +5949,7 @@ FileKey3=%LocalAppData%\VirtualStore\ProgramData\BioWare\Dragon Age\DA Updater\L
 
 [Dreadnought*]
 Section=Games
-Detect=HKCU\SOFTWARE\Grey Box\Dreadnought
+Detect=HKCU\Software\Grey Box\Dreadnought
 Default=False
 FileKey1=%LocalAppData%\DreadGame\Saved\Logs|*.log
 
@@ -6034,7 +6028,7 @@ FileKey1=%AppData%\Easeware\DriverEasy\drivers|*.*|RECURSE
 
 [DriverGenius*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\Driver-Soft\DriverGenius
+Detect=HKLM\Software\Driver-Soft\DriverGenius
 DetectFile=%ProgramFiles%\Driver-Soft\DriverGenius
 Default=False
 FileKey1=%CommonAppData%\DriverGenius|*.log
@@ -6179,7 +6173,7 @@ RegKey4=HKCU\Software\Prismatic Software\PhotoBatch\Dups|LastSingleFold
 
 [DVBDream*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\DVBDream
+Detect=HKLM\Software\DVBDream
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\dvbdream|*.log;*.bak;*levellog*|RECURSE
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\dvbdream\Logs|*.*
@@ -6295,8 +6289,8 @@ FileKey1=%Documents%\dvdsmith|*.log
 
 [DVDVideoSoft*]
 LangSecRef=3023
-Detect1=HKCU\Software\DVDVideoSoft
-Detect2=HKCU\Software\AppDataLow\Software\DVDVideoSoftTB
+Detect1=HKCU\Software\AppDataLow\Software\DVDVideoSoftTB
+Detect2=HKCU\Software\DVDVideoSoft
 Default=False
 FileKey1=%AppData%\DVDVideoSoft\*\History|*.*|RECURSE
 FileKey2=%AppData%\DVDVideoSoft\*Logs|*.*|RECURSE
@@ -6514,7 +6508,7 @@ FileKey1=%CommonAppData%\ElectricSheep\Logs|*.*
 
 [ElsterFormular*]
 LangSecRef=3021
-Detect=HKLM\SOFTWARE\Landesfinanzdirektion ThÃ¼ringen\ElsterFormular
+Detect=HKLM\Software\Landesfinanzdirektion Thüringen\ElsterFormular
 Default=False
 FileKey1=%AppData%\elsterformular\*\log|*.log;*.log.*
 FileKey2=%AppData%\elsterformular\*\tmp|*.*|RECURSE
@@ -6586,7 +6580,7 @@ FileKey2=%AppData%\SeriousBit\EnhanceMy8\Backups|*.*|RECURSE
 
 [Epic Games Launcher*]
 Section=Games
-Detect=HKCU\SOFTWARE\Epic Games\EpicGamesLauncher
+Detect=HKCU\Software\Epic Games\EpicGamesLauncher
 Default=False
 FileKey1=%LocalAppData%\EpicGamesLauncher\Saved\Crashes|*.*|REMOVESELF
 FileKey2=%LocalAppData%\EpicGamesLauncher\Saved\Logs|*.log
@@ -6832,8 +6826,8 @@ FileKey1=%SystemDrive%\|Faceprov.*
 
 [Fallout Shelter*]
 Section=Games
-Detect1=HKCU\Software\Valve\Steam\Apps\588430
-Detect2=HKCU\Software\Bethesda\Fallout Shelter
+Detect1=HKCU\Software\Bethesda\Fallout Shelter
+Detect2=HKCU\Software\Valve\Steam\Apps\588430
 Default=False
 FileKey1=%LocalAppData%\FalloutShelter|*.log;*.bkp
 
@@ -6906,7 +6900,7 @@ FileKey2=%ProgramFiles%\Steam\steamapps\common\FTL Faster Than Light\crashlogs|*
 
 [FastStone Capture More*]
 LangSecRef=3024
-Detect=HKCU\SOFTWARE\FastStone Capture
+Detect=HKCU\Software\FastStone Capture
 DetectFile=%AppData%\FastStone\FSC
 Default=False
 FileKey1=%AppData%\FastStone\FSC|*.bak;fsc.db
@@ -6920,7 +6914,7 @@ RegKey6=HKCU\Software\FastStone\APP.FSRecorder\Global|_LastRecordingFileName
 
 [FastStone Image Viewer More*]
 LangSecRef=3023
-Detect=HKLM\SOFTWARE\FastStone Image Viewer
+Detect=HKLM\Software\FastStone Image Viewer
 Default=False
 FileKey1=%AppData%\FastStone\FSIV|FSViewer.db
 
@@ -7122,7 +7116,7 @@ FileKey2=%SystemDrive%\FFOutput|*.*|RECURSE
 
 [Forte Agent*]
 LangSecRef=3025
-Detect=HKLM\SOFTWARE\Forte
+Detect=HKLM\Software\Forte
 Default=False
 FileKey1=%AppData%\Forte\Agent|errorlog.xml;*.log|RECURSE
 FileKey2=%SystemDrive%\My Data\ForteAgent|*.bak;*.log
@@ -7142,13 +7136,13 @@ FileKey2=%ProgramFiles%\AAForwardObserver|FO.log
 
 [FossaMail Corrupt SQLites*]
 LangSecRef=3030
-Detect=HKLM\SOFTWARE\Mozilla\FossaMail
+Detect=HKLM\Software\Mozilla\FossaMail
 Default=False
 FileKey1=%AppData%\FossaMail\Profiles|*.corrupt|RECURSE
 
 [FossaMail Log*]
 LangSecRef=3030
-Detect=HKLM\SOFTWARE\Mozilla\FossaMail
+Detect=HKLM\Software\Mozilla\FossaMail
 Default=False
 FileKey1=%AppData%\FossaMail\Crash Reports|*.*|REMOVESELF
 FileKey2=%AppData%\FossaMail\Profiles\*|TestPilotErrorLog.*;extensions.log|RECURSE
@@ -7160,25 +7154,25 @@ FileKey7=%ProgramFiles%\FossaMail|*.log
 
 [FossaMail Minidumps*]
 LangSecRef=3030
-Detect=HKLM\SOFTWARE\Mozilla\FossaMail
+Detect=HKLM\Software\Mozilla\FossaMail
 Default=False
 FileKey1=%AppData%\FossaMail\Profiles\*\Minidumps|*.*
 
 [FossaMail Net Predictions*]
 LangSecRef=3030
-Detect=HKLM\SOFTWARE\Mozilla\FossaMail
+Detect=HKLM\Software\Mozilla\FossaMail
 Default=False
 FileKey1=%AppData%\FossaMail\Profiles\*|seer.sqlite;netpredictions.sqlite
 
 [FossaMail Startup Cache*]
 LangSecRef=3030
-Detect=HKLM\SOFTWARE\Mozilla\FossaMail
+Detect=HKLM\Software\Mozilla\FossaMail
 Default=False
 FileKey1=%LocalAppData%\FossaMail\Profiles\*\startupCache|*.*
 
 [FossaMail webappsstore.sqlite*]
 LangSecRef=3030
-Detect=HKLM\SOFTWARE\Mozilla\FossaMail
+Detect=HKLM\Software\Mozilla\FossaMail
 Default=False
 FileKey1=%AppData%\FossaMail\Profiles\*|webappsstore.sqlite
 
@@ -7485,8 +7479,8 @@ RegKey4=HKCU\Software\gBurner|Reopen3
 [GEAR DIFx Installers*]
 LangSecRef=3024
 Detect1=HKCR\Installer\Products\CACFC38969C58104B8CE6D8561446C45
-Detect2=HKLM\SOFTWARE\GEAR Software\DIFx
-Detect3=HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\3EC13FCAF38E85F44B0F1137C7FB5037
+Detect2=HKLM\Software\GEAR Software\DIFx
+Detect3=HKLM\Software\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\3EC13FCAF38E85F44B0F1137C7FB5037
 Default=False
 FileKey1=%AppData%\188F1432-103A-4ffb-80F1-36B633C5C9E1|*.*|REMOVESELF
 FileKey2=%AppData%\34BE82C4-E596-4e99-A191-52C6199EBF69|*.*|REMOVESELF
@@ -7684,11 +7678,11 @@ FileKey4=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\GNU\Cache|*.*|RECU
 
 [GnuCash*]
 LangSecRef=3021
-Detect=HKCU\SOFTWARE\GSettings\org\gnucash
+Detect=HKCU\Software\GSettings\org\gnucash
 Default=False
 Warning=This removes the last open history, auto saves and logs.
 FileKey1=%UserProfile%\*|*.gnucash.*.log;*.gnucash.*.gnucash;translog.*.log|RECURSE
-RegKey1=HKCU\SOFTWARE\GSettings\org\gnucash\history
+RegKey1=HKCU\Software\GSettings\org\gnucash\history
 
 [Go!Zilla More*]
 LangSecRef=3022
@@ -7711,7 +7705,7 @@ FileKey1=%Documents%\my games\GoatSim\GoatGame\Logs|*.*
 
 [GOG.com Galaxy*]
 Section=Games
-Detect=HKCU\SOFTWARE\GOG.com\Galaxy
+Detect=HKCU\Software\GOG.com\Galaxy
 Default=False
 FileKey1=%CommonAppData%\GOG.com\Galaxy\logs|*.log
 FileKey2=%CommonAppData%\GOG.com\Galaxy\temp\desktop-galaxy-updater|*.*|REMOVESELF
@@ -7933,7 +7927,7 @@ FileKey2=%ProgramFiles%\Guild Wars|*.tmp
 
 [Gwent*]
 Section=Games
-Detect=HKCU\SOFTWARE\CDProjektRED\Gwent
+Detect=HKCU\Software\CDProjektRED\Gwent
 Default=False
 FileKey1=%CommonAppData%\CDProjekt RED\Gwent\Logs|*.log
 
@@ -7995,7 +7989,7 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData\AltrixSoft\Hard Drive Inspector
 
 [Hauppauge WinTV*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\Hauppauge
+Detect=HKLM\Software\Hauppauge
 Default=False
 FileKey1=%Public%\WinTV|Settings-old.xml
 FileKey2=%Public%\WinTV\Channel Database|hcwChanDB_5-lastgood.mdb
@@ -8031,7 +8025,7 @@ FileKey1=%AppData%\KC Softwares\HDDExpert|*.log
 
 [Hedgewars VideoTemp*]
 Section=Games
-Detect=HKLM\SOFTWARE\Hedgewars
+Detect=HKLM\Software\Hedgewars
 Default=False
 FileKey1=%Documents%\Hedgewars\VideoTemp|*.*
 
@@ -8087,7 +8081,7 @@ LangSecRef=3024
 Detect1=HKCU\Software\HitMan Pro
 Detect2=HKCU\Software\HitMan Pro 2
 Detect3=HKCU\Software\HitMan Pro 3
-Detect4=HKLM\SOFTWARE\HitmanPro
+Detect4=HKLM\Software\HitmanPro
 Default=False
 FileKey1=%CommonAppData%\HitmanPro\Logs|*.*
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Hitman Pro*\downloads|*.*
@@ -8100,8 +8094,8 @@ FileKey8=%ProgramFiles%\Hitman Pro*\updates|*.*
 
 [Holiday Express*]
 Section=Games
-Detect1=HKLM\Software\HipSoft\Holiday Express
-Detect2=HKLM\Software\GameHouse\Holiday Express
+Detect1=HKLM\Software\GameHouse\Holiday Express
+Detect2=HKLM\Software\HipSoft\Holiday Express
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\GameHouse Games Collection\Holiday Express|*.txt
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Holiday Express|*html;*.txt
@@ -8117,57 +8111,57 @@ FileKey2=%ProgramFiles%\HomeCinema\PowerProducer\Template\Cyberlink\frame|*tmp
 
 [Honeyview Bookmarks*]
 LangSecRef=3023
-Detect=HKCU\SOFTWARE\Honeyview
+Detect=HKCU\Software\Honeyview
 Default=False
-RegKey1=HKCU\SOFTWARE\Honeyview\BMPath0
-RegKey2=HKCU\SOFTWARE\Honeyview\BMPath1
-RegKey3=HKCU\SOFTWARE\Honeyview\BMPath2
-RegKey4=HKCU\SOFTWARE\Honeyview\BMPath3
-RegKey5=HKCU\SOFTWARE\Honeyview\BMPath4
-RegKey6=HKCU\SOFTWARE\Honeyview\BMPath5
-RegKey7=HKCU\SOFTWARE\Honeyview\BMPath6
-RegKey8=HKCU\SOFTWARE\Honeyview\BMPath7
-RegKey9=HKCU\SOFTWARE\Honeyview\BMPath8
-RegKey10=HKCU\SOFTWARE\Honeyview\BMPath9
-RegKey11=HKCU\SOFTWARE\Honeyview\BMPath10
-RegKey12=HKCU\SOFTWARE\Honeyview\BMPath11
-RegKey13=HKCU\SOFTWARE\Honeyview\BMPath12
-RegKey14=HKCU\SOFTWARE\Honeyview\BMPath13
-RegKey15=HKCU\SOFTWARE\Honeyview\BMPath14
-RegKey16=HKCU\SOFTWARE\Honeyview\BMPath15
-RegKey17=HKCU\SOFTWARE\Honeyview\BMPath16
-RegKey18=HKCU\SOFTWARE\Honeyview\BMPath17
-RegKey19=HKCU\SOFTWARE\Honeyview\BMPath18
-RegKey20=HKCU\SOFTWARE\Honeyview\BMPath19
-RegKey21=HKCU\SOFTWARE\Honeyview\BMPath20
-RegKey22=HKCU\SOFTWARE\Honeyview\BMPath21
-RegKey23=HKCU\SOFTWARE\Honeyview\BMPath22
-RegKey24=HKCU\SOFTWARE\Honeyview\BMPath23
-RegKey25=HKCU\SOFTWARE\Honeyview\BMPath24
-RegKey26=HKCU\SOFTWARE\Honeyview\BMPath25
-RegKey27=HKCU\SOFTWARE\Honeyview\BMPath26
-RegKey28=HKCU\SOFTWARE\Honeyview\BMPath27
-RegKey29=HKCU\SOFTWARE\Honeyview\BMPath28
-RegKey30=HKCU\SOFTWARE\Honeyview\BMPath29
+RegKey1=HKCU\Software\Honeyview\BMPath0
+RegKey2=HKCU\Software\Honeyview\BMPath1
+RegKey3=HKCU\Software\Honeyview\BMPath2
+RegKey4=HKCU\Software\Honeyview\BMPath3
+RegKey5=HKCU\Software\Honeyview\BMPath4
+RegKey6=HKCU\Software\Honeyview\BMPath5
+RegKey7=HKCU\Software\Honeyview\BMPath6
+RegKey8=HKCU\Software\Honeyview\BMPath7
+RegKey9=HKCU\Software\Honeyview\BMPath8
+RegKey10=HKCU\Software\Honeyview\BMPath9
+RegKey11=HKCU\Software\Honeyview\BMPath10
+RegKey12=HKCU\Software\Honeyview\BMPath11
+RegKey13=HKCU\Software\Honeyview\BMPath12
+RegKey14=HKCU\Software\Honeyview\BMPath13
+RegKey15=HKCU\Software\Honeyview\BMPath14
+RegKey16=HKCU\Software\Honeyview\BMPath15
+RegKey17=HKCU\Software\Honeyview\BMPath16
+RegKey18=HKCU\Software\Honeyview\BMPath17
+RegKey19=HKCU\Software\Honeyview\BMPath18
+RegKey20=HKCU\Software\Honeyview\BMPath19
+RegKey21=HKCU\Software\Honeyview\BMPath20
+RegKey22=HKCU\Software\Honeyview\BMPath21
+RegKey23=HKCU\Software\Honeyview\BMPath22
+RegKey24=HKCU\Software\Honeyview\BMPath23
+RegKey25=HKCU\Software\Honeyview\BMPath24
+RegKey26=HKCU\Software\Honeyview\BMPath25
+RegKey27=HKCU\Software\Honeyview\BMPath26
+RegKey28=HKCU\Software\Honeyview\BMPath27
+RegKey29=HKCU\Software\Honeyview\BMPath28
+RegKey30=HKCU\Software\Honeyview\BMPath29
 
 [Honeyview MRU*]
 LangSecRef=3023
-Detect=HKCU\SOFTWARE\Honeyview
+Detect=HKCU\Software\Honeyview
 Default=False
-RegKey1=HKCU\SOFTWARE\Honeyview\RecentFolder0
-RegKey2=HKCU\SOFTWARE\Honeyview\RecentFolder1
-RegKey3=HKCU\SOFTWARE\Honeyview\RecentFolder2
-RegKey4=HKCU\SOFTWARE\Honeyview\RecentFolder3
-RegKey5=HKCU\SOFTWARE\Honeyview\RecentFolder4
-RegKey6=HKCU\SOFTWARE\Honeyview\RecentFolder5
-RegKey7=HKCU\SOFTWARE\Honeyview\RecentFolder6
-RegKey8=HKCU\SOFTWARE\Honeyview\RecentFolder7
-RegKey9=HKCU\SOFTWARE\Honeyview\RecentFolder8
-RegKey10=HKCU\SOFTWARE\Honeyview\RecentFolder9
-RegKey11=HKCU\SOFTWARE\Honeyview\sRecentFolder
-RegKey12=HKCU\SOFTWARE\Honeyview\sStoreFilePath
-RegKey13=HKCU\SOFTWARE\Honeyview\sStoreFilePath2
-RegKey14=HKCU\SOFTWARE\Honeyview\transf.sTargetFolder
+RegKey1=HKCU\Software\Honeyview\RecentFolder0
+RegKey2=HKCU\Software\Honeyview\RecentFolder1
+RegKey3=HKCU\Software\Honeyview\RecentFolder2
+RegKey4=HKCU\Software\Honeyview\RecentFolder3
+RegKey5=HKCU\Software\Honeyview\RecentFolder4
+RegKey6=HKCU\Software\Honeyview\RecentFolder5
+RegKey7=HKCU\Software\Honeyview\RecentFolder6
+RegKey8=HKCU\Software\Honeyview\RecentFolder7
+RegKey9=HKCU\Software\Honeyview\RecentFolder8
+RegKey10=HKCU\Software\Honeyview\RecentFolder9
+RegKey11=HKCU\Software\Honeyview\sRecentFolder
+RegKey12=HKCU\Software\Honeyview\sStoreFilePath
+RegKey13=HKCU\Software\Honeyview\sStoreFilePath2
+RegKey14=HKCU\Software\Honeyview\transf.sTargetFolder
 
 [Hostile Makeover*]
 Section=Games
@@ -8251,8 +8245,8 @@ FileKey8=%WinDir%\|*.dat.temp
 
 [HP Installation Files*]
 LangSecRef=3024
-DetectFile1=%SystemDrive%\swsetup
-DetectFile2=%SystemDrive%\HP Universal Print Driver
+DetectFile1=%SystemDrive%\HP Universal Print Driver
+DetectFile2=%SystemDrive%\swsetup
 Default=False
 FileKey1=%SystemDrive%\HP Universal Print Driver|*.*|REMOVESELF
 FileKey2=%SystemDrive%\swsetup|*.*|REMOVESELF
@@ -8260,11 +8254,11 @@ FileKey2=%SystemDrive%\swsetup|*.*|REMOVESELF
 [HP Logs*]
 LangSecRef=3021
 Detect=HKCU\Software\HP
-DetectFile1=%CommonAppData%\HP
+DetectFile1=%AppData%\hpqlog
 DetectFile2=%CommonAppData%\Hewlett-Packard\
-DetectFile3=%AppData%\hpqlog
-DetectFile4=%ProgramFiles%\HPQ\Shared\Sierra Wireless
-DetectFile5=%LocalAppData%\TouchSmartData
+DetectFile3=%CommonAppData%\HP
+DetectFile4=%LocalAppData%\TouchSmartData
+DetectFile5=%ProgramFiles%\HPQ\Shared\Sierra Wireless
 Default=False
 FileKey1=%AppData%\HP\WebRegLogs|WebRegLog.txt
 FileKey2=%AppData%\hpqlog|*.log
@@ -8662,7 +8656,7 @@ FileKey3=%LocalAppData%\VirtualStore\Program Files*\inFlow Inventory\Logs|*.*
 
 [InkScape*]
 LangSecRef=3023
-Detect=HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\inkscape.exe
+Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\inkscape.exe
 Default=False
 FileKey1=%AppData%\InkScape|*.log|RECURSE
 FileKey2=%LocalAppData%\|recently-used.xbel
@@ -9172,13 +9166,13 @@ FileKey4=%CommonProgramFiles%\iSkysoft\iSkysoft Helper Compact\Temp|*.*|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\Program Files*\Common Files\iSkysoft\iSkysoft Helper Compact|ProductUpdateLists.xml;ISHelper.exe_temp;ISHelperSetup.exe_temp
 FileKey6=%LocalAppData%\VirtualStore\Program Files*\Common Files\iSkysoft\iSkysoft Helper Compact\log|*.*|RECURSE
 FileKey7=%LocalAppData%\VirtualStore\Program Files*\Common Files\iSkysoft\iSkysoft Helper Compact\Temp|*.*|RECURSE
-RegKey1=HKLM\SOFTWARE\iSkysoft\iSkysoft Helper Compact
-RegKey2=HKLM\SOFTWARE\Wow6432Node\iSkysoft\iSkysoft Helper Compact
+RegKey1=HKLM\Software\iSkysoft\iSkysoft Helper Compact
+RegKey2=HKLM\Software\Wow6432Node\iSkysoft\iSkysoft Helper Compact
 
 [iSkysoft Video Converter*]
 LangSecRef=3023
-Detect1=HKLM\Software\iSkysoft\iSkysoft Video Converter Ultimate
-Detect2=HKLM\Software\iSkysoft\iSkysoft Video Converter
+Detect1=HKLM\Software\iSkysoft\iSkysoft Video Converter
+Detect2=HKLM\Software\iSkysoft\iSkysoft Video Converter Ultimate
 Default=False
 FileKey1=%CommonAppData%\iSkysoft Video Converter*|*.dat.bak
 FileKey2=%CommonAppData%\iSkysoft Video Converter*\TempSiteIconDir|*.*|RECURSE
@@ -9323,9 +9317,9 @@ RegKey1=HKCU\Software\JASC\Animation Shop\Cache
 
 [Java More*]
 LangSecRef=3022
-Detect1=HKLM\SOFTWARE\JavaSoft\Java Plug-in
-Detect2=HKLM\SOFTWARE\JavaSoft\Java Runtime Environment
-Detect3=HKLM\SOFTWARE\JavaSoft\Java Web Start
+Detect1=HKLM\Software\JavaSoft\Java Plug-in
+Detect2=HKLM\Software\JavaSoft\Java Runtime Environment
+Detect3=HKLM\Software\JavaSoft\Java Web Start
 Default=False
 FileKey1=%AppData%\Sun\Java\Deployment\SystemCache|*.*|RECURSE
 FileKey2=%CommonAppData%\Oracle\Java\.oracle_jre_usage|*.*
@@ -9413,7 +9407,7 @@ FileKey4=%UserProfile%\.jd_home\logs|*.0
 
 [JDownloader2 Logs*]
 LangSecRef=3022
-Detect=HKLM\SOFTWARE\Classes\JDownloader2
+Detect=HKLM\Software\Classes\JDownloader2
 DetectFile=%ProgramFiles%\JDownloader 2
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*|JDownloader.log;Updater_*-*-*.log;SessionInstallLog.json.*
@@ -9423,7 +9417,7 @@ FileKey4=%ProgramFiles%\JDownloader*2*\logs|*.*|RECURSE
 
 [JDownloader2 Temps*]
 LangSecRef=3022
-Detect=HKLM\SOFTWARE\Classes\JDownloader2
+Detect=HKLM\Software\Classes\JDownloader2
 DetectFile=%ProgramFiles%\JDownloader 2
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*\captchas|*.*|RECURSE
@@ -9432,8 +9426,8 @@ FileKey3=%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*\tmp|*.*|RECUR
 FileKey4=%ProgramFiles%\JDownloader*2*\captchas|*.*|RECURSE
 FileKey5=%ProgramFiles%\JDownloader*2*\cfg|CaptchaDialogDimensions_*.json
 FileKey6=%ProgramFiles%\JDownloader*2*\tmp|*.*|RECURSE
-ExcludeKey1=PATH|%ProgramFiles%\JDownloader*2*\cfg\|subconf_*.ejs
-ExcludeKey2=PATH|%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*\cfg\|subconf_*.ejs
+ExcludeKey1=PATH|%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*\cfg\|subconf_*.ejs
+ExcludeKey2=PATH|%ProgramFiles%\JDownloader*2*\cfg\|subconf_*.ejs
 
 [jEdit*]
 LangSecRef=3021
@@ -9483,7 +9477,7 @@ FileKey2=%ProgramFiles%\Jetico\Jetico Personal Firewall|firewall*.log
 
 [Jing*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\TechSmith\Jing
+Detect=HKLM\Software\TechSmith\Jing
 Default=False
 FileKey1=%LocalAppData%\TechSmith\Jing\DataStore|*.*|RECURSE
 FileKey2=%LocalAppData%\TechSmith\Jing\Temp|*.*|RECURSE
@@ -9677,9 +9671,9 @@ RegKey2=HKLM\Software\Microsoft\Windows\CurrentVersion\Run|EKStatusMonitor
 
 [Kodak Logs*]
 LangSecRef=3021
-Detect1=HKLM\Software\Eastman Kodak Company\KODAK AiO Home Center
-Detect2=HKLM\Software\Kodak\Kodak AiO Software
-Detect3=HKCU\Software\Kodak
+Detect1=HKCU\Software\Kodak
+Detect2=HKLM\Software\Eastman Kodak Company\KODAK AiO Home Center
+Detect3=HKLM\Software\Kodak\Kodak AiO Software
 DetectFile=%AppData%\Kodak\Share Button App
 Default=False
 FileKey1=%AppData%\Kodak\Share Button App|*.log
@@ -10040,8 +10034,8 @@ FileKey1=%LocalAppData%\LogiShrd\Vid|*.*|RECURSE
 [Logitech Desktop Messenger*]
 LangSecRef=3024
 Detect1=HKCU\Software\Logitech\DesktopMessenger
-Detect2=HKLM\SOFTWARE\Logitech\DesktopMessenger
-Detect3=HKLM\SOFTWARE\Logitech\Logitech Desktop Messenger
+Detect2=HKLM\Software\Logitech\DesktopMessenger
+Detect3=HKLM\Software\Logitech\Logitech Desktop Messenger
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Logitech\Desktop Messenger|*.log;*.bak
 FileKey2=%ProgramFiles%\Logitech\Desktop Messenger|*.log;*.bak
@@ -10335,8 +10329,8 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData\ManiaPlanet\Cache|*.*
 
 [ManyCam More*]
 LangSecRef=3023
-Detect1=HKLM\Software\ManyCam
-Detect2=HKCU\Software\ManyCam
+Detect1=HKCU\Software\ManyCam
+Detect2=HKLM\Software\ManyCam
 Default=False
 FileKey1=%AppData%\ManyCam\Settings\MoviesThumbnails|*.*|RECURSE
 FileKey2=%LocalAppData%\ManyCam|*.log|RECURSE
@@ -10606,21 +10600,21 @@ RegKey15=HKCU\Software\JBSoftware\MemoMaster5|FileMRU15
 
 [Men of War Cache*]
 Section=Games
-Detect1=HKCU\Software\Valve\Steam\Apps\7830
-Detect2=HKCU\Software\Valve\Steam\Apps\64000
-Detect3=HKCU\Software\Valve\Steam\Apps\204860
-Detect4=HKCU\Software\Valve\Steam\Apps\3130
-Detect5=HKCU\Software\Valve\Steam\Apps\63940
+Detect1=HKCU\Software\Valve\Steam\Apps\204860
+Detect2=HKCU\Software\Valve\Steam\Apps\3130
+Detect3=HKCU\Software\Valve\Steam\Apps\63940
+Detect4=HKCU\Software\Valve\Steam\Apps\64000
+Detect5=HKCU\Software\Valve\Steam\Apps\7830
 Default=False
 FileKey1=%Documents%\My Games\men of war*\shader_cache|*.*|RECURSE
 
 [Men of War Log*]
 Section=Games
-Detect1=HKCU\Software\Valve\Steam\Apps\7830
-Detect2=HKCU\Software\Valve\Steam\Apps\64000
-Detect3=HKCU\Software\Valve\Steam\Apps\204860
-Detect4=HKCU\Software\Valve\Steam\Apps\3130
-Detect5=HKCU\Software\Valve\Steam\Apps\63940
+Detect1=HKCU\Software\Valve\Steam\Apps\204860
+Detect2=HKCU\Software\Valve\Steam\Apps\3130
+Detect3=HKCU\Software\Valve\Steam\Apps\63940
+Detect4=HKCU\Software\Valve\Steam\Apps\64000
+Detect5=HKCU\Software\Valve\Steam\Apps\7830
 Default=False
 FileKey1=%Documents%\My Games\men of war*\log|*.*
 
@@ -10693,8 +10687,8 @@ FileKey2=%AppData%\MetroTwit\*\User_Images|*.*|RECURSE
 
 [Microangelo*]
 LangSecRef=3021
-Detect1=HKCU\Software\Impact\Microangelo
-Detect2=HKCU\Software\Eclipsit\Microangelo\Toolset 6
+Detect1=HKCU\Software\Eclipsit\Microangelo\Toolset 6
+Detect2=HKCU\Software\Impact\Microangelo
 Default=False
 RegKey1=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Animator\MRU List
 RegKey2=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Librarian\MRU List
@@ -11150,10 +11144,10 @@ RegKey3=HKLM\Software\Wow6432Node\Microsoft\Direct3D\MostRecentApplication
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-RegKey1=HKCR\VirtualStore\MACHINE\SOFTWARE\Microsoft\DirectDraw\MostRecentApplication
-RegKey2=HKCR\VirtualStore\MACHINE\SOFTWARE\Wow6432Node\Microsoft\DirectDraw\MostRecentApplication
-RegKey3=HKCU\Software\Classes\VirtualStore\MACHINE\SOFTWARE\Microsoft\DirectDraw\MostRecentApplication
-RegKey4=HKCU\Software\Classes\VirtualStore\MACHINE\SOFTWARE\Wow6432Node\Microsoft\DirectDraw\MostRecentApplication
+RegKey1=HKCR\VirtualStore\MACHINE\Software\Microsoft\DirectDraw\MostRecentApplication
+RegKey2=HKCR\VirtualStore\MACHINE\Software\Wow6432Node\Microsoft\DirectDraw\MostRecentApplication
+RegKey3=HKCU\Software\Classes\VirtualStore\MACHINE\Software\Microsoft\DirectDraw\MostRecentApplication
+RegKey4=HKCU\Software\Classes\VirtualStore\MACHINE\Software\Wow6432Node\Microsoft\DirectDraw\MostRecentApplication
 RegKey5=HKLM\Software\Microsoft\DirectDraw\MostRecentApplication
 RegKey6=HKLM\Software\Wow6432Node\Microsoft\DirectDraw\MostRecentApplication
 
@@ -11254,22 +11248,22 @@ LangSecRef=3021
 Detect=HKCU\Software\Microsoft\Office
 Default=False
 FileKey1=%AppData%\Microsoft\Templates|*.xlt;*.xltx;*.pot;*.potx;*.dot;*.dotx
-RegKey1=HKCU\SOFTWARE\Microsoft\Office\12.0\Common\OfficeStart\Web\Templates
-RegKey2=HKCU\SOFTWARE\Microsoft\Office\12.0\Excel\Recent Templates
-RegKey3=HKCU\SOFTWARE\Microsoft\Office\12.0\PowerPoint\Recent Templates
-RegKey4=HKCU\SOFTWARE\Microsoft\Office\12.0\Word\Recent Templates
-RegKey5=HKCU\SOFTWARE\Microsoft\Office\14.0\Common\OfficeStart\Web\Templates
-RegKey6=HKCU\SOFTWARE\Microsoft\Office\14.0\Excel\Recent Templates
-RegKey7=HKCU\SOFTWARE\Microsoft\Office\14.0\PowerPoint\Recent Templates
-RegKey8=HKCU\SOFTWARE\Microsoft\Office\14.0\Word\Recent Templates
-RegKey9=HKCU\SOFTWARE\Microsoft\Office\15.0\Common\OfficeStart\Web\Templates
-RegKey10=HKCU\SOFTWARE\Microsoft\Office\15.0\Excel\Recent Templates
-RegKey11=HKCU\SOFTWARE\Microsoft\Office\15.0\PowerPoint\Recent Templates
-RegKey12=HKCU\SOFTWARE\Microsoft\Office\15.0\Word\Recent Templates
-RegKey13=HKCU\SOFTWARE\Microsoft\Office\16.0\Common\OfficeStart\Web\Templates
-RegKey14=HKCU\SOFTWARE\Microsoft\Office\16.0\Excel\Recent Templates
-RegKey15=HKCU\SOFTWARE\Microsoft\Office\16.0\PowerPoint\Recent Templates
-RegKey16=HKCU\SOFTWARE\Microsoft\Office\16.0\Word\Recent Templates
+RegKey1=HKCU\Software\Microsoft\Office\12.0\Common\OfficeStart\Web\Templates
+RegKey2=HKCU\Software\Microsoft\Office\12.0\Excel\Recent Templates
+RegKey3=HKCU\Software\Microsoft\Office\12.0\PowerPoint\Recent Templates
+RegKey4=HKCU\Software\Microsoft\Office\12.0\Word\Recent Templates
+RegKey5=HKCU\Software\Microsoft\Office\14.0\Common\OfficeStart\Web\Templates
+RegKey6=HKCU\Software\Microsoft\Office\14.0\Excel\Recent Templates
+RegKey7=HKCU\Software\Microsoft\Office\14.0\PowerPoint\Recent Templates
+RegKey8=HKCU\Software\Microsoft\Office\14.0\Word\Recent Templates
+RegKey9=HKCU\Software\Microsoft\Office\15.0\Common\OfficeStart\Web\Templates
+RegKey10=HKCU\Software\Microsoft\Office\15.0\Excel\Recent Templates
+RegKey11=HKCU\Software\Microsoft\Office\15.0\PowerPoint\Recent Templates
+RegKey12=HKCU\Software\Microsoft\Office\15.0\Word\Recent Templates
+RegKey13=HKCU\Software\Microsoft\Office\16.0\Common\OfficeStart\Web\Templates
+RegKey14=HKCU\Software\Microsoft\Office\16.0\Excel\Recent Templates
+RegKey15=HKCU\Software\Microsoft\Office\16.0\PowerPoint\Recent Templates
+RegKey16=HKCU\Software\Microsoft\Office\16.0\Word\Recent Templates
 
 [MS Office Remove Hidden Data Tool Log*]
 LangSecRef=3021
@@ -11292,9 +11286,9 @@ FileKey2=%AppData%\Microsoft\PowerPoint|*.*|RECURSE
 FileKey3=%AppData%\Microsoft\Word|*.*|RECURSE
 FileKey4=%LocalAppData%\Microsoft\Office\UnsavedFiles|*.*|RECURSE
 ExcludeKey1=FILE|%AppData%\Microsoft\Word\|listgal.dat
-ExcludeKey2=PATH|%AppData%\Microsoft\Word\STARTUP\|*.*
-ExcludeKey3=PATH|%AppData%\Microsoft\Excel\XLSTART\|*.*
-ExcludeKey4=PATH|%AppData%\Microsoft\PowerPoint\|PPT*.pcb
+ExcludeKey2=PATH|%AppData%\Microsoft\Excel\XLSTART\|*.*
+ExcludeKey3=PATH|%AppData%\Microsoft\PowerPoint\|PPT*.pcb
+ExcludeKey4=PATH|%AppData%\Microsoft\Word\STARTUP\|*.*
 
 [MS PCHealth*]
 LangSecRef=3025
@@ -11976,9 +11970,9 @@ FileKey1=%AppData%\MusicNet|*.log
 [MWConn Logs*]
 LangSecRef=3022
 DetectFile1=%AppData%\Microsoft\Windows\Start Menu\Programs\MWconn
-DetectFile2=%AppData%\Microsoft\Windows\StartmenÃ¼\Programs\MWconn
+DetectFile2=%AppData%\Microsoft\Windows\Startmenü\Programs\MWconn
 DetectFile3=%UserProfile%\Start Menu\Programs\MWconn
-DetectFile4=%UserProfile%\StartmenÃ¼\Programme\MWconn
+DetectFile4=%UserProfile%\Startmenü\Programme\MWconn
 Default=False
 FileKey1=%AppData%\Microsoft\Windows\Start*\Program*\MWconn|connlog.txt
 FileKey2=%UserProfile%\Start*\Program*\MWconn|connlog.txt
@@ -11986,9 +11980,9 @@ FileKey2=%UserProfile%\Start*\Program*\MWconn|connlog.txt
 [MWConn SMS In*]
 LangSecRef=3022
 DetectFile1=%AppData%\Microsoft\Windows\Start Menu\Programs\MWconn
-DetectFile2=%AppData%\Microsoft\Windows\StartmenÃ¼\Programs\MWconn
+DetectFile2=%AppData%\Microsoft\Windows\Startmenü\Programs\MWconn
 DetectFile3=%UserProfile%\Start Menu\Programs\MWconn
-DetectFile4=%UserProfile%\StartmenÃ¼\Programme\MWconn
+DetectFile4=%UserProfile%\Startmenü\Programme\MWconn
 Default=False
 Warning=This will delete all of your received SMS messages.
 FileKey1=%AppData%\Microsoft\Windows\Start*\Program*\MWconn\sms_in|*.*|RECURSE
@@ -11997,9 +11991,9 @@ FileKey2=%UserProfile%\Start*\Program*\MWconn\sms_in|*.*|RECURSE
 [MWConn SMS Out*]
 LangSecRef=3022
 DetectFile1=%AppData%\Microsoft\Windows\Start Menu\Programs\MWconn
-DetectFile2=%AppData%\Microsoft\Windows\StartmenÃ¼\Programs\MWconn
+DetectFile2=%AppData%\Microsoft\Windows\Startmenü\Programs\MWconn
 DetectFile3=%UserProfile%\Start Menu\Programs\MWconn
-DetectFile4=%UserProfile%\StartmenÃ¼\Programme\MWconn
+DetectFile4=%UserProfile%\Startmenü\Programme\MWconn
 Default=False
 Warning=This will delete all of your sent SMS messages.
 FileKey1=%AppData%\Microsoft\Windows\Start*\Program*\MWconn\sms_out|*.*|RECURSE
@@ -12008,9 +12002,9 @@ FileKey2=%UserProfile%\Start*\Program*\MWconn\sms_out|*.*|RECURSE
 [MWConn SMS Send*]
 LangSecRef=3022
 DetectFile1=%AppData%\Microsoft\Windows\Start Menu\Programs\MWconn
-DetectFile2=%AppData%\Microsoft\Windows\StartmenÃ¼\Programs\MWconn
+DetectFile2=%AppData%\Microsoft\Windows\Startmenü\Programs\MWconn
 DetectFile3=%UserProfile%\Start Menu\Programs\MWconn
-DetectFile4=%UserProfile%\StartmenÃ¼\Programme\MWconn
+DetectFile4=%UserProfile%\Startmenü\Programme\MWconn
 Default=False
 Warning=This will delete all of your pending SMS messages.
 FileKey1=%AppData%\Microsoft\Windows\Start*\Program*\MWconn\sms_send|*.*|RECURSE
@@ -12025,7 +12019,7 @@ FileKey2=%LocalAppData%\My Family Tree\Temp|*.*|RECURSE
 
 [My Horse and Me*]
 Section=Games
-Detect=HKLM\SOFTWARE\My Horse and Me 2
+Detect=HKLM\Software\My Horse and Me 2
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Atari\Mein Pferd und ich*\System|++ Finish log.txt;++ Start log.txt;*.log|RECURSE
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Atari\My Horse and Me|++ Finish log.txt;++ Start log.txt;*.log|RECURSE
@@ -12172,7 +12166,7 @@ FileKey6=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\TempState|*
 
 [Neostar CMS Station Client Logs*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\company\Neostar CMS
+Detect=HKLM\Software\company\Neostar CMS
 Default=False
 FileKey1=%ProgramFiles%\Neostar CMS Station\Neostar CMS\Neostar CMS Client\log|*.*
 FileKey2=%ProgramFiles%\Neostar CMS Station\Neostar CMS\Neostar CMS Client\StreamServer|*.log
@@ -12599,7 +12593,7 @@ FileKey1=%AppData%\Norton Utilities\log|pgscan_*.html
 
 [Notepad++ More*]
 LangSecRef=3021
-Detect=HKLM\SOFTWARE\Notepad++
+Detect=HKLM\Software\Notepad++
 Default=False
 FileKey1=%AppData%\Notepad++\backup|*.*|REMOVESELF
 FileKey2=%AppData%\Notepad++\plugins\config|PluginManagerGpup.xml;PluginManagerPlugins.xml;PluginManagerPlugins.zip
@@ -12610,7 +12604,7 @@ DetectOS=10.0|
 LangSecRef=3025
 Default=False
 FileKey1=%LocalAppData%\Microsoft\Windows\Notifications|*.*|RECURSE
-RegKey1=HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Notifications\Data
+RegKey1=HKLM\Software\Microsoft\Windows NT\CurrentVersion\Notifications\Data
 
 [NowSmart Cut*]
 LangSecRef=3023
@@ -12620,7 +12614,7 @@ FileKey1=%LocalAppData%\Cut|log.txt;*.dmp
 
 [Nox*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\BigNox
+Detect=HKLM\Software\BigNox
 DetectFile=%UserProfile%\.BigNox
 Default=False
 FileKey1=%LocalAppData%\Nox|Nox.log.*;*.log
@@ -12646,7 +12640,7 @@ Default=False
 FileKey1=%LocalAppData%\Microsoft\Windows|UsrClass.bak
 FileKey2=%WinDir%\ServiceProfiles\LocalService|NTUSER.bak
 FileKey3=%WinDir%\ServiceProfiles\NetworkService|NTUSER.bak
-FileKey4=%WinDir%\System32\config|COMPONENTS.bak;SYSTEM.bak;DEFAULT.bak;SAM.bak;SECURITY.bak;SOFTWARE.bak
+FileKey4=%WinDir%\System32\config|COMPONENTS.bak;SYSTEM.bak;DEFAULT.bak;SAM.bak;SECURITY.bak;Software.bak
 
 [NTI Backup Now*]
 LangSecRef=3024
@@ -12870,8 +12864,8 @@ FileKey2=%ProgramFiles%\Tall Emu\Online Armor\Logs|*.*
 
 [Ontrack EasyRecovery Logs*]
 LangSecRef=3024
-Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{AE695CA4-8847-4462-98CC-023874D29E72}_is1
-Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{668CC71A-C2AD-4D56-866D-CF300BD1D5BE}_is1
+Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{668CC71A-C2AD-4D56-866D-CF300BD1D5BE}_is1
+Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{AE695CA4-8847-4462-98CC-023874D29E72}_is1
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Kroll Ontrack\Ontrack EasyRecovery*|*erent_log.txt;*erpro_log.txt
 FileKey2=%ProgramFiles%\Kroll Ontrack\Ontrack EasyRecovery*|*erent_log.txt;*erpro_log.txt
@@ -13063,8 +13057,8 @@ RegKey1=HKCU\Software\Microsoft\Orca\Recent File List
 
 [Orcs Must Die! Unchained Logs*]
 LangSecRef=Games
-Detect1=HKCU\Software\Valve\Steam\Apps\427270
-Detect2=HKCU\SOFTWARE\Robot Entertainment\Orcs Must Die! Unchained
+Detect1=HKCU\Software\Robot Entertainment\Orcs Must Die! Unchained
+Detect2=HKCU\Software\Valve\Steam\Apps\427270
 Default=False
 FileKey1=%Documents%\My Games\Orcs Must Die Unchained\SpitfireGame\Logs|*.log;*.dmg|RECURSE
 
@@ -13463,7 +13457,7 @@ FileKey5=%ProgramFiles%\Steam\steamapps\common\Path of Exile\logs|*.*
 
 [PAYDAY 2*]
 Section=Games
-Detect=HKCU\SOFTWARE\Valve\Steam\Apps\218620
+Detect=HKCU\Software\Valve\Steam\Apps\218620
 DetectFile=%LocalAppData%\PAYDAY 2
 Default=False
 FileKey1=%LocalAppData%\PAYDAY 2|crash.txt;crashlog.txt
@@ -13831,15 +13825,15 @@ FileKey1=%AppData%\Pipy\Logs|*.*
 [PKWARE PKZIP Logs*]
 LangSecRef=3024
 Detect1=HKCU\Software\PKWARE\PKZIP for Windows
-Detect2=HKCU\Software\PKWARE\ZIPReader 0
-Detect3=HKCU\Software\PKWARE\PKZIP70
+Detect2=HKCU\Software\PKWARE\PKZIP70
+Detect3=HKCU\Software\PKWARE\ZIPReader 0
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\PKWARE\PKZIPW|*.log
 FileKey2=%ProgramFiles%\PKWARE\PKZIPW|*.log
 
 [Planet Horse*]
 Section=Games
-Detect=HKLM\SOFTWARE\Big Fish Games\Persistence\Install\F6023T1L1
+Detect=HKLM\Software\Big Fish Games\Persistence\Install\F6023T1L1
 DetectFile=%ProgramFiles%\Planet Horse
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Planet Horse|output_log.txt|RECURSE
@@ -14032,7 +14026,7 @@ RegKey1=HKCU\Software\Trident Software\PowerZip\Recent File List
 
 [Predator Logs*]
 LangSecRef=3021
-Detect=HKLM\SOFTWARE\Predator-Usb
+Detect=HKLM\Software\Predator-Usb
 Default=False
 FileKey1=%CommonAppData%\Predator-Usb\PredatorACE\data|*.log
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Predator-Usb\PredatorACE\data|*.log
@@ -14417,10 +14411,10 @@ FileKey1=%LocalAppData%\QuickPar|*.*
 LangSecRef=3023
 Detect=HKLM\Software\Apple Computer, Inc.\QuickTime
 Default=False
-RegKey1=HKCU\Software\Classes\VirtualStore\MACHINE\SOFTWARE\Apple Computer, Inc.\QuickTime\Favorite Movies
-RegKey2=HKCU\Software\Classes\VirtualStore\MACHINE\SOFTWARE\Apple Computer, Inc.\QuickTime\Recent Movies
-RegKey3=HKCU\Software\Classes\VirtualStore\MACHINE\SOFTWARE\WOW6432Node\Apple Computer, Inc.\QuickTime\Favorite Movies
-RegKey4=HKCU\Software\Classes\VirtualStore\MACHINE\SOFTWARE\WOW6432Node\Apple Computer, Inc.\QuickTime\Recent Movies
+RegKey1=HKCU\Software\Classes\VirtualStore\MACHINE\Software\Apple Computer, Inc.\QuickTime\Favorite Movies
+RegKey2=HKCU\Software\Classes\VirtualStore\MACHINE\Software\Apple Computer, Inc.\QuickTime\Recent Movies
+RegKey3=HKCU\Software\Classes\VirtualStore\MACHINE\Software\WOW6432Node\Apple Computer, Inc.\QuickTime\Favorite Movies
+RegKey4=HKCU\Software\Classes\VirtualStore\MACHINE\Software\WOW6432Node\Apple Computer, Inc.\QuickTime\Recent Movies
 
 [QuizUp*]
 DetectOS=10.0|
@@ -14740,7 +14734,7 @@ FileKey1=%AppData%\Systweak\RegClean Pro\Version 6.1|*.log
 
 [RegEditX More*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\DCSoft\RegEditX
+Detect=HKLM\Software\DCSoft\RegEditX
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\DCSoft\RegEditX\*|RegEditX.sav;RegEditX.bak
 RegKey1=HKLM\Software\4Developers\RCrawler\History
@@ -15194,7 +15188,7 @@ FileKey1=%Documents%\samsung\Kies*\backup|*.*|RECURSE
 LangSecRef=3023
 Detect1=HKCU\Software\Samsung\Kies2.0
 Detect2=HKCU\Software\Samsung\Kies3.0
-Detect3=HKLM\SOFTWARE\SAMSUNG\USB_DRIVER
+Detect3=HKLM\Software\SAMSUNG\USB_DRIVER
 Default=False
 FileKey1=%AppData%\Samsung\Kies|*.mlca;*.mlme;*.mlpb;*.mlpgb;|RECURSE
 FileKey2=%CommonAppData%\Samsung\Device Error Recovery|*.*
@@ -15239,9 +15233,9 @@ FileKey1=%ProgramFiles%\*Santa* Rampage|*.diz;*.nfo;*.txt;*.url;dotNetFx40_Full_
 FileKey2=%ProgramFiles%\*Santa* Rampage\Redist|*.*|REMOVESELF
 FileKey3=%ProgramFiles%\*Santa* Rampage\UDKGame\Logs|*.*|REMOVESELF
 ExcludeKey1=FILE|%ProgramFiles%\*Santa* Rampage\UDKGame\CookedPC\|Manifest.txt
-ExcludeKey2=PATH|%ProgramFiles%\*Santa* Rampage\UDKGame\Script\|*.*
-ExcludeKey3=PATH|%ProgramFiles%\*Santa* Rampage\Binaries\Win32\|*.*
-ExcludeKey4=PATH|%ProgramFiles%\*Santa* Rampage\Binaries\Win64\|*.*
+ExcludeKey2=PATH|%ProgramFiles%\*Santa* Rampage\Binaries\Win32\|*.*
+ExcludeKey3=PATH|%ProgramFiles%\*Santa* Rampage\Binaries\Win64\|*.*
+ExcludeKey4=PATH|%ProgramFiles%\*Santa* Rampage\UDKGame\Script\|*.*
 
 [Sauerbraten*]
 Section=Games
@@ -15329,9 +15323,9 @@ FileKey1=%AppData%\Scribus\scrapbook\tmp|*.*|RECURSE
 
 [SdfBrowser*]
 LangSecRef=3024
-DetectFile=%AppData%\BokorBÃ©la\SdfBrowser
+DetectFile=%AppData%\BokorBéla\SdfBrowser
 Default=False
-FileKey1=%AppData%\BokorBÃ©la\SdfBrowser|*.log
+FileKey1=%AppData%\BokorBéla\SdfBrowser|*.log
 
 [Seagate Dashboard*]
 LangSecRef=3024
@@ -15343,7 +15337,7 @@ FileKey3=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\Seagate\Seagate 
 
 [Seagate SeaTools for Windows Logs*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\SeaToolsforWindows
+Detect=HKLM\Software\SeaToolsforWindows
 Default=False
 FileKey1=%AppData%\Dexpot|*.log
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Seagate\SeaTools for Windows|*.log
@@ -15487,7 +15481,7 @@ FileKey1=%WinDir%\System32\LogFiles\Scm|*.*|RECURSE
 
 [Serviio Logs*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\Serviio
+Detect=HKLM\Software\Serviio
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Serviio\log|*.*
 FileKey2=%ProgramFiles%\Serviio\log|*.*
@@ -16355,12 +16349,12 @@ FileKey5=%LocalAppData%\VirtualStore\ProgramData\Spybot - Search & Destroy\Syste
 LangSecRef=3024
 Detect=HKLM\Software\Safer Networking Limited\SpybotSnD
 Default=False
-FileKey1=%CommonAppData%\Spybot â€“ Search & Destroy\Backups|*.*|RECURSE
-FileKey2=%CommonAppData%\Spybot â€“ Search & Destroy\Recovery|*.*|RECURSE
-FileKey3=%CommonAppData%\Spybot â€“ Search & Destroy\Snapshots*|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Spybot â€“ Search & Destroy\Backups|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Spybot â€“ Search & Destroy\Recovery|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Spybot â€“ Search & Destroy\Snapshots*|*.*|RECURSE
+FileKey1=%CommonAppData%\Spybot – Search & Destroy\Backups|*.*|RECURSE
+FileKey2=%CommonAppData%\Spybot – Search & Destroy\Recovery|*.*|RECURSE
+FileKey3=%CommonAppData%\Spybot – Search & Destroy\Snapshots*|*.*|RECURSE
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\Spybot – Search & Destroy\Backups|*.*|RECURSE
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\Spybot – Search & Destroy\Recovery|*.*|RECURSE
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Spybot – Search & Destroy\Snapshots*|*.*|RECURSE
 
 [Spybot Search and Destroy Hosts Backups*]
 LangSecRef=3024
@@ -16514,7 +16508,7 @@ FileKey14=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\swtor\retailc
 
 [StarCraft II*]
 Section=Games
-Detect=HKLM\SOFTWARE\Blizzard Entertainment\StarCraft II
+Detect=HKLM\Software\Blizzard Entertainment\StarCraft II
 Default=False
 FileKey1=%CommonAppData%\Blizzard Entertainment\Starcraft II\Maps\Cache|*.*|RECURSE
 FileKey2=%Documents%\StarCraft II\EditorLogs|*.*|RECURSE
@@ -16526,13 +16520,13 @@ FileKey7=%ProgramFiles%\Starcraft II\Logs|*.*
 
 [StarCraft II Editor Recent Files*]
 Section=Games
-Detect=HKLM\SOFTWARE\Blizzard Entertainment\StarCraft II Editor
+Detect=HKLM\Software\Blizzard Entertainment\StarCraft II Editor
 Default=False
 RegKey1=HKCU\Software\Blizzard Entertainment\StarCraft II Editor\Recent Files
 
 [StarCraft II More*]
 Section=Games
-Detect=HKLM\SOFTWARE\Blizzard Entertainment\StarCraft II
+Detect=HKLM\Software\Blizzard Entertainment\StarCraft II
 Default=False
 Warning=This will delete all of your image uploads, replays, and screenshots.
 FileKey1=%Documents%\StarCraft II\ImageUploads|*.*|RECURSE
@@ -16759,8 +16753,8 @@ FileKey1=%AppData%\STOIK\videopak2|*.ini
 [Store*]
 Section=3031
 Default=False
-Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\WinStore_cw5n1h2txyewy
-Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsStore_8wekyb3d8bbwe
+Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsStore_8wekyb3d8bbwe
+Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\WinStore_cw5n1h2txyewy
 FileKey1=%LocalAppData%\Packages\*Win*Store_*\AC\AppCache|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\*Win*Store_*\AC\INet*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\*Win*Store_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
@@ -17013,8 +17007,8 @@ RegKey2=HKCU\Software\grigsoft.com\Synchronize It!\Synchronize It!\Combos
 
 [Syncios Cell Phone Backup & Manage*]
 Section=3024
-Detect1=HKCU\SOFTWARE\Syncios Data Transfer
-Detect2=HKCU\SOFTWARE\Syncios
+Detect1=HKCU\Software\Syncios
+Detect2=HKCU\Software\Syncios Data Transfer
 Default=False
 FileKey1=%AppData%\Syncios|android.log;log.txt
 FileKey2=%AppData%\Syncios Data Transfer|*.log
@@ -17451,8 +17445,8 @@ FileKey5=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\TempState\Bing.Maps
 
 [The Witcher*]
 Section=Games
-Detect1=HKCU\Software\Valve\Steam\Apps\20900
-Detect2=HKCU\Software\Valve\Steam\Apps\105430
+Detect1=HKCU\Software\Valve\Steam\Apps\105430
+Detect2=HKCU\Software\Valve\Steam\Apps\20900
 Default=False
 FileKey1=%LocalAppData%\The Witcher\logs|*.*
 
@@ -17881,7 +17875,7 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData\Trend Micro|*.log
 
 [TrendMicro RUBotted Logs*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\TrendMicro\RUBotted
+Detect=HKLM\Software\TrendMicro\RUBotted
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Trend Micro\RUBotted\DebugLogs|*.*|REMOVESELF
 FileKey2=%ProgramFiles%\Trend Micro\RUBotted\DebugLogs|*.*|REMOVESELF
@@ -17943,8 +17937,8 @@ FileKey2=%ProgramFiles%\TrojanHunter*\Scan Reports|*.*
 
 [Tropico*]
 Section=Games
-Detect1=HKLM\Software\Haemimont Games\Tropico3
-Detect2=HKCU\Software\Haemimont Games\Tropico 4
+Detect1=HKCU\Software\Haemimont Games\Tropico 4
+Detect2=HKLM\Software\Haemimont Games\Tropico3
 Default=False
 FileKey1=%AppData%\Tropico*\logs|*.*|REMOVESELF
 FileKey2=%AppData%\Tropico*\ShaderCache|*.*|REMOVESELF
@@ -17968,7 +17962,7 @@ FileKey3=%Windir%\System32\config\systemprofile\AppData\Local\Trusteer\Rapport\u
 [Tubebox!*]
 LangSecRef=3023
 DetectFile1=%UserProfile%\Start Menu\Programs\TubeBox!
-DetectFile2=%UserProfile%\StartmenÃ¼\Programme\TubeBox!
+DetectFile2=%UserProfile%\Startmenü\Programme\TubeBox!
 Default=False
 FileKey1=%UserProfile%\Start*\Program*\TubeBox!|TubeBox!-Log.txt
 
@@ -18017,8 +18011,8 @@ FileKey5=%ProgramFiles%\TVersity\Media Server\logs|*.log;*.txt;*.xml;*.zip|RECUR
 FileKey6=%WinDir%\System32|tversity.cookies;TVersityMediaServer.log;*.1;*.2;*.3
 FileKey7=%WinDir%\System32\config\systemprofile\AppData\Local\Temp\TVersity Media Server|*.*|REMOVESELF
 FileKey8=%WinDir%\System32\config\systemprofile\Local Settings\Application Data\Temp\TVersity Media Server|*.*|REMOVESELF
-ExcludeKey1=PATH|%ProgramFiles%\TVersity\Media Server\|*version.txt;*HOWTO Share Media.txt
-ExcludeKey2=FILE|%ProgramFiles%\TVersity Codec Pack\|uninst.exe
+ExcludeKey1=FILE|%ProgramFiles%\TVersity Codec Pack\|uninst.exe
+ExcludeKey2=PATH|%ProgramFiles%\TVersity\Media Server\|*version.txt;*HOWTO Share Media.txt
 
 [TVUPlayer*]
 LangSecRef=3023
@@ -18036,8 +18030,8 @@ FileKey1=%LocalAppData%\The Weather Channel\Desktop\patch|*.*
 [Tweaking.com Windows Repair*]
 LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Tweaking.com - Windows Repair (All in One)
-DetectFile1=%SystemDrive%\Tweaking.com_Windows_Repair_Logs
-DetectFile2=%ProgramFiles%\Tweaking.com
+DetectFile1=%ProgramFiles%\Tweaking.com
+DetectFile2=%SystemDrive%\Tweaking.com_Windows_Repair_Logs
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Tweaking.com\Windows Repair (All in One)\Logs|*.*|REMOVESELF
 FileKey2=%ProgramFiles%\Tweaking.com\Windows Repair (All in One)\Logs|*.*|REMOVESELF
@@ -18140,7 +18134,7 @@ FileKey2=%ProgramFiles%\Disktrix\UltimateDefrag|*.db;*Crash.dmp
 
 [UltraDefrag Logs*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\UltraDefrag
+Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\UltraDefrag
 DetectFile=%WinDir%\UltraDefrag\ultradefrag.exe
 Default=False
 FileKey1=%ProgramFiles%\UltraDefrag\logs|*.*
@@ -18245,8 +18239,8 @@ FileKey2=%ProgramFiles%\Unlocker|Unlocker-List.txt
 
 [Unlockroot*]
 LangSecRef=3024
-Detect1=HKLM\Software\UnlockrootPro
-Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\unlockroot.exe
+Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\unlockroot.exe
+Detect2=HKLM\Software\UnlockrootPro
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Unlockroot|*.txt
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Unlockroot Pro|*.txt
@@ -18316,9 +18310,9 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData|AsACPLog.*
 
 [UsbFix*]
 LangSecRef=3023
-Detect=HKCU\SOFTWARE\UsbFix
+Detect=HKCU\Software\UsbFix
 Default=False
-RegKey1=HKCU\SOFTWARE\UsbFix\LastReport
+RegKey1=HKCU\Software\UsbFix\LastReport
 FileKey1=%SystemDrive%\UsbFix|Log|REMOVESELF
 FileKey2=%SystemDrive%\UsbFix|Quarantine|REMOVESELF
 FileKey3=%UserProfile%\Desktop|UsbFix_Report.txt
@@ -18517,9 +18511,9 @@ FileKey10=%LocalAppData%\VirtualStore\ProgramData\VMware\VMware vCenter Converte
 FileKey11=%LocalAppData%\VMware\VMware vCenter Converter Standalone Client\Logs|*.log;*.gz
 FileKey12=%ProgramFiles%\VMware\VMware vCenter Converter Standalone|*.rtf;*.zip|RECURSE
 FileKey13=%ProgramFiles%\VMware\VMware VIX|*.txt;*.rtf
-ExcludeKey1=PATH|%ProgramFiles%\VMware\VMware vCenter Converter Standalone\Help\|*.txt
-ExcludeKey2=FILE|%ProgramFiles%\VMware\VMware VIX\|vixwrapper-config.txt
-ExcludeKey3=FILE|%ProgramFiles%\VMware\VMware Workstation\|vixwrapper-product-config.txt
+ExcludeKey1=FILE|%ProgramFiles%\VMware\VMware VIX\|vixwrapper-config.txt
+ExcludeKey2=FILE|%ProgramFiles%\VMware\VMware Workstation\|vixwrapper-product-config.txt
+ExcludeKey3=PATH|%ProgramFiles%\VMware\VMware vCenter Converter Standalone\Help\|*.txt
 
 [VNCViewer 5*]
 LangSecRef=3024
@@ -18548,15 +18542,15 @@ FileKey6=%WinDir%|ModemLog_*.txt
 
 [VoidTools Search Everything*]
 LangSecRef=3024
-DetectFile1=%ProgramFiles%\Everything
-DetectFile2=%AppData%\Everything
+DetectFile1=%AppData%\Everything
+DetectFile2=%ProgramFiles%\Everything
 Default=False
 FileKey1=%AppData%\Everything|*.csv;*.txt;*.tmp
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Everything|*.txt;*.csv;*.tmp
 FileKey3=%ProgramFiles%\Everything|*.csv;*.txt;*.tmp
 ExcludeKey1=FILE|%AppData%\Everything\|Filters.csv
-ExcludeKey2=FILE|%ProgramFiles%\Everything\|Filters.csv
-ExcludeKey3=FILE|%LocalAppData%\VirtualStore\Program Files*\Everything\|Filters.csv
+ExcludeKey2=FILE|%LocalAppData%\VirtualStore\Program Files*\Everything\|Filters.csv
+ExcludeKey3=FILE|%ProgramFiles%\Everything\|Filters.csv
 
 [VoipBuster Logs*]
 LangSecRef=3022
@@ -18570,7 +18564,7 @@ FileKey3=%WinDir%\SysWOW64|VoipBuster*.log
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-RegKey1=HKLM\SOFTWARE\Microsoft\Windows Search\VolumeInfoCache
+RegKey1=HKLM\Software\Microsoft\Windows Search\VolumeInfoCache
 
 [Vopt 9*]
 LangSecRef=3024
@@ -19213,8 +19207,8 @@ RegKey3=HKCU\Software\Microsoft\Windows Live\Photo Gallery|galleryscopedfolders
 
 [Windows Live Setup Logs*]
 LangSecRef=3022
-Detect1=HKLM\Software\Microsoft\Windows Live
-Detect2=HKCU\Software\Microsoft\Windows Live Mail
+Detect1=HKCU\Software\Microsoft\Windows Live Mail
+Detect2=HKLM\Software\Microsoft\Windows Live
 Default=False
 FileKey1=%CommonAppData%\Microsoft\WLSetup\*logs|*.*|RECURSE
 FileKey2=%CommonAppData%\WLInstaller|*.log
@@ -19232,7 +19226,7 @@ FileKey3=%LocalAppData%\VirtualStore\ProgramData\Microsoft\WLSetup|*.tmp
 
 [Windows Live Writer Logs*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\Microsoft\Windows Live Writer
+Detect=HKLM\Software\Microsoft\Windows Live Writer
 Default=False
 FileKey1=%LocalAppData%\Windows Live Writer|*.log
 
@@ -19585,7 +19579,7 @@ FileKey2=%SystemDrive%\ThumbnailCache|*.*
 
 [Wistron Corp Launch Manager Logs*]
 LangSecRef=3024
-Detect=HKLM\SOFTWARE\Wistron Corp\Launch Manager
+Detect=HKLM\Software\Wistron Corp\Launch Manager
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Launch Manager|*.log
 FileKey2=%ProgramFiles%\Launch Manager|*.log
@@ -19617,7 +19611,7 @@ ExcludeKey1=FILE|%ProgramFiles%\WolfQuest\|Help.txt
 
 [Wondershare AllMyTube*]
 LangSecRef=3022
-Detect=HKLM\SOFTWARE\Wondershare\Wondershare AllMyTube
+Detect=HKLM\Software\Wondershare\Wondershare AllMyTube
 Default=False
 FileKey1=%AppData%\Wondershare AllMyTube|*.*|RECURSE
 FileKey2=%CommonAppData%\Wondershare AllMyTube\ConvertedLibPic|*.*|RECURSE
@@ -19630,7 +19624,7 @@ FileKey8=%ProgramFiles%\Wondershare\AllMyTube\Log|*.*|RECURSE
 
 [Wondershare dr.fone toolkit for Android*]
 LangSecRef=3021
-Detect=HKLM\SOFTWARE\Wondershare\dr.fone toolkit for Android
+Detect=HKLM\Software\Wondershare\dr.fone toolkit for Android
 Default=False
 FileKey1=%CommonAppData%\Wondershare\DrFoneAndroid\log|*.*|RECURSE
 FileKey2=%CommonAppData%\Wondershare\WAF\Log|*.*|RECURSE
@@ -19641,7 +19635,7 @@ FileKey6=%CommonAppData%\Wondershare\WSRoot\Logs|*.*|RECURSE
 
 [Wondershare dr.fone toolkit for iOS*]
 LangSecRef=3021
-Detect=HKLM\SOFTWARE\Wondershare\dr.fone toolkit for iOS
+Detect=HKLM\Software\Wondershare\dr.fone toolkit for iOS
 Default=False
 FileKey1=%CommonAppData%\Wondershare\DrFoneiOS\DBCache\NormalMode|*.*|RECURSE
 FileKey2=%CommonAppData%\Wondershare\DrFoneiOS\log|*.*|RECURSE
@@ -19660,11 +19654,11 @@ FileKey5=%LocalAppData%\VirtualStore\Program Files*\Common Files\Wondershare\Won
 FileKey6=%LocalAppData%\VirtualStore\Program Files*\Common Files\Wondershare\Wondershare Helper Compact\Log|*.*|RECURSE
 FileKey7=%LocalAppData%\VirtualStore\Program Files*\Common Files\Wondershare\Wondershare Helper Compact\Temp|*.*|RECURSE
 RegKey1=HKLM\Software\Wondershare\Wondershare Helper Compact
-RegKey2=HKLM\SOFTWARE\Wow6432Node\Wondershare\Wondershare Helper Compact
+RegKey2=HKLM\Software\Wow6432Node\Wondershare\Wondershare Helper Compact
 
 [Wondershare MobileGo*]
 LangSecRef=3021
-Detect=HKCU\SOFTWARE\Wondershare\MobileGo
+Detect=HKCU\Software\Wondershare\MobileGo
 DetectFile=%AppData%\Wondershare\MobileGo for iOS
 Default=False
 FileKey1=%AppData%\se_tmp|*.*|REMOVESELF
@@ -19705,7 +19699,7 @@ FileKey9=%SystemDrive%\se_tmp|*.*|REMOVESELF
 
 [Wondershare Video Converter Ultimate More*]
 LangSecRef=3023
-Detect=HKLM\SOFTWARE\Wondershare\Wondershare Video Converter Ultimate
+Detect=HKLM\Software\Wondershare\Wondershare Video Converter Ultimate
 Default=False
 FileKey1=%CommonAppData%\Wondershare\ProductFeatures\*Logs|*.*|RECURSE
 FileKey2=%Documents%\Wondershare MediaServer\log|*.*|RECURSE

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
-; Version: 171115
-; # of entries: 2,376
+; Version: 171124
+; # of entries: 2,355
 ; You can get the latest Winapp2 here: https://github.com/MoscaDotTo/Winapp2
 ; Any contributions are appreciated. Please send them to the link above.
 ; Is CCleaner taking too long to load with Winapp2? Please head to this link and follow the instructions: http://www.winapp2.com/howto.html
@@ -50,17 +50,17 @@ Detect2=HKCU\Software\SuperBird
 Detect3=HKCU\Software\Torch
 Detect4=HKCU\Software\Vivaldi
 Default=False
-FileKey1=%LocalAppData%\Amigo\User Data\*\Application Cache|*.*|REMOVESELF
-FileKey2=%LocalAppData%\Chrome Plus\User Data\*\Application Cache|*.*|REMOVESELF
-FileKey3=%LocalAppData%\Chromium\User Data\*\Application Cache|*.*|REMOVESELF
-FileKey4=%LocalAppData%\Flock\User Data\*\Application Cache|*.*|REMOVESELF
-FileKey5=%LocalAppData%\Google\Chrome*\User Data\*\Application Cache|*.*|REMOVESELF
-FileKey6=%LocalAppData%\Rockmelt\User Data\*\Application Cache|*.*|REMOVESELF
-FileKey7=%LocalAppData%\SRWare Iron\User Data\*\Application Cache|*.*|REMOVESELF
-FileKey8=%LocalAppData%\SuperBird\User Data\*\Application Cache|*.*|REMOVESELF
-FileKey9=%LocalAppData%\Torch\User Data\*\Application Cache|*.*|REMOVESELF
-FileKey10=%LocalAppData%\Vivaldi\User Data\*\Application Cache|*.*|REMOVESELF
-FileKey11=%AppData%\Brave\*\Application Cache|*.*|REMOVESELF
+FileKey1=%AppData%\Brave\*\Application Cache|*.*|REMOVESELF
+FileKey2=%LocalAppData%\Amigo\User Data\*\Application Cache|*.*|REMOVESELF
+FileKey3=%LocalAppData%\Chrome Plus\User Data\*\Application Cache|*.*|REMOVESELF
+FileKey4=%LocalAppData%\Chromium\User Data\*\Application Cache|*.*|REMOVESELF
+FileKey5=%LocalAppData%\Flock\User Data\*\Application Cache|*.*|REMOVESELF
+FileKey6=%LocalAppData%\Google\Chrome*\User Data\*\Application Cache|*.*|REMOVESELF
+FileKey7=%LocalAppData%\Rockmelt\User Data\*\Application Cache|*.*|REMOVESELF
+FileKey8=%LocalAppData%\SRWare Iron\User Data\*\Application Cache|*.*|REMOVESELF
+FileKey9=%LocalAppData%\SuperBird\User Data\*\Application Cache|*.*|REMOVESELF
+FileKey10=%LocalAppData%\Torch\User Data\*\Application Cache|*.*|REMOVESELF
+FileKey11=%LocalAppData%\Vivaldi\User Data\*\Application Cache|*.*|REMOVESELF
 
 [Chrome Crash Reports*]
 LangSecRef=3029
@@ -196,17 +196,17 @@ Detect2=HKCU\Software\SuperBird
 Detect3=HKCU\Software\Torch
 Detect4=HKCU\Software\Vivaldi
 Default=False
-FileKey1=%LocalAppData%\Amigo\User Data\*\GPUCache|*.*
-FileKey2=%LocalAppData%\Chrome Plus\User Data\*\GPUCache|*.*
-FileKey3=%LocalAppData%\Chromium\User Data\*\GPUCache|*.*
-FileKey4=%LocalAppData%\Flock\User Data\*\GPUCache|*.*
-FileKey5=%LocalAppData%\Google\Chrome*\User Data\*\GPUCache|*.*
-FileKey6=%LocalAppData%\Rockmelt\User Data\*\GPUCache|*.*
-FileKey7=%LocalAppData%\SRWare Iron\User Data\*\GPUCache|*.*
-FileKey8=%LocalAppData%\SuperBird\User Data\*\GPUCache|*.*
-FileKey9=%LocalAppData%\Torch\User Data\*\GPUCache|*.*
-FileKey10=%LocalAppData%\Vivaldi\User Data\*\GPUCache|*.*
-FileKey11=%AppData%\Brave\*\GPUCache|*.*
+FileKey1=%AppData%\Brave\*\GPUCache|*.*
+FileKey2=%LocalAppData%\Amigo\User Data\*\GPUCache|*.*
+FileKey3=%LocalAppData%\Chrome Plus\User Data\*\GPUCache|*.*
+FileKey4=%LocalAppData%\Chromium\User Data\*\GPUCache|*.*
+FileKey5=%LocalAppData%\Flock\User Data\*\GPUCache|*.*
+FileKey6=%LocalAppData%\Google\Chrome*\User Data\*\GPUCache|*.*
+FileKey7=%LocalAppData%\Rockmelt\User Data\*\GPUCache|*.*
+FileKey8=%LocalAppData%\SRWare Iron\User Data\*\GPUCache|*.*
+FileKey9=%LocalAppData%\SuperBird\User Data\*\GPUCache|*.*
+FileKey10=%LocalAppData%\Torch\User Data\*\GPUCache|*.*
+FileKey11=%LocalAppData%\Vivaldi\User Data\*\GPUCache|*.*
 
 [History*]
 LangSecRef=3029
@@ -253,10 +253,10 @@ Detect1=HKCU\Software\Vivaldi
 Default=False
 FileKey1=%LocalAppData%\Google\Chrome*\Application\*\Installer|*.*|RECURSE
 FileKey2=%LocalAppData%\Google\Update\*\*\Installer|*.*|RECURSE
-FileKey3=%ProgramFiles%\|GUT*tmp
-FileKey4=%ProgramFiles%\Google\Chrome*\Application\*\Installer|*.*|RECURSE
-FileKey5=%ProgramFiles%\Google\Update\*\*\Installer|*.*|RECURSE
-FileKey6=%LocalAppData%\Vivaldi\Application\*\Installer|*.*|RECURSE
+FileKey3=%LocalAppData%\Vivaldi\Application\*\Installer|*.*|RECURSE
+FileKey4=%ProgramFiles%\|GUT*tmp
+FileKey5=%ProgramFiles%\Google\Chrome*\Application\*\Installer|*.*|RECURSE
+FileKey6=%ProgramFiles%\Google\Update\*\*\Installer|*.*|RECURSE
 
 [JumpListIconsRecentClosed*]
 LangSecRef=3029
@@ -272,17 +272,17 @@ Detect2=HKCU\Software\SuperBird
 Detect3=HKCU\Software\Torch
 Detect4=HKCU\Software\Vivaldi
 Default=False
-FileKey1=%LocalAppData%\Amigo\User Data\*\Local Storage|http*.*|RECURSE
-FileKey2=%LocalAppData%\Chrome Plus\User Data\*\Local Storage|http*.*|RECURSE
-FileKey3=%LocalAppData%\Chromium\User Data\*\Local Storage|http*.*|RECURSE
-FileKey4=%LocalAppData%\Flock\User Data\*\Local Storage|http*.*|RECURSE
-FileKey5=%LocalAppData%\Google\Chrome*\User Data\*\Local Storage|http*.*|RECURSE
-FileKey6=%LocalAppData%\Rockmelt\User Data\*\Local Storage|http*.*|RECURSE
-FileKey7=%LocalAppData%\SRWare Iron\User Data\*\Local Storage|http*.*|RECURSE
-FileKey8=%LocalAppData%\SuperBird\User Data\*\Local Storage|http*.*|RECURSE
-FileKey9=%LocalAppData%\Torch\User Data\*\Local Storage|http*.*|RECURSE
-FileKey10=%LocalAppData%\Vivaldi\User Data\*\Local Storage|http*.*|RECURSE
-FileKey11=%AppData%\Brave\*\Local Storage|http*.*|RECURSE
+FileKey1=%AppData%\Brave\*\Local Storage|http*.*|RECURSE
+FileKey2=%LocalAppData%\Amigo\User Data\*\Local Storage|http*.*|RECURSE
+FileKey3=%LocalAppData%\Chrome Plus\User Data\*\Local Storage|http*.*|RECURSE
+FileKey4=%LocalAppData%\Chromium\User Data\*\Local Storage|http*.*|RECURSE
+FileKey5=%LocalAppData%\Flock\User Data\*\Local Storage|http*.*|RECURSE
+FileKey6=%LocalAppData%\Google\Chrome*\User Data\*\Local Storage|http*.*|RECURSE
+FileKey7=%LocalAppData%\Rockmelt\User Data\*\Local Storage|http*.*|RECURSE
+FileKey8=%LocalAppData%\SRWare Iron\User Data\*\Local Storage|http*.*|RECURSE
+FileKey9=%LocalAppData%\SuperBird\User Data\*\Local Storage|http*.*|RECURSE
+FileKey10=%LocalAppData%\Torch\User Data\*\Local Storage|http*.*|RECURSE
+FileKey11=%LocalAppData%\Vivaldi\User Data\*\Local Storage|http*.*|RECURSE
 
 [Logs*]
 LangSecRef=3029
@@ -292,29 +292,29 @@ Detect2=HKCU\Software\SuperBird
 Detect3=HKCU\Software\Torch
 Detect4=HKCU\Software\Vivaldi
 Default=False
-FileKey1=%LocalAppData%\Amigo\Application|debug.log
-FileKey2=%LocalAppData%\Amigo\User Data\*\*|*LOG.*;Log;*.log;*.old|RECURSE
-FileKey3=%LocalAppData%\Chrome Plus\Application|debug.log
-FileKey4=%LocalAppData%\Chrome Plus\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
-FileKey5=%LocalAppData%\Chromium\Application|debug.log
-FileKey6=%LocalAppData%\Chromium\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
-FileKey7=%LocalAppData%\Flock\Application|debug.log
-FileKey8=%LocalAppData%\Flock\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
-FileKey9=%LocalAppData%\Google\Chrome*\Application|debug.log
-FileKey10=%LocalAppData%\Google\Chrome*\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
-FileKey11=%LocalAppData%\Google\Chrome Cleanup Tool|*.log
-FileKey12=%LocalAppData%\Rockmelt\Application|debug.log
-FileKey13=%LocalAppData%\Rockmelt\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
-FileKey14=%LocalAppData%\SRWare Iron\Application|debug.log
-FileKey15=%LocalAppData%\SRWare Iron\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
-FileKey16=%LocalAppData%\SuperBird\Application|debug.log
-FileKey17=%LocalAppData%\SuperBird\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
-FileKey18=%LocalAppData%\Torch\Application|debug.log
-FileKey19=%LocalAppData%\Torch\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
-FileKey20=%LocalAppData%\VirtualStore\Program Files*\Google\Chrome*\Application|debug.log
-FileKey21=%LocalAppData%\Vivaldi\Application|debug.log
-FileKey22=%LocalAppData%\Vivaldi\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
-FileKey23=%AppData%\Brave\*|*LOG.*;Log;*.log;*.old|RECURSE
+FileKey1=%AppData%\Brave\*|*LOG.*;Log;*.log;*.old|RECURSE
+FileKey2=%LocalAppData%\Amigo\Application|debug.log
+FileKey3=%LocalAppData%\Amigo\User Data\*\*|*LOG.*;Log;*.log;*.old|RECURSE
+FileKey4=%LocalAppData%\Chrome Plus\Application|debug.log
+FileKey5=%LocalAppData%\Chrome Plus\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
+FileKey6=%LocalAppData%\Chromium\Application|debug.log
+FileKey7=%LocalAppData%\Chromium\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
+FileKey8=%LocalAppData%\Flock\Application|debug.log
+FileKey9=%LocalAppData%\Flock\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
+FileKey10=%LocalAppData%\Google\Chrome Cleanup Tool|*.log
+FileKey11=%LocalAppData%\Google\Chrome*\Application|debug.log
+FileKey12=%LocalAppData%\Google\Chrome*\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
+FileKey13=%LocalAppData%\Rockmelt\Application|debug.log
+FileKey14=%LocalAppData%\Rockmelt\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
+FileKey15=%LocalAppData%\SRWare Iron\Application|debug.log
+FileKey16=%LocalAppData%\SRWare Iron\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
+FileKey17=%LocalAppData%\SuperBird\Application|debug.log
+FileKey18=%LocalAppData%\SuperBird\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
+FileKey19=%LocalAppData%\Torch\Application|debug.log
+FileKey20=%LocalAppData%\Torch\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
+FileKey21=%LocalAppData%\VirtualStore\Program Files*\Google\Chrome*\Application|debug.log
+FileKey22=%LocalAppData%\Vivaldi\Application|debug.log
+FileKey23=%LocalAppData%\Vivaldi\User Data\*|*LOG.*;Log;*.log;*.old|RECURSE
 ExcludeKey1=PATH|%LocalAppData%\Amigo\User Data\*\Extensions\|*.*
 ExcludeKey2=PATH|%LocalAppData%\Amigo\User Data\*\File System\|*.*
 ExcludeKey3=PATH|%LocalAppData%\Amigo\User Data\*\Local App Settings\|*.*
@@ -422,25 +422,25 @@ Detect2=HKCU\Software\SuperBird
 Detect3=HKCU\Software\Torch
 Detect4=HKCU\Software\Vivaldi
 Default=False
-FileKey1=%LocalAppData%\Amigo\User Data\*\Session Storage|*.*|RECURSE
-FileKey2=%LocalAppData%\Chrome Plus\User Data\*\Session Storage|*.*|RECURSE
-FileKey3=%LocalAppData%\Chromium\User Data\*\Session Storage|*.*|RECURSE
-FileKey4=%LocalAppData%\Flock\User Data\*\Session Storage|*.*|RECURSE
-FileKey5=%LocalAppData%\Google\Chrome*\User Data\*\Session Storage|*.*|RECURSE
-FileKey6=%LocalAppData%\Rockmelt\User Data\*\Session Storage|*.*|RECURSE
-FileKey7=%LocalAppData%\SRWare Iron\User Data\*\Session Storage|*.*|RECURSE
-FileKey8=%LocalAppData%\SuperBird\User Data\*\Session Storage|*.*|RECURSE
-FileKey9=%LocalAppData%\Torch\User Data\*\Session Storage|*.*|RECURSE
-FileKey10=%LocalAppData%\Vivaldi\User Data\*\Session Storage|*.*|RECURSE
-FileKey11=%AppData%\Brave\*\Session Storage|*.*|RECURSE
+FileKey1=%AppData%\Brave\*\Session Storage|*.*|RECURSE
+FileKey2=%LocalAppData%\Amigo\User Data\*\Session Storage|*.*|RECURSE
+FileKey3=%LocalAppData%\Chrome Plus\User Data\*\Session Storage|*.*|RECURSE
+FileKey4=%LocalAppData%\Chromium\User Data\*\Session Storage|*.*|RECURSE
+FileKey5=%LocalAppData%\Flock\User Data\*\Session Storage|*.*|RECURSE
+FileKey6=%LocalAppData%\Google\Chrome*\User Data\*\Session Storage|*.*|RECURSE
+FileKey7=%LocalAppData%\Rockmelt\User Data\*\Session Storage|*.*|RECURSE
+FileKey8=%LocalAppData%\SRWare Iron\User Data\*\Session Storage|*.*|RECURSE
+FileKey9=%LocalAppData%\SuperBird\User Data\*\Session Storage|*.*|RECURSE
+FileKey10=%LocalAppData%\Torch\User Data\*\Session Storage|*.*|RECURSE
+FileKey11=%LocalAppData%\Vivaldi\User Data\*\Session Storage|*.*|RECURSE
 
 [SetupMetrics*]
 LangSecRef=3029
 SpecialDetect=DET_CHROME
 Detect1=HKCU\Software\Vivaldi
 Default=False
-FileKey1=%ProgramFiles%\Google\Chrome\Application\SetupMetrics|*.*|RECURSE
-FileKey2=%LocalAppData%\Vivaldi\Application\SetupMetrics|*.*|RECURSE
+FileKey1=%LocalAppData%\Vivaldi\Application\SetupMetrics|*.*|RECURSE
+FileKey2=%ProgramFiles%\Google\Chrome\Application\SetupMetrics|*.*|RECURSE
 
 [Software Reporter Tool*]
 LangSecRef=3029
@@ -600,8 +600,8 @@ LangSecRef=3026
 SpecialDetect=DET_MOZILLA
 Default=False
 FileKey1=%CommonAppData%\Mozilla*\logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Mozilla*\logs|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Mozilla Maintenance Service\logs|*.log
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Mozilla Maintenance Service\logs|*.log
+FileKey3=%LocalAppData%\VirtualStore\ProgramData\Mozilla*\logs|*.*
 FileKey4=%ProgramFiles%\Mozilla Maintenance Service\logs|*.log
 
 [Minidumps*]
@@ -621,8 +621,8 @@ LangSecRef=3026
 DetectFile1=%ProgramFiles%\Nightly
 DetectFile2=%ProgramFiles%\Mozilla\Nightly
 Default=False
-FileKey1=%ProgramFiles%\Nightly.bak|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Mozilla\Nightly.bak|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\Mozilla\Nightly.bak|*.*|REMOVESELF
+FileKey2=%ProgramFiles%\Nightly.bak|*.*|REMOVESELF
 
 [Session Backups*]
 LangSecRef=3026
@@ -786,12 +786,6 @@ FileKey1=%AppData%\Thunderbird\Profiles\*|webappsstore.sqlite
 
 ; End of Thunderbird entries.
 
-[.NET Framework Cache*]
-LangSecRef=3025
-Detect=HKLM\Software\Microsoft\.NETFramework
-Default=False
-FileKey1=%WinDir%\Microsoft.NET\Framework*\v4.0.30319\SetupCache|*.*|RECURSE
-
 [.NET Framework*]
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\.NETFramework
@@ -804,12 +798,18 @@ FileKey5=%WinDir%\Microsoft.NET\Framework*\*\Temporary ASP.NET Files|*.*|REMOVES
 FileKey6=%WinDir%\System32\URTTemp|*.*|RECURSE
 RegKey1=HKCU\Software\Microsoft\.NETFramework\SQM\Apps
 
+[.NET Framework Cache*]
+LangSecRef=3025
+Detect=HKLM\Software\Microsoft\.NETFramework
+Default=False
+FileKey1=%WinDir%\Microsoft.NET\Framework*\v4.0.30319\SetupCache|*.*|RECURSE
+
 [.NET Reflector*]
 LangSecRef=3021
 DetectFile=%LocalAppData%\Red Gate\.NET Reflector 6\Reflector.cfg
 Default=False
-FileKey1=%LocalAppData%\Red Gate\.NET Reflector 6\Cache|*.*|RECURSE
-FileKey2=%LocalAppData%\Red Gate\.NET Reflector 6|Reflector.cfg
+FileKey1=%LocalAppData%\Red Gate\.NET Reflector 6|Reflector.cfg
+FileKey2=%LocalAppData%\Red Gate\.NET Reflector 6\Cache|*.*|RECURSE
 
 [.Thumbnails*]
 LangSecRef=3021
@@ -821,44 +821,9 @@ FileKey1=%UserProfile%\.Thumbnails|*.*|RECURSE
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\270090
 Default=False
-FileKey1=%LocalAppData%\NPPDRUSH\Cache|*.*|RECURSE
-FileKey2=%LocalAppData%\NPPDRUSH\GPUCache|*.*|RECURSE
-FileKey3=%LocalAppData%\NPPDRUSH|Web Data*|RECURSE
-
-[10 Years After*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\339240
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\10 Years After\10 Years After_Data|output_log.txt
-FileKey2=%ProgramFiles%\Steam\SteamApps\common\10 Years After\10 Years After_Data|output_log.txt
-
-[1000 Amps*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\205690
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\1000 Amps|stdout.txt
-FileKey2=%ProgramFiles%\Steam\SteamApps\common\1000 Amps|stdout.txt
-
-[140*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\242820
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\140\140_Data|output_log.txt
-FileKey2=%ProgramFiles%\Steam\SteamApps\common\140\140_Data|output_log.txt
-
-[18 Wheels of Steel*]
-Section=Games
-Detect=HKCU\Software\ValuSoft
-Default=False
-FileKey1=%Documents%\18 WoS*|*.log;*.crash
-
-[1954 Alcatraz*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\255280
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\1954 Alcatraz\Alcatraz_Data|output_log.txt
-FileKey2=%LocalLowAppData%\Daedalic Entertainment\1954 Alcatraz|*.log
-FileKey3=%ProgramFiles%\Steam\SteamApps\common\1954 Alcatraz\Alcatraz_Data|output_log.txt
+FileKey1=%LocalAppData%\NPPDRUSH|Web Data*|RECURSE
+FileKey2=%LocalAppData%\NPPDRUSH\Cache|*.*|RECURSE
+FileKey3=%LocalAppData%\NPPDRUSH\GPUCache|*.*|RECURSE
 
 [1Click DVD Copy Pro*]
 LangSecRef=3023
@@ -872,52 +837,6 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\278530
 Default=False
 FileKey1=%AppData%\3Stars|*.tmp
-
-[32bit Web Browser*]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\32BITWEB\32BW.exe
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\32BITWEB\Data|LastURL.dat;LastURL.da0
-FileKey2=%ProgramFiles%\32BITWEB\Data|LastURL.dat;LastURL.da0
-
-[360 Browser - Cache*]
-LangSecRef=3029
-Detect=HKCU\Software\360Browser\Browser
-Default=False
-FileKey1=%LocalAppData%\360Browser\Browser\User Data\Default|*-journal*
-FileKey2=%LocalAppData%\360Browser\Browser\User Data\Default\Cache|*.*
-FileKey3=%LocalAppData%\360Browser\Browser\User Data\Default\Local Storage|*.*
-ExcludeKey1=FILE|%LocalAppData%\360Browser\Browser\User Data\Default\|Login data-journal
-ExcludeKey2=FILE|%LocalAppData%\360Browser\Browser\User Data\Default\|switcher-journal
-ExcludeKey3=FILE|%LocalAppData%\360Browser\Browser\User Data\Default\|Web data-journal
-
-[360 Browser - Cookies*]
-LangSecRef=3029
-Detect=HKCU\Software\360Browser\Browser
-Default=False
-FileKey1=%LocalAppData%\360Browser\Browser\User Data\Default|Cookies
-
-[360 Browser - History*]
-LangSecRef=3029
-Detect=HKCU\Software\360Browser\Browser
-Default=False
-FileKey1=%LocalAppData%\360Browser\Browser\User Data\Default|Archived History;Current Tabs;History Provider Cache;Network Action Predictor;Top Sites;Visited Links
-
-[360 Browser - Session*]
-LangSecRef=3029
-Detect=HKCU\Software\360Browser\Browser
-Default=False
-FileKey1=%LocalAppData%\360Browser\Browser\User Data\Default|Current*
-FileKey2=%LocalAppData%\360Browser\Browser\User Data\Default|Last*
-
-[360 Internet Security Logs*]
-LangSecRef=3024
-Detect=HKCU\Software\360Safe
-Default=False
-FileKey1=%AppData%\360safe\360ScanLog|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\360\360 Internet Security|*.log*|RECURSE
-FileKey3=%ProgramFiles%\360\360 Internet Security|*.log*|RECURSE
-FileKey4=%SystemDrive%\360SANDBOX|*.log*|RECURSE
 
 [3D Builder*]
 DetectOS=10.0|
@@ -945,25 +864,11 @@ DetectFile=%Documents%\3DMark
 Default=False
 FileKey1=%Documents%\3DMark|*.3dmark-result
 
-[3GP Video Converter*]
-LangSecRef=3024
-Detect=HKCU\Software\ImTOO\3GP Video Converter
-Default=False
-RegKey1=HKCU\Software\ImTOO\3GP Video Converter\Settings|last_openpath
-RegKey2=HKCU\Software\ImTOO\3GP Video Converter\Settings|OutputDir
-
 [3SwitcheD*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\206610
 Default=False
 FileKey1=%LocalAppData%\3SwitcheD\cache|*.*|RECURSE
-
-[3ware 3DM2*]
-LangSecRef=3024
-Detect=HKU\.DEFAULT\Software\3ware\3DM2
-Default=False
-FileKey1=%CommonAppData%\3ware|tw_mgmt.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\3ware|tw_mgmt.log
 
 [4K Video Downloader*]
 LangSecRef=3023
@@ -993,17 +898,17 @@ DetectFile=%AppData%\4Team\4Team-Updater
 Default=False
 FileKey1=%AppData%\4Team\4Team-Updater\Logs|*.*
 
-[7Star - GPU Cache*]
-LangSecRef=3029
-Detect=HKCU\Software\7Star
-Default=False
-FileKey1=%LocalAppData%\7Star\7Star\User Data\Default\GPUCache|*.*|RECURSE
-
 [7Star Browser - Cookies*]
 LangSecRef=3029
 Detect=HKCU\Software\7Star
 Default=False
 FileKey1=%LocalAppData%\7Star\7Star\User Data\Default|Cookies;Cookies-journal
+
+[7Star Browser - GPU Cache*]
+LangSecRef=3029
+Detect=HKCU\Software\7Star
+Default=False
+FileKey1=%LocalAppData%\7Star\7Star\User Data\Default\GPUCache|*.*|RECURSE
 
 [7Star Browser - Internet Cache*]
 LangSecRef=3029
@@ -1050,6 +955,87 @@ LangSecRef=3024
 Detect=HKCU\Software\7z SFX Builder
 Default=False
 RegKey1=HKCU\Software\7z SFX Builder\MRU
+
+[10 Years After*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\339240
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\10 Years After\10 Years After_Data|output_log.txt
+FileKey2=%ProgramFiles%\Steam\SteamApps\common\10 Years After\10 Years After_Data|output_log.txt
+
+[1000 Amps*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\205690
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\1000 Amps|stdout.txt
+FileKey2=%ProgramFiles%\Steam\SteamApps\common\1000 Amps|stdout.txt
+
+[140*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\242820
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\140\140_Data|output_log.txt
+FileKey2=%ProgramFiles%\Steam\SteamApps\common\140\140_Data|output_log.txt
+
+[18 Wheels of Steel*]
+Section=Games
+Detect=HKCU\Software\ValuSoft
+Default=False
+FileKey1=%Documents%\18 WoS*|*.log;*.crash
+
+[1954 Alcatraz*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\255280
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\1954 Alcatraz\Alcatraz_Data|output_log.txt
+FileKey2=%LocalLowAppData%\Daedalic Entertainment\1954 Alcatraz|*.log
+FileKey3=%ProgramFiles%\Steam\SteamApps\common\1954 Alcatraz\Alcatraz_Data|output_log.txt
+
+[32bit Web Browser*]
+LangSecRef=3022
+DetectFile=%ProgramFiles%\32BITWEB\32BW.exe
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\32BITWEB\Data|LastURL.dat;LastURL.da0
+FileKey2=%ProgramFiles%\32BITWEB\Data|LastURL.dat;LastURL.da0
+
+[360 Browser - Cache*]
+LangSecRef=3029
+Detect=HKCU\Software\360Browser\Browser
+Default=False
+FileKey1=%LocalAppData%\360Browser\Browser\User Data\Default|*-journal*
+FileKey2=%LocalAppData%\360Browser\Browser\User Data\Default\Cache|*.*
+FileKey3=%LocalAppData%\360Browser\Browser\User Data\Default\Local Storage|*.*
+ExcludeKey1=FILE|%LocalAppData%\360Browser\Browser\User Data\Default\|Login data-journal
+ExcludeKey2=FILE|%LocalAppData%\360Browser\Browser\User Data\Default\|switcher-journal
+ExcludeKey3=FILE|%LocalAppData%\360Browser\Browser\User Data\Default\|Web data-journal
+
+[360 Browser - Cookies*]
+LangSecRef=3029
+Detect=HKCU\Software\360Browser\Browser
+Default=False
+FileKey1=%LocalAppData%\360Browser\Browser\User Data\Default|Cookies
+
+[360 Browser - History*]
+LangSecRef=3029
+Detect=HKCU\Software\360Browser\Browser
+Default=False
+FileKey1=%LocalAppData%\360Browser\Browser\User Data\Default|Archived History;Current Tabs;History Provider Cache;Network Action Predictor;Top Sites;Visited Links
+
+[360 Browser - Session*]
+LangSecRef=3029
+Detect=HKCU\Software\360Browser\Browser
+Default=False
+FileKey1=%LocalAppData%\360Browser\Browser\User Data\Default|Current*
+FileKey2=%LocalAppData%\360Browser\Browser\User Data\Default|Last*
+
+[360 Internet Security Logs*]
+LangSecRef=3024
+Detect=HKCU\Software\360Safe
+Default=False
+FileKey1=%AppData%\360safe\360ScanLog|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\360\360 Internet Security|*.log*|RECURSE
+FileKey3=%ProgramFiles%\360\360 Internet Security|*.log*|RECURSE
+FileKey4=%SystemDrive%\360SANDBOX|*.log*|RECURSE
 
 [A58-Easytune6 Logs*]
 LangSecRef=3024
@@ -1100,8 +1086,8 @@ Detect=HKCU\Software\Ability 6.0
 Default=False
 FileKey1=%Documents%\My Ability Files|*.*|RECURSE
 RegKey1=HKCU\Software\Ability 6.0\Ability Database\Recent File List
-RegKey2=HKCU\Software\Ability 6.0\Ability PhotoPaint\Recent File List
-RegKey3=HKCU\Software\Ability 6.0\Ability PhotoPaint Studio\Recent File List
+RegKey2=HKCU\Software\Ability 6.0\Ability PhotoPaint Studio\Recent File List
+RegKey3=HKCU\Software\Ability 6.0\Ability PhotoPaint\Recent File List
 RegKey4=HKCU\Software\Ability 6.0\Ability Spreadsheet\Recent File List
 RegKey5=HKCU\Software\Ability 6.0\Ability Write\Files
 
@@ -1115,9 +1101,9 @@ FileKey1=%AppData%\Ableton\Cache|*.*|RECURSE
 LangSecRef=3023
 Detect=HKLM\Software\Propellerhead Software\ReWire\Ableton Live Engine
 Default=False
-FileKey1=%AppData%\Ableton\Live Reports\Temp|*.*|REMOVESELF
-FileKey2=%AppData%\Ableton\Live Reports\Usage|*.*|REMOVESELF
-FileKey3=%AppData%\Ableton\*\Preferences|AsioLog.txt;Indexer.txt;Log.txt|RECURSE
+FileKey1=%AppData%\Ableton\*\Preferences|AsioLog.txt;Indexer.txt;Log.txt|RECURSE
+FileKey2=%AppData%\Ableton\Live Reports\Temp|*.*|REMOVESELF
+FileKey3=%AppData%\Ableton\Live Reports\Usage|*.*|REMOVESELF
 FileKey4=%CommonAppData%\Ableton\*\Redist|vcredist*.exe
 FileKey5=%ProgramFiles%\Ableton\*\Redist|vcredist*.exe
 
@@ -1183,8 +1169,8 @@ RegKey3=HKCU\Software\ACD Systems\ACDSee\60|LastOptionPageName
 RegKey4=HKCU\Software\ACD Systems\ACDSee\60|OpenFolder
 RegKey5=HKCU\Software\ACD Systems\ACDSee\60\PrintOptions\OutputContactSheet|ContactSheetFN
 RegKey6=HKCU\Software\ACD Systems\ACDSee\60\PrintOptions\OutputContactSheet|ImageMapFN
-RegKey7=HKU\S-1-5-21-1202660629-854245398-1801674531-1003\Software\ACD Systems\ACDSee\60|HistPaths
-RegKey8=HKU\S-1-5-21-1202660629-854245398-1801674531-1003\Software\ACD Systems\ACDSee\60|HistMCFDestFolder
+RegKey7=HKU\S-1-5-21-1202660629-854245398-1801674531-1003\Software\ACD Systems\ACDSee\60|HistMCFDestFolder
+RegKey8=HKU\S-1-5-21-1202660629-854245398-1801674531-1003\Software\ACD Systems\ACDSee\60|HistPaths
 RegKey9=HKU\S-1-5-21-1202660629-854245398-1801674531-1003\Software\ACD Systems\ACDSee\60|LastOptionPageName
 RegKey10=HKU\S-1-5-21-1202660629-854245398-1801674531-1003\Software\ACD Systems\ACDSee\60|OpenFolder
 RegKey11=HKU\S-1-5-21-1202660629-854245398-1801674531-1003\Software\ACD Systems\ACDSee\60\PrintOptions\OutputContactSheet|ContactSheetFN
@@ -1295,10 +1281,10 @@ RegKey2=HKLM\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\Volu
 LangSecRef=3024
 Detect=HKLM\Software\LSoft Technologies\Active Disk Image
 Default=False
-FileKey1=%ProgramFiles%\LSoft Technologies\Active@ Disk Image|*.txt
-FileKey2=%ProgramFiles%\LSoft Technologies\Active@ Disk Image\Logs|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\LSoft Technologies\Active@ Disk Image|*.txt
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\LSoft Technologies\Active@ Disk Image\Logs|*.*|REMOVESELF
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\LSoft Technologies\Active@ Disk Image|*.txt
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\LSoft Technologies\Active@ Disk Image\Logs|*.*|REMOVESELF
+FileKey3=%ProgramFiles%\LSoft Technologies\Active@ Disk Image|*.txt
+FileKey4=%ProgramFiles%\LSoft Technologies\Active@ Disk Image\Logs|*.*|REMOVESELF
 
 [Active@ File Recovery*]
 LangSecRef=3024
@@ -1476,9 +1462,9 @@ Default=False
 FileKey1=%AppData%\Adobe\amecommand\6.0|Plugin Loading.log
 FileKey2=%AppData%\Adobe\Elements Organizer\*\Organizer|*.txt;status.dat
 FileKey3=%AppData%\Adobe\Elements Smart Tag Agent\*\Logs|*.log
-FileKey4=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog\Watch Folder|*.txt;*.xml
-FileKey5=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog|face.thumb.9.cache;thumb.5.cache
-FileKey6=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog\WaldoData\waldo.cache
+FileKey4=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog|face.thumb.9.cache;thumb.5.cache
+FileKey5=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog\WaldoData\waldo.cache
+FileKey6=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog\Watch Folder|*.txt;*.xml
 RegKey1=HKCU\Software\Adobe\Elements Organizer\11.0\CurrentMediaFilePath
 RegKey2=HKCU\Software\Adobe\Elements Organizer\12.0\CurrentMediaFilePath
 RegKey3=HKCU\Software\Adobe\Elements Organizer\13.0\CurrentMediaFilePath
@@ -1516,9 +1502,9 @@ FileKey1=%Documents%\My Digital Editions|import.log
 LangSecRef=3021
 Detect=HKCU\Software\Adobe
 Default=False
-FileKey1=%ProgramFiles%\Adobe\Adobe\AdobePatchFiles|*.*|RECURSE
-FileKey2=%ProgramFiles%\Common Files\Adobe\Adobe\AdobePatchFiles|*.*|RECURSE
-FileKey3=%CommonAppData%\Adobe\CameraRaw\Adobe\AdobePatchFiles|*.*|RECURSE
+FileKey1=%CommonAppData%\Adobe\CameraRaw\Adobe\AdobePatchFiles|*.*|RECURSE
+FileKey2=%ProgramFiles%\Adobe\Adobe\AdobePatchFiles|*.*|RECURSE
+FileKey3=%ProgramFiles%\Common Files\Adobe\Adobe\AdobePatchFiles|*.*|RECURSE
 
 [Adobe Photoshop 5.5*]
 LangSecRef=3021
@@ -1537,8 +1523,8 @@ LangSecRef=3021
 Detect=HKCU\Software\Adobe\Photoshop\9.0
 DetectFile1=%AppData%\Adobe\*\Cache
 Default=False
-FileKey1=%AppData%\Adobe\CameraRaw\Cache|*.*|RECURSE
-FileKey2=%AppData%\Adobe\Bridge\Cache\Thumbnails|*.*|RECURSE
+FileKey1=%AppData%\Adobe\Bridge\Cache\Thumbnails|*.*|RECURSE
+FileKey2=%AppData%\Adobe\CameraRaw\Cache|*.*|RECURSE
 FileKey3=%Pictures%|.BridgeSort|RECURSE
 
 [Adobe Photoshop Elements*]
@@ -1566,9 +1552,9 @@ RegKey15=HKCU\Software\Adobe\Photoshop Elements\15.0\VisitedDirs|STARTUPIMAGEDIR
 LangSecRef=3023
 Detect=HKCU\Software\Adobe\Premiere Elements
 Default=False
-FileKey1=%CommonAppData%\|StreamingMediaTechnologyLog.txt
+FileKey1=%AppData%\Adobe\Premiere Elements\*|Plugin Loading.log
 FileKey2=%AppData%\Adobe\Premiere Elements\*\logs|*.*|RECURSE
-FileKey3=%AppData%\Adobe\Premiere Elements\*|Plugin Loading.log
+FileKey3=%CommonAppData%\|StreamingMediaTechnologyLog.txt
 FileKey4=%Documents%\Adobe\Premiere Elements\*|*.log
 FileKey5=%Documents%\NewBlueFX\Logs|*.txt
 RegKey1=HKCU\Software\Adobe\Premiere Elements\11.0\MRUDocuments
@@ -1645,10 +1631,10 @@ Default=False
 FileKey1=%AppData%\Adobe\Acrobat\*\Updater|*.log
 FileKey2=%AppData%\Adobe\LogTransport*\Logs|ulog_*.tmp
 FileKey3=%CommonAppData%\Adobe\ARM|*.*|RECURSE
-FileKey4=%ProgramFiles%\Common Files\Adobe\Installers|*.log.gz|RECURSE
-FileKey5=%LocalAppData%\Adobe\AAMUpdater|*.Log|RECURSE
-FileKey6=%LocalAppData%\Adobe\Acrobat\*\Updater|*.log
-FileKey7=%LocalAppData%\Adobe\Updater*|*.log|RECURSE
+FileKey4=%LocalAppData%\Adobe\AAMUpdater|*.Log|RECURSE
+FileKey5=%LocalAppData%\Adobe\Acrobat\*\Updater|*.log
+FileKey6=%LocalAppData%\Adobe\Updater*|*.log|RECURSE
+FileKey7=%ProgramFiles%\Common Files\Adobe\Installers|*.log.gz|RECURSE
 
 [Advanced Browser*]
 LangSecRef=3022
@@ -1697,14 +1683,6 @@ RegKey2=HKLM\Software\AdwCleaner|SearchCount
 RegKey3=HKLM\Software\Wow6432node\AdwCleaner|DeleteCount
 RegKey4=HKLM\Software\Wow6432node\AdwCleaner|SearchCount
 
-[Aegisub Backups*]
-LangSecRef=3023
-Detect=HKLM\Software\Aegisub
-Default=False
-Warning=Aegisub automatically saves a backup copy of each script you open. This will delete them.
-FileKey1=%AppData%\Aegisub\autoback|*.*|REMOVESELF
-FileKey2=%AppData%\Aegisub\autosave|*.*|REMOVESELF
-
 [Aegisub*]
 LangSecRef=3023
 Detect=HKLM\Software\Aegisub
@@ -1716,6 +1694,14 @@ FileKey4=%LocalAppData%\Aegisub\ffms2cache|*.*|REMOVESELF
 FileKey5=%LocalAppData%\VirtualStore\Program Files*\Aegisub|*.txt
 FileKey6=%ProgramFiles%\Aegisub|*.txt
 
+[Aegisub Backups*]
+LangSecRef=3023
+Detect=HKLM\Software\Aegisub
+Default=False
+Warning=Aegisub automatically saves a backup copy of each script you open. This will delete them.
+FileKey1=%AppData%\Aegisub\autoback|*.*|REMOVESELF
+FileKey2=%AppData%\Aegisub\autosave|*.*|REMOVESELF
+
 [Age of Conan*]
 Section=Games
 Detect=HKLM\Software\Funcom\Age of Conan
@@ -1724,13 +1710,6 @@ FileKey1=%LocalAppData%\VirtualStore\Program Files*\Funcom\Age of Conan|patcher.
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Funcom\Age of Conan\OldLogs|*.*
 FileKey3=%ProgramFiles%\Funcom\Age of Conan|patcher.log;chrome_debug.log;MiniDump.dmp;CrashLog.txt;ConanPatcher.exe.0.tmp;AgeOfConan.log
 FileKey4=%ProgramFiles%\Funcom\Age of Conan\OldLogs|*.*
-
-[Age of Empires Online*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\105430
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Age Of Empires Online|PatchLog.txt;PatchLogDetail.txt
-FileKey2=%ProgramFiles%\Steam\steamapps\common\Age Of Empires Online|PatchLog.txt;PatchLogDetail.txt
 
 [Age of Empires*]
 Section=Games
@@ -1743,11 +1722,18 @@ FileKey2=%Documents%\My Games\Age of Empires 3\RM|*.dmp.txt
 FileKey3=%Documents%\My Games\Age of Mythology|*.txt
 RegKey1=HKLM\Software\Microsoft\Games\Age of Empires\1.00|Zone
 RegKey2=HKLM\Software\Microsoft\Microsoft Games\Age of Empires|Zone
-RegKey3=HKLM\Software\Microsoft\Microsoft Games\Age of Empires\2.0|Zone
-RegKey4=HKLM\Software\Microsoft\Microsoft Games\Age of Empires Expansion\1.0|Zone
-RegKey5=HKLM\Software\Microsoft\Microsoft Games\Age of Empires II: The Conquerors Expansion\1.0|Zone
+RegKey3=HKLM\Software\Microsoft\Microsoft Games\Age of Empires Expansion\1.0|Zone
+RegKey4=HKLM\Software\Microsoft\Microsoft Games\Age of Empires II: The Conquerors Expansion\1.0|Zone
+RegKey5=HKLM\Software\Microsoft\Microsoft Games\Age of Empires\2.0|Zone
 ExcludeKey1=PATH|%ProgramFiles%\Microsoft Games\Age of Empires III\|*Readme.rtf;*ReadmeX.rtf;*ReadmeY.rtf
 ExcludeKey2=PATH|%ProgramFiles%\Microsoft Games\Age of Mythology\|*Readme.rtf;*Readmex.rtf
+
+[Age of Empires Online*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\105430
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Age Of Empires Online|PatchLog.txt;PatchLogDetail.txt
+FileKey2=%ProgramFiles%\Steam\steamapps\common\Age Of Empires Online|PatchLog.txt;PatchLogDetail.txt
 
 [Age of Oracles Taras Journey*]
 Section=Games
@@ -1842,6 +1828,15 @@ Detect=HKCU\Software\FinalWire\AIDA64
 Default=False
 FileKey1=%Documents%\AIDA64 Reports|*.*|REMOVESELF
 
+[Aignes Website-Watcher*]
+LangSecRef=3023
+Detect=HKCU\SOFTWARE\aignes\wswatch
+Default=False
+FileKey1=%AppData%\aignes\WebSite-Watcher\config\favicons|*.*
+FileKey2=%AppData%\aignes\website-watcher\config\log|*.*
+FileKey3=%AppData%\aignes\WebSite-Watcher\config\settings|*.cfg_bak*
+FileKey4=%AppData%\aignes\website-watcher\config\temp|*.*
+
 [Aignes Website-Watcher AutoBackup*]
 LangSecRef=3023
 Warning=This will delete your AutoBackup of your site.
@@ -1855,15 +1850,6 @@ Warning=This will delete all of your Bookmarks.
 Detect=HKCU\Software\aignes\wswatch
 Default=False
 FileKey1=%AppData%\aignes\website-watcher\bookmarks|*.*
-
-[Aignes Website-Watcher*]
-LangSecRef=3023
-Detect=HKCU\SOFTWARE\aignes\wswatch
-Default=False
-FileKey1=%AppData%\aignes\WebSite-Watcher\config\favicons|*.*
-FileKey2=%AppData%\aignes\website-watcher\config\log|*.*
-FileKey3=%AppData%\aignes\WebSite-Watcher\config\settings|*.cfg_bak*
-FileKey4=%AppData%\aignes\website-watcher\config\temp|*.*
 
 [AIM*]
 LangSecRef=3022
@@ -1909,9 +1895,9 @@ DetectFile2=%ProgramFiles%\AIMP Classic\cAIMP.exe
 Default=False
 FileKey1=%AppData%\AIMP|*.bak
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\AIMP2\Data|*.bak|RECURSE
-FileKey3=%ProgramFiles%\AIMP2\Data|*.bak|RECURSE
+FileKey3=%ProgramFiles%\AIMP Classic\Data|*.bak|RECURSE
 FileKey4=%ProgramFiles%\AIMP\!Backup|*.*|REMOVESELF
-FileKey5=%ProgramFiles%\AIMP Classic\Data|*.bak|RECURSE
+FileKey5=%ProgramFiles%\AIMP2\Data|*.bak|RECURSE
 
 [AirBuccaneers*]
 Section=Games
@@ -2072,6 +2058,13 @@ DetectFile=%Documents%\Amazon Downloader Logs
 Default=False
 FileKey1=%Documents%\Amazon Downloader Logs|*.*|RECURSE
 
+[Amazon Kindle for PC*]
+LangSecRef=3023
+Detect=HKCU\Software\Amazon\Kindle
+Default=False
+FileKey1=%LocalAppData%\Amazon\Kindle\Cache|*.*|RECURSE
+FileKey2=%LocalAppData%\Amazon\Kindle\Logs|*.txt|RECURSE
+
 [Amazon Kindle for PC Session*]
 LangSecRef=3023
 Detect=HKCU\Software\Amazon\Kindle
@@ -2087,13 +2080,6 @@ RegKey8=HKCU\Software\Amazon\Kindle\User Settings|LastSyncDate5
 RegKey9=HKCU\Software\Amazon\Kindle\User Settings|LastSyncDate6
 RegKey10=HKCU\Software\Amazon\Kindle\User Settings|LastSyncDate7
 RegKey11=HKCU\Software\Amazon\Kindle\User Settings|OpenBook
-
-[Amazon Kindle for PC*]
-LangSecRef=3023
-Detect=HKCU\Software\Amazon\Kindle
-Default=False
-FileKey1=%LocalAppData%\Amazon\Kindle\Cache|*.*|RECURSE
-FileKey2=%LocalAppData%\Amazon\Kindle\Logs|*.txt|RECURSE
 
 [Amazon MP3 Downloader Log*]
 LangSecRef=3023
@@ -2121,20 +2107,20 @@ FileKey2=%CommonAppData%\AMD\KDB|*.log
 FileKey3=%LocalAppData%\AMD\Fuel|ClientProxyLog*.*
 FileKey4=%LocalAppData%\AMD\GLCache|*.*|RECURSE
 FileKey5=%LocalAppData%\ATI\ACE|*.txt
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\AMD\OverDrive|*.log
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\AMD\amdkmpfd|*.*|REMOVESELF
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\ATI\CIM\Reports|*.*
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\ATI Technologies|*.log|RECURSE
-FileKey10=%LocalAppData%\VirtualStore\Program Files*\ATI Technologies|cccutil64.txt
+FileKey6=%LocalAppData%\VirtualStore\Program Files*\AMD\amdkmpfd|*.*|REMOVESELF
+FileKey7=%LocalAppData%\VirtualStore\Program Files*\AMD\OverDrive|*.log
+FileKey8=%LocalAppData%\VirtualStore\Program Files*\ATI Technologies|*.log|RECURSE
+FileKey9=%LocalAppData%\VirtualStore\Program Files*\ATI Technologies|cccutil64.txt
+FileKey10=%LocalAppData%\VirtualStore\Program Files*\ATI\CIM\Reports|*.*
 FileKey11=%LocalAppData%\VirtualStore\ProgramData\AMD\Fuel|*.txt
 FileKey12=%LocalAppData%\VirtualStore\ProgramData\AMD\KDB|*.log
-FileKey13=%ProgramFiles%\AMD\OverDrive|*.log
-FileKey14=%ProgramFiles%\AMD\amdkmpfd|*.*|REMOVESELF
-FileKey15=%ProgramFiles%\ATI\CIM\Reports|*.*
-FileKey16=%ProgramFiles%\ATI Technologies|*.log|RECURSE
-FileKey17=%ProgramFiles%\ATI Technologies|cccutil64.txt
-FileKey18=%SystemDrive%\ATI|*.*|REMOVESELF
-FileKey19=%SystemDrive%\AMD|*.*|REMOVESELF
+FileKey13=%ProgramFiles%\AMD\amdkmpfd|*.*|REMOVESELF
+FileKey14=%ProgramFiles%\AMD\OverDrive|*.log
+FileKey15=%ProgramFiles%\ATI Technologies|*.log|RECURSE
+FileKey16=%ProgramFiles%\ATI Technologies|cccutil64.txt
+FileKey17=%ProgramFiles%\ATI\CIM\Reports|*.*
+FileKey18=%SystemDrive%\AMD|*.*|REMOVESELF
+FileKey19=%SystemDrive%\ATI|*.*|REMOVESELF
 FileKey20=%WinDir%\System32|CCCInstall*.log
 FileKey21=%WinDir%\SysWOW64|CCCInstall*.log
 
@@ -2167,8 +2153,8 @@ FileKey6=%UserProfile%\amsn\displaypic\cache|*.*
 LangSecRef=3021
 DetectFile=%CommonAppData%\Package Cache\3DBECED19CFC2819A7E0BE14463CF18FC8720D91\amyuni_pdfconverter_5_00
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\ProgramData\Package Cache\3DBECED19CFC2819A7E0BE14463CF18FC8720D91\amyuni_pdfconverter_5_00|*.log|RECURSE
-FileKey2=%CommonAppData%\Package Cache\3DBECED19CFC2819A7E0BE14463CF18FC8720D91\amyuni_pdfconverter_5_00|*.log|RECURSE
+FileKey1=%CommonAppData%\Package Cache\3DBECED19CFC2819A7E0BE14463CF18FC8720D91\amyuni_pdfconverter_5_00|*.log|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\ProgramData\Package Cache\3DBECED19CFC2819A7E0BE14463CF18FC8720D91\amyuni_pdfconverter_5_00|*.log|RECURSE
 
 [And Yet It Moves*]
 Section=Games
@@ -2234,16 +2220,6 @@ FileKey1=%AppData%\Ubisoft\ANNO 2070\Cache|*.*|REMOVESELF
 FileKey2=%AppData%\Ubisoft\ANNO 2070\Logs|*.log;*.dmp
 FileKey3=%AppData%\Ubisoft\ANNO 2070\Logs\netlogs|*.log
 
-[Anvisoft Cloud System Booster Backups*]
-LangSecRef=3024
-Detect=HKLM\Software\Anvisoft\Cloud System Booster
-Default=False
-Warning=This will delete your backups. You will be unable to undo any changes made with Cloud System Booster.
-FileKey1=%LocalAppData%\Anvisoft\Anvi Slim Toolbar\FFToobar|*.*|REMOVESELF
-FileKey2=%LocalAppData%\Anvisoft\Anvi Slim Toolbar\IEToobar|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Anvisoft\Cloud System Booster\bak|*.*
-FileKey4=%ProgramFiles%\Anvisoft\Cloud System Booster\bak|*.*
-
 [Anvisoft Cloud System Booster*]
 LangSecRef=3024
 Detect=HKLM\Software\Anvisoft\Cloud System Booster
@@ -2257,6 +2233,16 @@ FileKey6=%ProgramFiles%\Anvisoft\Cloud System Booster|*.log;*.txt
 FileKey7=%ProgramFiles%\Anvisoft\Cloud System Booster\logs|*.*
 FileKey8=%ProgramFiles%\Anvisoft\Cloud System Booster\reports|*.*
 FileKey9=%ProgramFiles%\Anvisoft\Cloud System Booster\VLog|*.*
+
+[Anvisoft Cloud System Booster Backups*]
+LangSecRef=3024
+Detect=HKLM\Software\Anvisoft\Cloud System Booster
+Default=False
+Warning=This will delete your backups. You will be unable to undo any changes made with Cloud System Booster.
+FileKey1=%LocalAppData%\Anvisoft\Anvi Slim Toolbar\FFToobar|*.*|REMOVESELF
+FileKey2=%LocalAppData%\Anvisoft\Anvi Slim Toolbar\IEToobar|*.*|REMOVESELF
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Anvisoft\Cloud System Booster\bak|*.*
+FileKey4=%ProgramFiles%\Anvisoft\Cloud System Booster\bak|*.*
 
 [AnvSoft Any Audio Converter Logs*]
 LangSecRef=3023
@@ -2306,14 +2292,14 @@ LangSecRef=3022
 Detect=HKCU\Software\America Online
 Default=False
 FileKey1=%AppData%\AOL\C_AOL*|*.tmp|RECURSE
-FileKey2=%CommonAppData%\AOL\C_AOL*|*.tmp|RECURSE
-FileKey3=%CommonAppData%\AOL\C_AOL*\bart|*.*|RECURSE
-FileKey4=%CommonAppData%\AOL\C_AOL*\spool|*.*|RECURSE
-FileKey5=%CommonAppData%\AOL Downloads|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\AOL\C_AOL*|*.tmp|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\AOL\C_AOL*\bart|*.*|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\AOL\C_AOL*\spool|*.*|RECURSE
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\AOL Downloads|*.*|RECURSE
+FileKey2=%CommonAppData%\AOL Downloads|*.*|RECURSE
+FileKey3=%CommonAppData%\AOL\C_AOL*|*.tmp|RECURSE
+FileKey4=%CommonAppData%\AOL\C_AOL*\bart|*.*|RECURSE
+FileKey5=%CommonAppData%\AOL\C_AOL*\spool|*.*|RECURSE
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\AOL Downloads|*.*|RECURSE
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\AOL\C_AOL*|*.tmp|RECURSE
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\AOL\C_AOL*\bart|*.*|RECURSE
+FileKey9=%LocalAppData%\VirtualStore\ProgramData\AOL\C_AOL*\spool|*.*|RECURSE
 RegKey1=HKCU\Software\America Online\AOL Instant Messenger ™\CurrentVersion\recent IM ScreenNames
 RegKey2=HKCU\Software\America Online\AOL Instant Messenger ™\CurrentVersion\recent ScreenNames
 RegKey3=HKCU\Software\America Online\AOL Instant Messenger ™\CurrentVersion\Users
@@ -2366,28 +2352,34 @@ LangSecRef=3024
 DetectFile=%AppData%\Appupdater
 Default=False
 FileKey1=%AppData%\Appupdater|appupdaterw.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Appupdater|*.log
-FileKey3=%CommonAppData%\Appupdater|*.log
-
-[AQQ Chat History*]
-LangSecRef=3022
-Detect1=HKCU\Software\MyPortal\AQQ
-Detect2=HKCU\Software\Wapster\AQQ
-Default=False
-FileKey1=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\Archive|*.DC2
-FileKey2=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\Temp|*.*
-FileKey3=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\Archive|*.DC2
-FileKey4=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\Temp|*.*
+FileKey2=%CommonAppData%\Appupdater|*.log
+FileKey3=%LocalAppData%\VirtualStore\ProgramData\Appupdater|*.log
 
 [AQQ*]
 LangSecRef=3022
 Detect1=HKCU\Software\MyPortal\AQQ
 Detect2=HKCU\Software\Wapster\AQQ
 Default=False
-FileKey1=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\*Avatars|*.*
+FileKey1=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\*Avatars|*.*
+FileKey2=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\*Avatars|*.*
+
+[AQQ Cache*]
+LangSecRef=3022
+Detect1=HKCU\Software\MyPortal\AQQ
+Detect2=HKCU\Software\Wapster\AQQ
+Default=False
+FileKey1=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\*Cache|*.*
 FileKey2=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\*Cache|*.*
-FileKey3=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\*Avatars|*.*
-FileKey4=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\*Cache|*.*
+
+[AQQ Chat History*]
+LangSecRef=3022
+Detect1=HKCU\Software\MyPortal\AQQ
+Detect2=HKCU\Software\Wapster\AQQ
+Default=False
+FileKey1=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\Archive|*.DC2
+FileKey2=%LocalAppData%\MyPortal\AQQ Folder\Profiles\*\Data\Temp|*.*
+FileKey3=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\Archive|*.DC2
+FileKey4=%UserProfile%\WapSter\AQQ Folder\Profiles\*\Data\Temp|*.*
 
 [Arasan Chess*]
 Section=Games
@@ -2451,86 +2443,77 @@ RegKey7=HKCU\Software\Ashampoo\Ashampoo Burning Studio 6\Unknown Project\AddDial
 RegKey8=HKCU\Software\Ashampoo\Ashampoo Burning Studio 7\Burn Image Project\SelectImage
 RegKey9=HKCU\Software\Ashampoo\Ashampoo Burning Studio 7\Data Disc Project\AddDialog
 RegKey10=HKCU\Software\Ashampoo\Ashampoo Burning Studio 7\Unknown Project\AddDialog
-RegKey11=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2007\Burn Image Project\AddDialog
-RegKey12=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2007\Data Disc Project\AddDialog
-RegKey13=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2007\Dump Image Project\DumpImage
-RegKey14=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2007\Unknown Project\AddDialog
-RegKey15=HKCU\Software\Ashampoo\Ashampoo Burning Studio 8\Data Disc Project\AddDialog
-RegKey16=HKCU\Software\Ashampoo\Ashampoo Burning Studio 14\Data Disc Project\SaveDialog_AddFilesAndDirs|InitialDirectory
-RegKey17=HKCU\Software\Ashampoo\Ashampoo Burning Studio 14\tempFiles
-RegKey18=HKCU\Software\Ashampoo\Ashampoo Burning Studio 15\Data Disc Project\SaveDialog_AddFilesAndDirs|InitialDirectory
-RegKey19=HKCU\Software\Ashampoo\Ashampoo Burning Studio 15\tempFiles
-RegKey20=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Audio Disc Project\SaveDialog_CPlaylistDlgEx|InitialDirectory
-RegKey21=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Backup Project\BackupOptions|CustomLocation
-RegKey22=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\BDMV Disc Project\SelectBDMVFolder|BdmvPath
-RegKey23=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Browse Image Project\BrowseImageFile|ImagePath
-RegKey24=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Browse Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
-RegKey25=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Burn Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
-RegKey26=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Burn Image Project\SelectImage|ImagePath
-RegKey27=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Data Disc Project\SaveDialog_AddFilesAndDirs|InitialDirectory
-RegKey28=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Data Disc Project\DumpImage|ImagePath
-RegKey29=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\DVD-Video Disc Project\MoviesPage|Path
-RegKey30=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\DVD-Video Disc Project\SaveDialog_authed.CMoviesPage.Movies|InitialDirectory
-RegKey31=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Logs
-RegKey32=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\tempFiles
-RegKey33=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Unknown Project
-RegKey34=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\VCD Project\SaveDialog_OnAddMovies|InitialDirectory
-RegKey35=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\VIDEO_TS Disc Project\DumpImage|ImagePath
-RegKey36=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\VIDEO_TS Disc Project\SelectVideoTSFolder|VideoTSPath
-RegKey37=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Audio Disc Project\SaveDialog_CPlaylistDlgEx|InitialDirectory
-RegKey38=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Backup Project\BackupOptions|CustomLocation
-RegKey39=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Browse Image Project\BrowseImageFile|ImagePath
-RegKey40=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Browse Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
-RegKey41=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Burn Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
-RegKey42=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Burn Image Project\SelectImage|ImagePath
-RegKey43=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Data Disc Project\SaveDialog_AddFilesAndDirs|InitialDirectory
-RegKey44=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Data Disc Project\DumpImage|ImagePath
-RegKey45=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Logs
-RegKey46=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\tempFiles
-RegKey47=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Unknown Project
-RegKey48=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\VCD Project\SaveDialog_OnAddMovies|InitialDirectory
-RegKey49=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\VIDEO_TS Disc Project\DumpImage|ImagePath
-RegKey50=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\VIDEO_TS Disc Project\SelectVideoTSFolder|VideoTSPath
-RegKey51=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Audio Disc Project\SaveDialog_CPlaylistDlgEx|InitialDirectory
-RegKey52=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Backup Project\BackupOptions|CustomLocation
-RegKey53=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\BDMV Disc Project\SelectBDMVFolder|BdmvPath
-RegKey54=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Browse Image Project\BrowseImageFile|ImagePath
-RegKey55=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Browse Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
-RegKey56=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Burn Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
-RegKey57=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Burn Image Project\SelectImage|ImagePath
-RegKey58=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Data Disc Project\SaveDialog_AddFilesAndDirs|InitialDirectory
-RegKey59=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Data Disc Project\DumpImage|ImagePath
-RegKey60=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\DVD-Video Disc Project\MoviesPage|Path
-RegKey61=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\DVD-Video Disc Project\SaveDialog_authed.CMoviesPage.Movies|InitialDirectory
-RegKey62=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Logs
-RegKey63=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\tempFiles
-RegKey64=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Unknown Project
-RegKey65=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\VCD Project\SaveDialog_OnAddMovies|InitialDirectory
-RegKey66=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\VIDEO_TS Disc Project\DumpImage|ImagePath
-RegKey67=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\VIDEO_TS Disc Project\SelectVideoTSFolder|VideoTSPath
+RegKey11=HKCU\Software\Ashampoo\Ashampoo Burning Studio 8\Data Disc Project\AddDialog
+RegKey12=HKCU\Software\Ashampoo\Ashampoo Burning Studio 14\Data Disc Project\SaveDialog_AddFilesAndDirs|InitialDirectory
+RegKey13=HKCU\Software\Ashampoo\Ashampoo Burning Studio 14\tempFiles
+RegKey14=HKCU\Software\Ashampoo\Ashampoo Burning Studio 15\Data Disc Project\SaveDialog_AddFilesAndDirs|InitialDirectory
+RegKey15=HKCU\Software\Ashampoo\Ashampoo Burning Studio 15\tempFiles
+RegKey16=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Audio Disc Project\SaveDialog_CPlaylistDlgEx|InitialDirectory
+RegKey17=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Backup Project\BackupOptions|CustomLocation
+RegKey18=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\BDMV Disc Project\SelectBDMVFolder|BdmvPath
+RegKey19=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Browse Image Project\BrowseImageFile|ImagePath
+RegKey20=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Browse Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
+RegKey21=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Burn Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
+RegKey22=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Burn Image Project\SelectImage|ImagePath
+RegKey23=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Data Disc Project\DumpImage|ImagePath
+RegKey24=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Data Disc Project\SaveDialog_AddFilesAndDirs|InitialDirectory
+RegKey25=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\DVD-Video Disc Project\MoviesPage|Path
+RegKey26=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\DVD-Video Disc Project\SaveDialog_authed.CMoviesPage.Movies|InitialDirectory
+RegKey27=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Logs
+RegKey28=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\tempFiles
+RegKey29=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\Unknown Project
+RegKey30=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\VCD Project\SaveDialog_OnAddMovies|InitialDirectory
+RegKey31=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\VIDEO_TS Disc Project\DumpImage|ImagePath
+RegKey32=HKCU\Software\Ashampoo\Ashampoo Burning Studio 16\VIDEO_TS Disc Project\SelectVideoTSFolder|VideoTSPath
+RegKey33=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Audio Disc Project\SaveDialog_CPlaylistDlgEx|InitialDirectory
+RegKey34=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Backup Project\BackupOptions|CustomLocation
+RegKey35=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\BDMV Disc Project\SelectBDMVFolder|BdmvPath
+RegKey36=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Browse Image Project\BrowseImageFile|ImagePath
+RegKey37=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Browse Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
+RegKey38=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Burn Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
+RegKey39=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Burn Image Project\SelectImage|ImagePath
+RegKey40=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Data Disc Project\DumpImage|ImagePath
+RegKey41=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Data Disc Project\SaveDialog_AddFilesAndDirs|InitialDirectory
+RegKey42=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\DVD-Video Disc Project\MoviesPage|Path
+RegKey43=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\DVD-Video Disc Project\SaveDialog_authed.CMoviesPage.Movies|InitialDirectory
+RegKey44=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Logs
+RegKey45=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\tempFiles
+RegKey46=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\Unknown Project
+RegKey47=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\VCD Project\SaveDialog_OnAddMovies|InitialDirectory
+RegKey48=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\VIDEO_TS Disc Project\DumpImage|ImagePath
+RegKey49=HKCU\Software\Ashampoo\Ashampoo Burning Studio 18\VIDEO_TS Disc Project\SelectVideoTSFolder|VideoTSPath
+RegKey50=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2007\Burn Image Project\AddDialog
+RegKey51=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2007\Data Disc Project\AddDialog
+RegKey52=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2007\Dump Image Project\DumpImage
+RegKey53=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2007\Unknown Project\AddDialog
+RegKey54=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Audio Disc Project\SaveDialog_CPlaylistDlgEx|InitialDirectory
+RegKey55=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Backup Project\BackupOptions|CustomLocation
+RegKey56=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Browse Image Project\BrowseImageFile|ImagePath
+RegKey57=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Browse Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
+RegKey58=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Burn Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
+RegKey59=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Burn Image Project\SelectImage|ImagePath
+RegKey60=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Data Disc Project\DumpImage|ImagePath
+RegKey61=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Data Disc Project\SaveDialog_AddFilesAndDirs|InitialDirectory
+RegKey62=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Logs
+RegKey63=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\tempFiles
+RegKey64=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\Unknown Project
+RegKey65=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\VCD Project\SaveDialog_OnAddMovies|InitialDirectory
+RegKey66=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\VIDEO_TS Disc Project\DumpImage|ImagePath
+RegKey67=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016\VIDEO_TS Disc Project\SelectVideoTSFolder|VideoTSPath
 RegKey68=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\Audio Disc Project\SaveDialog_CPlaylistDlgEx|InitialDirectory
 RegKey69=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\Backup Project\BackupOptions|CustomLocation
 RegKey70=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\Browse Image Project\BrowseImageFile|ImagePath
 RegKey71=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\Browse Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
 RegKey72=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\Burn Image Project\SaveDialog_SelectImageBrowse|InitialDirectory
 RegKey73=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\Burn Image Project\SelectImage|ImagePath
-RegKey74=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\Data Disc Project\SaveDialog_AddFilesAndDirs|InitialDirectory
-RegKey75=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\Data Disc Project\DumpImage|ImagePath
+RegKey74=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\Data Disc Project\DumpImage|ImagePath
+RegKey75=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\Data Disc Project\SaveDialog_AddFilesAndDirs|InitialDirectory
 RegKey76=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\Logs
 RegKey77=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\tempFiles
 RegKey78=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\Unknown Project
 RegKey79=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\VCD Project\SaveDialog_OnAddMovies|InitialDirectory
 RegKey80=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\VIDEO_TS Disc Project\DumpImage|ImagePath
 RegKey81=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017\VIDEO_TS Disc Project\SelectVideoTSFolder|VideoTSPath
-
-[Ashampoo Snap AutoSave*]
-LangSecRef=3024
-Detect1=HKCU\Software\Ashampoo\Ashampoo Snap 7
-Detect2=HKCU\Software\Ashampoo\Ashampoo Snap 8
-Detect3=HKCU\Software\Ashampoo\Ashampoo Snap 9
-Detect4=HKCU\Software\Ashampoo\Ashampoo Snap 10
-Default=False
-FileKey1=%Pictures%\Ashampoo Snap *\_SNAPDOC|*.*|RECURSE
 
 [Ashampoo Snap*]
 LangSecRef=3024
@@ -2544,6 +2527,15 @@ FileKey2=%LocalAppData%\ashampoo\BaNT\product|*.*|RECURSE
 FileKey3=%LocalAppData%\CrashRpt\UnsentCrashReports|*.*|RECURSE
 FileKey4=%LocalAppData%\VirtualStore\Program Files*\Ashampoo\Ashampoo Snap *|_NLogMsg.txt
 FileKey5=%ProgramFiles%\Ashampoo\Ashampoo Snap *|_NLogMsg.txt
+
+[Ashampoo Snap AutoSave*]
+LangSecRef=3024
+Detect1=HKCU\Software\Ashampoo\Ashampoo Snap 7
+Detect2=HKCU\Software\Ashampoo\Ashampoo Snap 8
+Detect3=HKCU\Software\Ashampoo\Ashampoo Snap 9
+Detect4=HKCU\Software\Ashampoo\Ashampoo Snap 10
+Default=False
+FileKey1=%Pictures%\Ashampoo Snap *\_SNAPDOC|*.*|RECURSE
 
 [Ashley Jones - The Heart Of Egypt*]
 Section=Games
@@ -2657,8 +2649,8 @@ Detect3=HKLM\Software\Auslogics\DiskDefrag Portable
 Detect4=HKLM\Software\Auslogics\Disk Defrag Portable
 Detect5=HKLM\SOFTWARE\Auslogics\Disk Defrag Professional
 Default=False
-FileKey1=%AppData%\Auslogics\Disk*Defrag*\Reports|*.*|RECURSE
-FileKey2=%AppData%\Auslogics\Disk*Defrag*\Logs|*.*RECURSE
+FileKey1=%AppData%\Auslogics\Disk*Defrag*\Logs|*.*|RECURSE
+FileKey2=%AppData%\Auslogics\Disk*Defrag*\Reports|*.*|RECURSE
 FileKey3=%CommonAppData%\Auslogics\Disk*Defrag*\*\Reports|*.*
 FileKey4=%ProgramFiles%\Auslogics\Disk Defrag Professional|ndefrg.log
 
@@ -2682,26 +2674,26 @@ RegKey6=HKLM\Software\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogi
 RegKey7=HKLM\Software\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
 RegKey8=HKLM\Software\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.ErrorsRemovedTotal
 RegKey9=HKLM\Software\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.LastScan
-RegKey10=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.ErrorsFailed
-RegKey11=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.ErrorsFound
-RegKey12=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
-RegKey13=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.ErrorsRemovedTotal
-RegKey14=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.LastScan
-RegKey15=HKLM\Software\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsFailed
-RegKey16=HKLM\Software\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsFound
-RegKey17=HKLM\Software\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
-RegKey18=HKLM\Software\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsRemovedTotal
-RegKey19=HKLM\Software\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.LastScan
-RegKey20=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsFailed
-RegKey21=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsFound
-RegKey22=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
-RegKey23=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsRemovedTotal
-RegKey24=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.LastScan
-RegKey25=HKLM\Software\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.ErrorsFailed
-RegKey26=HKLM\Software\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.ErrorsFound
-RegKey27=HKLM\Software\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.ErrorsRemoved
-RegKey28=HKLM\Software\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.ErrorsRemovedTotal
-RegKey29=HKLM\Software\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.LastScan
+RegKey10=HKLM\Software\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsFailed
+RegKey11=HKLM\Software\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsFound
+RegKey12=HKLM\Software\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
+RegKey13=HKLM\Software\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsRemovedTotal
+RegKey14=HKLM\Software\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.LastScan
+RegKey15=HKLM\Software\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.ErrorsFailed
+RegKey16=HKLM\Software\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.ErrorsFound
+RegKey17=HKLM\Software\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.ErrorsRemoved
+RegKey18=HKLM\Software\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.ErrorsRemovedTotal
+RegKey19=HKLM\Software\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.LastScan
+RegKey20=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.ErrorsFailed
+RegKey21=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.ErrorsFound
+RegKey22=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
+RegKey23=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.ErrorsRemovedTotal
+RegKey24=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\3.x\Settings|RegCleaner.AppLogic.LastScan
+RegKey25=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsFailed
+RegKey26=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsFound
+RegKey27=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
+RegKey28=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.ErrorsRemovedTotal
+RegKey29=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\4.x\Settings|RegCleaner.AppLogic.LastScan
 RegKey30=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.ErrorsFailed
 RegKey31=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.ErrorsFound
 RegKey32=HKLM\Software\Wow6432Node\Auslogics\Registry Cleaner\5.X\Settings|RegCleaner.AppLogic.ErrorsRemoved
@@ -2808,52 +2800,6 @@ FileKey11=%LocalAppData%\VirtualStore\ProgramData\AVAST Software\Browser|*.*|REC
 FileKey12=%LocalAppData%\VirtualStore\ProgramData\AVAST Software\Persistent Data\Avast\Logs|*.log
 RegKey1=HKCU\Software\AVAST Software\Avast Browser Cleanup
 
-[AVG PC TuneUp & Utilities CrashDumps*]
-LangSecRef=3024
-Detect1=HKCU\Software\TuneUp
-Detect2=HKCU\Software\AVG\AWL\RegistryCleaner
-Default=False
-FileKey1=%AppData%\AVG\AWL*\CrashDumps|*.*
-FileKey2=%AppData%\TuneUp Software\TuneUp Utilities\CrashDumps|*.*
-FileKey3=%LocalAppData%\Avg\dumps\fmw1|*.*
-
-[AVG PC TuneUp & Utilities Logs*]
-LangSecRef=3024
-Detect1=HKCU\Software\TuneUp
-Detect2=HKCU\Software\AVG\AWL\RegistryCleaner
-Default=False
-FileKey1=%CommonAppData%\TuneUp Software\TuneUp Utilities *|*.log|RECURSE
-FileKey2=%LocalAppData%\AvgSetupLog|*.*|REMOVESELF
-FileKey3=%LocalAppData%\Avg\AWL*\Log|*.log
-FileKey4=%LocalAppData%\Avg\Log|*.log;zappapi.log.1|RECURSE
-FileKey5=%LocalAppData%\Avg\log\fmw1|*.*
-FileKey6=%LocalAppData%\Avg\log\tu16|*.log
-FileKey7=%LocalAppData%\TuneUp Software|*.log|RECURSE
-FileKey8=%WinDir%\System32\config\systemprofile\AppData\Local\Avg\Log\fmw1|*.log
-FileKey9=%WinDir%\System32\config\systemprofile\AppData\Local\Avg\Log\tu16|*.log
-FileKey10=%SystemDrive%\Users\Default\AppData\Local\Avg\Log\tu16|*.log
-
-[AVG PC TuneUp & Utilities Reg Defrag Cleanup*]
-LangSecRef=3024
-Detect1=HKCU\Software\AVG\AWL\RegistryCleaner
-Detect2=HKCU\Software\TuneUp\Utilities\10.0
-Detect3=HKCU\Software\TuneUp\Utilities\12.0
-Detect4=HKCU\Software\TuneUp\Utilities\13.0
-Detect5=HKCU\Software\TuneUp\Utilities\14.0
-Default=False
-FileKey1=%CommonAppData%\|NTUSER.DAT_tureg_new.LOG1;NTUSER.DAT_tureg_new.LOG2;NTUSER.DAT_tureg_old
-FileKey2=%LocalAppData%\Microsoft\Windows|USRCLASS.DAT_tureg_new.LOG*;USRCLASS.DAT_tureg_old
-FileKey3=%SystemDrive%\Boot|BCD_tureg_new.LOG*;BCD_tureg_old
-FileKey4=%SystemDrive%\Documents and Settings\LocalService*|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey5=%SystemDrive%\Documents and Settings\NetworkService*|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey6=%SystemDrive%\Users\Public|NTUSER.DAT_tureg_new.LOG1;NTUSER.DAT_tureg_new.LOG2;NTUSER.DAT_tureg_old
-FileKey7=%UserProfile%\|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey8=%WinDir%\ServiceProfiles\LocalService|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey9=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows|USRCLASS.DAT_tureg_old;USRCLASS.DAT_tureg_new.LOG*
-FileKey10=%WinDir%\ServiceProfiles\NetworkService|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey11=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows|USRCLASS.DAT_tureg_old;USRCLASS.DAT_tureg_new.LOG*
-FileKey12=%WinDir%\System32\config|COMPONENTS_tureg_new.LOG*;COMPONENTS_tureg_old;DEFAULT_tureg_new.LOG*;DEFAULT_tureg_old;SAM_tureg_new.LOG*;SAM_tureg_old;SECURITY_tureg_new.LOG*;SECURITY_tureg_old;SOFTWARE_tureg_new.LOG*;SOFTWARE_tureg_old;SYSTEM_tureg_new.LOG*;SYSTEM_tureg_old;DRIVERS_tureg_new.LOG*;DRIVERS_tureg_old;SOFTWARE_tureg_new;SYSTEM_tureg_new
-
 [AVG*]
 LangSecRef=3024
 Detect=HKLM\SOFTWARE\AVG
@@ -2878,6 +2824,52 @@ FileKey17=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Avg\av16\temp|*.*
 FileKey18=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Avg\log\av16|history.xml;*.log;*.log.*;*.log.lock
 FileKey19=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Avg\log\fmw1|*.log;*.log.*;*.log.lock
 FileKey20=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\AvgSetupLog|*.*|REMOVESELF
+
+[AVG PC TuneUp & Utilities CrashDumps*]
+LangSecRef=3024
+Detect1=HKCU\Software\TuneUp
+Detect2=HKCU\Software\AVG\AWL\RegistryCleaner
+Default=False
+FileKey1=%AppData%\AVG\AWL*\CrashDumps|*.*
+FileKey2=%AppData%\TuneUp Software\TuneUp Utilities\CrashDumps|*.*
+FileKey3=%LocalAppData%\Avg\dumps\fmw1|*.*
+
+[AVG PC TuneUp & Utilities Logs*]
+LangSecRef=3024
+Detect1=HKCU\Software\TuneUp
+Detect2=HKCU\Software\AVG\AWL\RegistryCleaner
+Default=False
+FileKey1=%CommonAppData%\TuneUp Software\TuneUp Utilities *|*.log|RECURSE
+FileKey2=%LocalAppData%\Avg\AWL*\Log|*.log
+FileKey3=%LocalAppData%\Avg\Log|*.log;zappapi.log.1|RECURSE
+FileKey4=%LocalAppData%\Avg\log\fmw1|*.*
+FileKey5=%LocalAppData%\Avg\log\tu16|*.log
+FileKey6=%LocalAppData%\AvgSetupLog|*.*|REMOVESELF
+FileKey7=%LocalAppData%\TuneUp Software|*.log|RECURSE
+FileKey8=%SystemDrive%\Users\Default\AppData\Local\Avg\Log\tu16|*.log
+FileKey9=%WinDir%\System32\config\systemprofile\AppData\Local\Avg\Log\fmw1|*.log
+FileKey10=%WinDir%\System32\config\systemprofile\AppData\Local\Avg\Log\tu16|*.log
+
+[AVG PC TuneUp & Utilities Reg Defrag Cleanup*]
+LangSecRef=3024
+Detect1=HKCU\Software\AVG\AWL\RegistryCleaner
+Detect2=HKCU\Software\TuneUp\Utilities\10.0
+Detect3=HKCU\Software\TuneUp\Utilities\12.0
+Detect4=HKCU\Software\TuneUp\Utilities\13.0
+Detect5=HKCU\Software\TuneUp\Utilities\14.0
+Default=False
+FileKey1=%CommonAppData%\|NTUSER.DAT_tureg_new.LOG1;NTUSER.DAT_tureg_new.LOG2;NTUSER.DAT_tureg_old
+FileKey2=%LocalAppData%\Microsoft\Windows|USRCLASS.DAT_tureg_new.LOG*;USRCLASS.DAT_tureg_old
+FileKey3=%SystemDrive%\Boot|BCD_tureg_new.LOG*;BCD_tureg_old
+FileKey4=%SystemDrive%\Documents and Settings\LocalService*|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
+FileKey5=%SystemDrive%\Documents and Settings\NetworkService*|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
+FileKey6=%SystemDrive%\Users\Public|NTUSER.DAT_tureg_new.LOG1;NTUSER.DAT_tureg_new.LOG2;NTUSER.DAT_tureg_old
+FileKey7=%UserProfile%\|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
+FileKey8=%WinDir%\ServiceProfiles\LocalService|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
+FileKey9=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows|USRCLASS.DAT_tureg_old;USRCLASS.DAT_tureg_new.LOG*
+FileKey10=%WinDir%\ServiceProfiles\NetworkService|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
+FileKey11=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows|USRCLASS.DAT_tureg_old;USRCLASS.DAT_tureg_new.LOG*
+FileKey12=%WinDir%\System32\config|COMPONENTS_tureg_new.LOG*;COMPONENTS_tureg_old;DEFAULT_tureg_new.LOG*;DEFAULT_tureg_old;SAM_tureg_new.LOG*;SAM_tureg_old;SECURITY_tureg_new.LOG*;SECURITY_tureg_old;SOFTWARE_tureg_new.LOG*;SOFTWARE_tureg_old;SYSTEM_tureg_new.LOG*;SYSTEM_tureg_old;DRIVERS_tureg_new.LOG*;DRIVERS_tureg_old;SOFTWARE_tureg_new;SYSTEM_tureg_new
 
 [Avi-Mux GUI*]
 LangSecRef=3023
@@ -2948,10 +2940,10 @@ LangSecRef=3024
 Detect1=HKLM\Software\AviraSpeedup
 Detect2=HKLM\Software\Avira\Speedup
 Default=False
-FileKey1=%CommonAppData%\Avira\SystemSpeedup\Errors|*.*
-FileKey2=%CommonAppData%\Avira\SystemSpeedup\Logs|*.*
-FileKey3=%LocalAppData%\AviraSpeedup\logs|*.*
-FileKey4=%CommonAppData%\Avira\Launcher\Logfiles|*.log
+FileKey1=%CommonAppData%\Avira\Launcher\Logfiles|*.log
+FileKey2=%CommonAppData%\Avira\SystemSpeedup\Errors|*.*
+FileKey3=%CommonAppData%\Avira\SystemSpeedup\Logs|*.*
+FileKey4=%LocalAppData%\AviraSpeedup\logs|*.*
 
 [AVS Audio Converter 6*]
 LangSecRef=3023
@@ -3059,8 +3051,8 @@ Detect=HKCU\Software\Baidu Security
 Default=False
 FileKey1=%CommonAppData%\Baidu Security\RpData|*.tmp
 FileKey2=%Documents%\Baidu Security\Bav\Dump|*.*|REMOVESELF
-FileKey3=%Documents%\Baidu Security\PC Faster\*\log|*.*|REMOVESELF
-FileKey4=%Documents%\Baidu Security\PC Faster\*\Dump|*.*|REMOVESELF
+FileKey3=%Documents%\Baidu Security\PC Faster\*\Dump|*.*|REMOVESELF
+FileKey4=%Documents%\Baidu Security\PC Faster\*\log|*.*|REMOVESELF
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\Baidu Security\RpData|*.tmp
 
 [Baidu Spark*]
@@ -3120,7 +3112,7 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\209000
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Batman Arkham Origins\SinglePlayer\BMGame\Logs|*.*
-FileKey2=%ProgramFiles%\Steam\steamapps\common\Batman Arkham Origins\SinglePlayer\BMGame\Logs
+FileKey2=%ProgramFiles%\Steam\steamapps\common\Batman Arkham Origins\SinglePlayer\BMGame\Logs|*.*
 
 [Battle Islands*]
 Section=Games
@@ -3138,19 +3130,24 @@ FileKey3=%CommonAppData%\Battle.net\Agent\Agent.*\Logs|*.*|RECURSE
 FileKey4=%CommonAppData%\Battle.net\Client\Blizzard Launcher.*\Logs|*.*|RECURSE
 FileKey5=%CommonAppData%\Battle.net\Setup\*\Logs|*.*
 FileKey6=%CommonAppData%\Battle.net\Telemetry|*.*
-FileKey7=%CommonAppData%\Blizzard Entertainment\Battle.net\Cache|*.*|REMOVESELF
-FileKey8=%LocalAppData%\Battle.net\BrowserCache|*.*|RECURSE
-FileKey9=%LocalAppData%\Battle.net\Cache|*.*|RECURSE
-FileKey10=%LocalAppData%\Battle.net\Errors|*.*
-FileKey11=%LocalAppData%\Battle.net\Logs|*.*|RECURSE
-FileKey12=%LocalAppData%\Blizzard Entertainment\System Survey|*.log|RECURSE
-FileKey13=%LocalAppData%\Blizzard Entertainment\Battle.net\Cache|*.*|RECURSE
-FileKey14=%LocalAppData%\Blizzard Entertainment\System Survey|log.txt
-FileKey15=%LocalAppData%\VirtualStore\ProgramData\Battle.net|*.log|RECURSE
-FileKey16=%LocalAppData%\VirtualStore\ProgramData\Battle.net\*\Logs|*.*|RECURSE
-FileKey17=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Agent\Agent.*\Logs|*.*|RECURSE
-FileKey18=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Client\Blizzard Launcher.*\Logs|*.*|RECURSE
-FileKey19=%LocalAppData%\VirtualStore\ProgramData\Blizzard Entertainment\Battle.net\Cache|*.*|REMOVESELF
+FileKey7=%LocalAppData%\Battle.net\BrowserCache|*.*|RECURSE
+FileKey8=%LocalAppData%\Battle.net\Errors|*.*
+FileKey9=%LocalAppData%\Battle.net\Logs|*.*|RECURSE
+FileKey10=%LocalAppData%\Blizzard Entertainment\System Survey|*.log|RECURSE
+FileKey11=%LocalAppData%\Blizzard Entertainment\System Survey|log.txt
+FileKey12=%LocalAppData%\VirtualStore\ProgramData\Battle.net|*.log|RECURSE
+FileKey13=%LocalAppData%\VirtualStore\ProgramData\Battle.net\*\Logs|*.*|RECURSE
+FileKey14=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Agent\Agent.*\Logs|*.*|RECURSE
+FileKey15=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Client\Blizzard Launcher.*\Logs|*.*|RECURSE
+FileKey16=%LocalAppData%\VirtualStore\ProgramData\Blizzard Entertainment\Battle.net\Cache|*.*|REMOVESELF
+
+[Battle.net Cache*]
+Section=Games
+Detect=HKCU\Software\Blizzard Entertainment\Battle.net
+Default=False
+FileKey1=%CommonAppData%\Blizzard Entertainment\Battle.net\Cache|*.*|REMOVESELF
+FileKey2=%LocalAppData%\Battle.net\Cache|*.*|RECURSE
+FileKey3=%LocalAppData%\Blizzard Entertainment\Battle.net\Cache|*.*|RECURSE
 
 [Battlefield 3*]
 Section=Games
@@ -3190,8 +3187,8 @@ FileKey7=%WinDir%\system32\MTSLog|*.*|REMOVESELF
 LangSecRef=3021
 Detect=HKCU\SOFTWARE\Beckhoff
 Default=False
-FileKey1=%UserProfile%\|*TwinCat*.log;TC*.log;TF*.log
-FileKey2=%HomeDrive%\TwinCAT\3.1\Components\TcEventLogger\EventConfigurator|~evtCfgTmp*.html
+FileKey1=%HomeDrive%\TwinCAT\3.1\Components\TcEventLogger\EventConfigurator|~evtCfgTmp*.html
+FileKey2=%UserProfile%\|*TwinCat*.log;TC*.log;TF*.log
 
 [Belarc Advisor*]
 LangSecRef=3024
@@ -3200,10 +3197,10 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Belarc\*Advisor\System|Progress.Log
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Belarc\*Advisor\System\Security\BelNotify|BelNotify.log;History.log;HistoryHF.log
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\Belarc\*Advisor\System\Tmp|*.*
-FileKey4=%ProgramFiles%\Belarc\*Advisor\System|Progress.Log
-FileKey5=%ProgramFiles%\Belarc\*Advisor\System\Security\BelNotify|BelNotify.log;History.log;HistoryHF.log
-FileKey6=%ProgramFiles%\Belarc\*Advisor\System\Tmp|*.*
-FileKey7=%ProgramFiles%\Belarc\*Advisor|install.log
+FileKey4=%ProgramFiles%\Belarc\*Advisor|install.log
+FileKey5=%ProgramFiles%\Belarc\*Advisor\System|Progress.Log
+FileKey6=%ProgramFiles%\Belarc\*Advisor\System\Security\BelNotify|BelNotify.log;History.log;HistoryHF.log
+FileKey7=%ProgramFiles%\Belarc\*Advisor\System\Tmp|*.*
 
 [BestBuy Software Installer*]
 LangSecRef=3024
@@ -3244,25 +3241,25 @@ Default=False
 FileKey1=%CommonAppData%\JollyBear\Big City Adventure Sydney|error.*
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\JollyBear\Big City Adventure Sydney|error.*
 
+[Big Fish Games*]
+Section=Games
+Detect=HKCU\Software\Big Fish Games
+Default=False
+FileKey1=%CommonAppData%\Big Fish Games\Game Manager\resources-old|*.*|RECURSE
+FileKey2=%CommonAppData%\Big Fish\Game Manager\Addons\BFGameLauncher|*.log|RECURSE
+FileKey3=%CommonAppData%\BigFishCache\GameManager\log|*.txt|RECURSE
+FileKey4=%CommonAppData%\BigFishGamesCache\GameManager\log|*.*
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\Big Fish Games\Game Manager\resources-old|*.*|RECURSE
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Big Fish\Game Manager\Addons\BFGameLauncher|*.log|RECURSE
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\BigFishCache\GameManager\log|*.txt|RECURSE
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\BigFishGamesCache\GameManager\log|*.*
+
 [Big Fish Games Installers*]
 Section=Games
 Detect=HKCU\Software\Big Fish Games
 Default=False
 FileKey1=%CommonAppData%\BigFishCache|*.exe|RECURSE
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\BigFishCache|*.exe|RECURSE
-
-[Big Fish Games*]
-Section=Games
-Detect=HKCU\Software\Big Fish Games
-Default=False
-FileKey1=%CommonAppData%\Big Fish\Game Manager\Addons\BFGameLauncher|*.log|RECURSE
-FileKey2=%CommonAppData%\Big Fish Games\Game Manager\resources-old|*.*|RECURSE
-FileKey3=%CommonAppData%\BigFishCache\GameManager\log|*.txt|RECURSE
-FileKey4=%CommonAppData%\BigFishGamesCache\GameManager\log|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Big Fish\Game Manager\Addons\BFGameLauncher|*.log|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Big Fish Games\Game Manager\resources-old|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\BigFishCache\GameManager\log|*.txt|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\BigFishGamesCache\GameManager\log|*.*
 
 [Binding of Isaac Afterbirth+*]
 Section=Games
@@ -3313,15 +3310,15 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingMaps_8wekyb3d8bbwe
 DetectFile=%LocalAppData%\Packages\Microsoft.BingMaps_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.BingMaps_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.BingMaps*\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.BingMaps*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.BingMaps_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.BingMaps_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.BingMaps_*\AC\PRICache|*.*
-FileKey7=%LocalAppData%\Packages\Microsoft.BingMaps_*\AC\Temp|*.*
+FileKey1=%LocalAppData%\Packages\Microsoft.BingMaps*\AC\AppCache|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.BingMaps*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.BingMaps*\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.BingMaps*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.BingMaps*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.BingMaps*\AC\PRICache|*.*
+FileKey7=%LocalAppData%\Packages\Microsoft.BingMaps*\AC\Temp|*.*
 FileKey8=%LocalAppData%\Packages\Microsoft.BingMaps*\LocalState\Bing.Maps|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.BingMaps_8wekyb3d8bbwe\LocalState\MapInstrumentation|*.*
+FileKey9=%LocalAppData%\Packages\Microsoft.BingMaps*\LocalState\MapInstrumentation|*.*
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingMaps_8wekyb3d8bbwe\SearchHistory
 
 [Bing News More*]
@@ -3421,9 +3418,9 @@ Detect2=HKLM\Software\Bitdefender\Bitdefender Total Security
 Detect3=HKLM\Software\Bitdefender\Bitdefender Total Security 2015
 Detect4=HKLM\Software\Bitdefender\Bitdefender Internet Security
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Softwin\Bitdefender*\Logs|*.*
-FileKey2=%ProgramFiles%\Softwin\Bitdefender*\Logs|*.*
-FileKey3=%AppData%\Bitdefender\Desktop\profiles\Logs\*|*.xml
+FileKey1=%AppData%\Bitdefender\Desktop\profiles\Logs\*|*.xml
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Softwin\Bitdefender*\Logs|*.*
+FileKey3=%ProgramFiles%\Softwin\Bitdefender*\Logs|*.*
 FileKey4=%SystemDrive%\|bdlog.txt
 
 [BITS Logs*]
@@ -3470,8 +3467,8 @@ FileKey1=%AppData%\Research In Motion\BlackBerry\AddinSync|sync.log
 LangSecRef=3023
 Detect=HKCU\Software\Research In Motion\BlackBerry
 Default=False
-FileKey1=%AppData%\Research In Motion\BlackBerry Desktop|*.dmp
-FileKey2=%AppData%\|Rim*.log
+FileKey1=%AppData%\|Rim*.log
+FileKey2=%AppData%\Research In Motion\BlackBerry Desktop|*.dmp
 FileKey3=%LocalAppData%\Research In Motion\BlackBerry*Desktop\*\*|*.backup
 FileKey4=%LocalAppData%\Research In Motion\BlackBerry*Desktop\*\*\Log|*.html
 FileKey5=%LocalAppData%\Research In Motion\BlackBerry*Desktop\Logs|*.*|REMOVESELF
@@ -3505,8 +3502,8 @@ FileKey1=%LocalAppData%\BladesOfTime\_debuginfo|*.*
 LangSecRef=3024
 Detect=HKCU\Software\BleachBit
 Default=False
-FileKey1=%ProgramFiles%\BleachBit|bleachbit.exe.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\BleachBit|bleachbit.exe.log
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\BleachBit|bleachbit.exe.log
+FileKey2=%ProgramFiles%\BleachBit|bleachbit.exe.log
 
 [Blender*]
 LangSecRef=3023
@@ -3583,8 +3580,8 @@ Detect1=HKCU\Software\Bluestacks
 Detect2=HKLM\Software\Bluestacks
 Default=False
 Warning=You will have to redownload these files in order to reinstall the application.
-FileKey1=%LocalAppData%\VirtualStore\ProgramData\BlueStacksSetup\Images|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\BlueStacksSetup|runtimedata_*.zip;runtimedata_*.zip.manifest
+FileKey1=%LocalAppData%\VirtualStore\ProgramData\BlueStacksSetup|runtimedata_*.zip;runtimedata_*.zip.manifest
+FileKey2=%LocalAppData%\VirtualStore\ProgramData\BlueStacksSetup\Images|*.*|REMOVESELF
 
 [BlueStacks SharedFolder*]
 LangSecRef=3021
@@ -3621,19 +3618,19 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\BOINC|stdout*.*;stderr*.*
 FileKey2=%ProgramFiles%\BOINC|stdout*.*;stderr*.*
 
-[Borderlands 2*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\49520
-DetectFile=%Documents%\My Games\Borderlands 2
-Default=False
-FileKey1=%Documents%\My Games\Borderlands 2\WillowGame\Logs|*.*
-
 [Borderlands*]
 Section=Games
 Detect1=HKCU\Software\Valve\Steam\Apps\8980
 Detect2=HKLM\Software\Borderlands
 Default=False
 FileKey1=%Documents%\My Games\Borderlands*\WillowGame\Logs|*.log
+
+[Borderlands 2*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\49520
+DetectFile=%Documents%\My Games\Borderlands 2
+Default=False
+FileKey1=%Documents%\My Games\Borderlands 2\WillowGame\Logs|*.*
 
 [Borland C++ Builder 5.0*]
 LangSecRef=3024
@@ -3850,8 +3847,8 @@ FileKey2=%ProgramFiles%\P2 Games\Burn Zombie Burn|*.log
 Section=Games
 DetectFile=%ProgramFiles%\Bus-Simulator 2009
 Default=False
-FileKey1=%ProgramFiles%\Bus-Simulator 2009|*.dmp;*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Bus-Simulator 2009|*.dmp;*.log|RECURSE
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Bus-Simulator 2009|*.dmp;*.log|RECURSE
+FileKey2=%ProgramFiles%\Bus-Simulator 2009|*.dmp;*.log|RECURSE
 
 [Business Objects Enterprise 11*]
 LangSecRef=3021
@@ -3963,12 +3960,12 @@ FileKey1=%Documents%\My CamStudio Temp Files|*.*
 LangSecRef=3024
 Detect=HKCU\Software\TechSmith\Camtasia Studio\9.0
 Default=False
-RegKey1=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Studio\9.0|ExportAsZipMru
-RegKey2=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Studio\9.0|FileSaveAsMru
-RegKey3=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Studio\9.0|MRUImportFolder
-RegKey4=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Studio\9.0|MRUOpenProjectFolder
-RegKey5=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Studio\9.0|RecentRecordingsMru
-RegKey6=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Recorder\9.0\General|lstLastSaveDir
+RegKey1=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Recorder\9.0\General|lstLastSaveDir
+RegKey2=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Studio\9.0|ExportAsZipMru
+RegKey3=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Studio\9.0|FileSaveAsMru
+RegKey4=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Studio\9.0|MRUImportFolder
+RegKey5=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Studio\9.0|MRUOpenProjectFolder
+RegKey6=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Studio\9.0|RecentRecordingsMru
 
 [Canon Digital Photo Professional 4*]
 LangSecRef=3021
@@ -4093,8 +4090,8 @@ LangSecRef=3021
 DetectFile=%ProgramFiles%\CFE Exam Prep Course
 Default=False
 FileKey1=%AppData%\ACFEExamPrep|*.log
-FileKey2=%ProgramFiles%\CFE Exam Prep Course\Log|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\CFE Exam Prep Course\Log|*.*|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\CFE Exam Prep Course\Log|*.*|RECURSE
+FileKey3=%ProgramFiles%\CFE Exam Prep Course\Log|*.*|RECURSE
 
 [Chameleon*]
 LangSecRef=3024
@@ -4108,10 +4105,10 @@ Section=Games
 Detect1=HKCU\Software\Cryptic\Champions Online
 Detect2=HKCU\Software\Valve\Steam\Apps\9880
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Champions Online\Champions Online\*\Cache|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Champions Online\*\Logs\GameClient|*.*
-FileKey3=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\Champions Online\*\Cache|*.*
-FileKey4=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\*\Logs\GameClient|*.*
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Champions Online\*\Logs\GameClient|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Champions Online\Champions Online\*\Cache|*.*
+FileKey3=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\*\Logs\GameClient|*.*
+FileKey4=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\Champions Online\*\Cache|*.*
 FileKey5=%Public%\Games\cryptic studios\Champions Online\*\Cache|*.*
 FileKey6=%Public%\Games\cryptic studios\Champions Online\*\Logs\GameClient|*.*
 
@@ -4143,11 +4140,11 @@ DetectFile2=%ProgramFiles%\Chicken*Invaders*
 Default=False
 FileKey1=%AppData%\InterAction studios|*.log|RECURSE
 FileKey2=%CommonAppData%\InterAction studios|*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Chicken*Invaders*|*.log|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\*\Chicken Invaders*|*.log;*.html;*.png|RECURSE
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\*\Chicken Invaders*|*.log;*.html;*.png|RECURSE
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\Chicken*Invaders*|*.log|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\InterAction studios|*.log|RECURSE
-FileKey6=%ProgramFiles%\Chicken*Invaders*|*.log|RECURSE
-FileKey7=%ProgramFiles%\*\Chicken Invaders*|*.log;*.html;*.png|RECURSE
+FileKey6=%ProgramFiles%\*\Chicken Invaders*|*.log;*.html;*.png|RECURSE
+FileKey7=%ProgramFiles%\Chicken*Invaders*|*.log|RECURSE
 
 [Children of the Nile*]
 Section=Games
@@ -4177,10 +4174,10 @@ FileKey5=%ProgramFiles%\Foxy Games\Christmas Adventure - Candy Storm|*.html;*.ms
 Section=Games
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Griddlers 20141.1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\*\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
-FileKey3=%ProgramFiles%\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
-FileKey4=%ProgramFiles%\*\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\*\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
+FileKey3=%ProgramFiles%\*\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
+FileKey4=%ProgramFiles%\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
 
 [Christmas Wonderland*]
 Section=Games
@@ -4246,9 +4243,9 @@ Detect=HKLM\Software\Citrix\ICA Client
 Default=False
 FileKey1=%AppData%\Citrix\ICA Client\Cache|*.*
 FileKey2=%AppData%\Citrix\ICA Client\Cache\zlcache|*.*
-FileKey3=%AppData%\ICAClient\Cache|*.*
-FileKey4=%AppData%\ICAClient\Cache\zlcache|*.*
-FileKey5=%AppData%\ICAClient|wfcwin32.*
+FileKey3=%AppData%\ICAClient|wfcwin32.*
+FileKey4=%AppData%\ICAClient\Cache|*.*
+FileKey5=%AppData%\ICAClient\Cache\zlcache|*.*
 RegKey1=HKLM\Software\Citrix\ICA Client\Default
 
 [Citrix Online Plug-in Web Setup Files*]
@@ -4389,13 +4386,6 @@ FileKey6=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalCa
 FileKey7=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalState\Cache|*.*|RECURSE
 FileKey8=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\TempState|*.*|RECURSE
 
-[Cloudfogger Keys*]
-LangSecRef=3023
-Detect1=HKCU\SOFTWARE\Cloudfogger
-Detect2=HKCU\SOFTWARE\Cloudfogger.com
-Default=False
-FileKey1=%AppData%\Cloudfogger\Keys|*.*|RECURSE
-
 [Cloudfogger*]
 LangSecRef=3023
 Detect1=HKCU\SOFTWARE\Cloudfogger
@@ -4403,6 +4393,13 @@ Detect2=HKCU\SOFTWARE\Cloudfogger.com
 Default=False
 FileKey1=%AppData%\Cloudfogger|*.log|RECURSE
 FileKey2=%LocalAppData%\CrashRpt|*.log|RECURSE
+
+[Cloudfogger Keys*]
+LangSecRef=3023
+Detect1=HKCU\SOFTWARE\Cloudfogger
+Detect2=HKCU\SOFTWARE\Cloudfogger.com
+Default=False
+FileKey1=%AppData%\Cloudfogger\Keys|*.*|RECURSE
 
 [CloudShark Plugin for Wireshark*]
 LangSecRef=3024
@@ -4426,9 +4423,9 @@ FileKey1=%LocalAppData%\Clover\User Data\Default|current session;current tabs;la
 LangSecRef=3024
 Detect=HKCU\Software\Clover
 Default=False
-FileKey1=%LocalAppData%\Clover\User Data\temp|*.*|RECURSE
-FileKey2=%LocalAppData%\Clover\User Data\Default\JumpListIcons|*tmp
-FileKey3=%LocalAppData%\Clover\User Data\Default\JumpListIconsOld|*tmp
+FileKey1=%LocalAppData%\Clover\User Data\Default\JumpListIcons|*tmp
+FileKey2=%LocalAppData%\Clover\User Data\Default\JumpListIconsOld|*tmp
+FileKey3=%LocalAppData%\Clover\User Data\temp|*.*|RECURSE
 
 [CNET Tech Tracker*]
 LangSecRef=3024
@@ -4534,6 +4531,24 @@ FileKey6=%LocalAppData%\Packages\Microsoft.CommsPhone_*\LocalCache|*.*|RECURSE
 FileKey7=%LocalAppData%\Packages\Microsoft.CommsPhone_*\LocalState\Cache|*.*|RECURSE
 FileKey8=%LocalAppData%\Packages\Microsoft.CommsPhone_*\TempState|*.*|RECURSE
 
+[Comodo*]
+LangSecRef=3024
+Detect=HKCU\Software\ComodoGroup
+Default=False
+FileKey1=%AllUsersProfile%\Comodo\Firewall Pro|cislogs.sdb
+FileKey2=%AppData%\Comodo\CCE\Logs|*.*
+FileKey3=%AppData%\ComodoGroup\CSC\Cache|*.*
+FileKey4=%CommonAppData%\Comodo Downloader|*.*
+FileKey5=%CommonAppData%\Comodo\CisDumps|*.*
+FileKey6=%CommonAppData%\Comodo\Installer|*.*
+FileKey7=%LocalAppData%\COMODO|*.tmp
+FileKey8=%LocalAppData%\Temp\Comodo\Firewall Pro\Data\TempFiles|*.*
+FileKey9=%LocalAppData%\VirtualStore\Program Files*\COMODO\COMODO Internet Security|*.tmp
+FileKey10=%LocalAppData%\VirtualStore\ProgramData\Comodo Downloader|*.*
+FileKey11=%LocalAppData%\VirtualStore\ProgramData\Comodo\CisDumps|*.*
+FileKey12=%LocalAppData%\VirtualStore\ProgramData\Comodo\Installer|*.*
+FileKey13=%ProgramFiles%\COMODO\COMODO Internet Security|*.tmp;CRASH.DMP;cmdagent.zip
+
 [Comodo CertSentry Logs*]
 LangSecRef=3022
 Detect=HKLM\Software\COMODO\CertSentry
@@ -4546,17 +4561,17 @@ Detect=HKLM\Software\ComodoGroup\Dragon
 Default=False
 FileKey1=%LocalAppData%\COMODO|*.lock;*.old|RECURSE
 FileKey2=%LocalAppData%\COMODO\Dragon\User Data|*.*
-FileKey3=%LocalAppData%\COMODO\Dragon\User Data\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\COMODO\Dragon\User Data\Default|Archived History;Archived History-journal;Extension Cookies;History;History Index;History Index *;History-journal;Network Action Predictor-journal;Top Sites;Top Sites-journal;Visited Links
-FileKey5=%LocalAppData%\COMODO\Dragon\User Data\Default\Application Cache|*.*|RECURSE
+FileKey3=%LocalAppData%\COMODO\Dragon\User Data\Default|Archived History;Archived History-journal;Extension Cookies;History;History Index;History Index *;History-journal;Network Action Predictor-journal;Top Sites;Top Sites-journal;Visited Links
+FileKey4=%LocalAppData%\COMODO\Dragon\User Data\Default\Application Cache|*.*|RECURSE
+FileKey5=%LocalAppData%\COMODO\Dragon\User Data\Default\Extension Rules|*.*|RECURSE
 FileKey6=%LocalAppData%\COMODO\Dragon\User Data\Default\Extensions\Temp|*.*
-FileKey7=%LocalAppData%\COMODO\Dragon\User Data\Default\Extension Rules|*.*|RECURSE
-FileKey8=%LocalAppData%\COMODO\Dragon\User Data\Default\File System|*.*|RECURSE
-FileKey9=%LocalAppData%\COMODO\Dragon\User Data\Default\GPUCache|*.*|RECURSE
-FileKey10=%LocalAppData%\COMODO\Dragon\User Data\Default\Media Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\COMODO\Dragon\User Data\Default\Session Storage|*.*|RECURSE
-FileKey12=%LocalAppData%\COMODO\Dragon\User Data\Default\Temp|*.*|RECURSE
-FileKey13=%LocalAppData%\COMODO\Dragon\User Data\Performance Monitor Databases|*.*|REMOVESELF
+FileKey7=%LocalAppData%\COMODO\Dragon\User Data\Default\File System|*.*|RECURSE
+FileKey8=%LocalAppData%\COMODO\Dragon\User Data\Default\GPUCache|*.*|RECURSE
+FileKey9=%LocalAppData%\COMODO\Dragon\User Data\Default\Media Cache|*.*|RECURSE
+FileKey10=%LocalAppData%\COMODO\Dragon\User Data\Default\Session Storage|*.*|RECURSE
+FileKey11=%LocalAppData%\COMODO\Dragon\User Data\Default\Temp|*.*|RECURSE
+FileKey12=%LocalAppData%\COMODO\Dragon\User Data\Performance Monitor Databases|*.*|REMOVESELF
+FileKey13=%LocalAppData%\COMODO\Dragon\User Data\Temp|*.*|RECURSE
 FileKey14=%SystemDrive%\first_launch|*.*|REMOVESELF
 ExcludeKey1=FILE|%LocalAppData%\COMODO\Dragon\User Data\|First Run
 ExcludeKey2=FILE|%LocalAppData%\COMODO\Dragon\User Data\|Local State
@@ -4568,24 +4583,6 @@ DetectFile=%ProgramFiles%\Common Files\COMODO\GeekBuddyRSP.exe
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Comodo\GeekBuddy\logs|*.*|RECURSE
 FileKey2=%ProgramFiles%\Comodo\GeekBuddy\logs|*.*|RECURSE
-
-[Comodo*]
-LangSecRef=3024
-Detect=HKCU\Software\ComodoGroup
-Default=False
-FileKey1=%AllUsersProfile%\Comodo\Firewall Pro|cislogs.sdb
-FileKey2=%AppData%\Comodo\CCE\Logs|*.*
-FileKey3=%AppData%\ComodoGroup\CSC\Cache|*.*
-FileKey4=%CommonAppData%\Comodo\CisDumps|*.*
-FileKey5=%CommonAppData%\Comodo\Installer|*.*
-FileKey6=%CommonAppData%\Comodo Downloader|*.*
-FileKey7=%LocalAppData%\COMODO|*.tmp
-FileKey8=%LocalAppData%\Temp\Comodo\Firewall Pro\Data\TempFiles|*.*
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\COMODO\COMODO Internet Security|*.tmp
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Comodo\CisDumps|*.*
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\Comodo\Installer|*.*
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\Comodo Downloader|*.*
-FileKey13=%ProgramFiles%\COMODO\COMODO Internet Security|*.tmp;CRASH.DMP;cmdagent.zip
 
 [Company of Heroes*]
 Section=Games
@@ -4604,27 +4601,22 @@ RegKey2=HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Compati
 RegKey3=HKU\.DEFAULT\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Compatibility Assistant\Persisted
 RegKey4=HKU\.DEFAULT\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Compatibility Assistant\Store
 
-[Conceiva Mezzmo Crash Dump*]
-LangSecRef=3023
-Detect=HKLM\Software\Conceiva
-Default=False
-FileKey1=%CommonAppData%\Conceiva\Mezzmo\CER|*.zip
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Conceiva\Mezzmo\CER|*.zip
-
 [Conceiva Mezzmo*]
 LangSecRef=3023
 Detect=HKLM\Software\Conceiva\Mezzmo
 Default=False
 FileKey1=%CommonAppData%\Conceiva\*|*.bat;*.exe;*.txt
-FileKey2=%LocalAppData%\Conceiva\Logs|*.*|REMOVESELF
-FileKey3=%LocalAppData%\Conceiva\Mezzmo|DebugCERwrite.txt
-FileKey4=%LocalAppData%\Conceiva\Mezzmo\Temporary_*_Files|*.*|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo|*.txt
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo\Third\OGMDemuxer\doc|*.*|REMOVESELF
+FileKey2=%CommonAppData%\Conceiva\Mezzmo\CER|*.zip
+FileKey3=%LocalAppData%\Conceiva\Logs|*.*|REMOVESELF
+FileKey4=%LocalAppData%\Conceiva\Mezzmo|DebugCERwrite.txt
+FileKey5=%LocalAppData%\Conceiva\Mezzmo\Temporary_*_Files|*.*|REMOVESELF
+FileKey6=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo|*.txt
 FileKey7=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo\Third\MKVToolNix|*.txt
-FileKey8=%ProgramFiles%\Conceiva\Mezzmo|*.txt
-FileKey9=%ProgramFiles%\Conceiva\Mezzmo\Third\OGMDemuxer\doc|*.*|REMOVESELF
-FileKey10=%ProgramFiles%\Conceiva\Mezzmo\Third\MKVToolNix|*.txt
+FileKey8	=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo\Third\OGMDemuxer\doc|*.*|REMOVESELF
+FileKey9=%LocalAppData%\VirtualStore\ProgramData\Conceiva\Mezzmo\CER|*.zip
+FileKey10=%ProgramFiles%\Conceiva\Mezzmo|*.txt
+FileKey11=%ProgramFiles%\Conceiva\Mezzmo\Third\MKVToolNix|*.txt
+FileKey12=%ProgramFiles%\Conceiva\Mezzmo\Third\OGMDemuxer\doc|*.*|REMOVESELF
 RegKey1=HKCU\Software\Conceiva\Mezzmo\General|LastWatchFolder
 
 [Conduit*]
@@ -4734,10 +4726,10 @@ LangSecRef=3021
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Cook'n
 DetectFile=%LocalAppData%\DVO\Cook'n*App\Cook'n.exe
 Default=False
-FileKey1=%Documents%\Cook'n10\Workspace\data|download;dvodb.backup
-FileKey2=%Documents%\Cook'n10\Workspace\update|update.zip
-FileKey3=%Documents%\Cook'n11\Download|*.*
-FileKey4=%Documents%\Cook'n Backups|*.ckn
+FileKey1=%Documents%\Cook'n Backups|*.ckn
+FileKey2=%Documents%\Cook'n10\Workspace\data|download;dvodb.backup
+FileKey3=%Documents%\Cook'n10\Workspace\update|update.zip
+FileKey4=%Documents%\Cook'n11\Download|*.*
 
 [Cook'n Cache*]
 LangSecRef=3021
@@ -4778,8 +4770,8 @@ FileKey1=%LocalAppData%\Coowon\Coowon\User Data\*\GPUCache|*.*|RECURSE
 LangSecRef=3029
 Detect=HKCU\Software\Coowon
 Default=False
-FileKey1=%LocalAppData%\Coowon\Coowon\User Data\*\Cache|*.*|REMOVESELF
-FileKey2=%LocalAppData%\Coowon\Coowon\User Data\*|Favicons;Favicons-journal
+FileKey1=%LocalAppData%\Coowon\Coowon\User Data\*|Favicons;Favicons-journal
+FileKey2=%LocalAppData%\Coowon\Coowon\User Data\*\Cache|*.*|REMOVESELF
 
 [Coowon Browser - Internet History*]
 LangSecRef=3029
@@ -4825,36 +4817,36 @@ FileKey2=%LocalAppData%\Copernic\DesktopSearch4\Logs|*.*|REMOVESELF
 LangSecRef=3024
 Detect=HKCU\Software\kishDesign\CopyTo
 Default=False
-RegKey1=HKCU\Software\kishDesign\CopyTo\settings3|Source00
-RegKey2=HKCU\Software\kishDesign\CopyTo\settings3|Source01
-RegKey3=HKCU\Software\kishDesign\CopyTo\settings3|Source02
-RegKey4=HKCU\Software\kishDesign\CopyTo\settings3|Source03
-RegKey5=HKCU\Software\kishDesign\CopyTo\settings3|Source04
-RegKey6=HKCU\Software\kishDesign\CopyTo\settings3|Source05
-RegKey7=HKCU\Software\kishDesign\CopyTo\settings3|Source06
-RegKey8=HKCU\Software\kishDesign\CopyTo\settings3|Source07
-RegKey9=HKCU\Software\kishDesign\CopyTo\settings3|Source08
-RegKey10=HKCU\Software\kishDesign\CopyTo\settings3|Source09
-RegKey11=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder00
-RegKey12=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder01
-RegKey13=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder02
-RegKey14=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder03
-RegKey15=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder04
-RegKey16=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder05
-RegKey17=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder06
-RegKey18=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder07
-RegKey19=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder08
-RegKey20=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder09
-RegKey21=HKCU\Software\kishDesign\CopyTo\settings3|scutname00
-RegKey22=HKCU\Software\kishDesign\CopyTo\settings3|scutname01
-RegKey23=HKCU\Software\kishDesign\CopyTo\settings3|scutname02
-RegKey24=HKCU\Software\kishDesign\CopyTo\settings3|scutname03
-RegKey25=HKCU\Software\kishDesign\CopyTo\settings3|scutname04
-RegKey26=HKCU\Software\kishDesign\CopyTo\settings3|scutname05
-RegKey27=HKCU\Software\kishDesign\CopyTo\settings3|scutname06
-RegKey28=HKCU\Software\kishDesign\CopyTo\settings3|scutname07
-RegKey29=HKCU\Software\kishDesign\CopyTo\settings3|scutname08
-RegKey30=HKCU\Software\kishDesign\CopyTo\settings3|scutname09
+RegKey1=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder00
+RegKey2=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder01
+RegKey3=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder02
+RegKey4=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder03
+RegKey5=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder04
+RegKey6=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder05
+RegKey7=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder06
+RegKey8=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder07
+RegKey9=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder08
+RegKey10=HKCU\Software\kishDesign\CopyTo\settings3|scutFolder09
+RegKey11=HKCU\Software\kishDesign\CopyTo\settings3|scutname00
+RegKey12=HKCU\Software\kishDesign\CopyTo\settings3|scutname01
+RegKey13=HKCU\Software\kishDesign\CopyTo\settings3|scutname02
+RegKey14=HKCU\Software\kishDesign\CopyTo\settings3|scutname03
+RegKey15=HKCU\Software\kishDesign\CopyTo\settings3|scutname04
+RegKey16=HKCU\Software\kishDesign\CopyTo\settings3|scutname05
+RegKey17=HKCU\Software\kishDesign\CopyTo\settings3|scutname06
+RegKey18=HKCU\Software\kishDesign\CopyTo\settings3|scutname07
+RegKey19=HKCU\Software\kishDesign\CopyTo\settings3|scutname08
+RegKey20=HKCU\Software\kishDesign\CopyTo\settings3|scutname09
+RegKey21=HKCU\Software\kishDesign\CopyTo\settings3|Source00
+RegKey22=HKCU\Software\kishDesign\CopyTo\settings3|Source01
+RegKey23=HKCU\Software\kishDesign\CopyTo\settings3|Source02
+RegKey24=HKCU\Software\kishDesign\CopyTo\settings3|Source03
+RegKey25=HKCU\Software\kishDesign\CopyTo\settings3|Source04
+RegKey26=HKCU\Software\kishDesign\CopyTo\settings3|Source05
+RegKey27=HKCU\Software\kishDesign\CopyTo\settings3|Source06
+RegKey28=HKCU\Software\kishDesign\CopyTo\settings3|Source07
+RegKey29=HKCU\Software\kishDesign\CopyTo\settings3|Source08
+RegKey30=HKCU\Software\kishDesign\CopyTo\settings3|Source09
 RegKey31=HKCU\Software\kishDesign\CopyTo\settings3|target00
 RegKey32=HKCU\Software\kishDesign\CopyTo\settings3|target01
 RegKey33=HKCU\Software\kishDesign\CopyTo\settings3|target02
@@ -4897,8 +4889,28 @@ FileKey1=%ProgramFiles%\Core Temp|*.csv
 LangSecRef=3023
 Detect1=HKCU\Software\Corel\AfterShot Pro V3
 Default=False
-FileKey1=%LocalAppData%\Corel\AfterShot Pro *\Cache|*.*|RECURSE
-FileKey2=%LocalAppData%\Corel\AfterShot Pro *|*.log
+FileKey1=%LocalAppData%\Corel\AfterShot Pro *|*.log
+FileKey2=%LocalAppData%\Corel\AfterShot Pro *\Cache|*.*|RECURSE
+
+[Corel PaintShop Pro*]
+LangSecRef=3023
+Detect1=HKCU\Software\Corel\PhotoDownloader\2
+Detect2=HKCU\Software\Corel\PaintShop Pro\X4
+Detect3=HKCU\Software\Corel\PaintShop Pro\X5
+Detect4=HKCU\Software\Corel\PaintShop Pro\X6
+Detect5=HKCU\Software\Corel\PaintShop Pro\X7
+Detect6=HKCU\Software\Corel\PaintShop Pro\X10
+Default=False
+FileKey1=%AppData%\Corel\PaintShop Photo Pro\13\Cache|*.*|RECURSE
+FileKey2=%LocalAppData%\Corel|*.db;*.PspCache
+FileKey3=%LocalAppData%\Corel PaintShop Pro\*\Cache|*.*
+FileKey4=%LocalAppData%\Corel PaintShop Pro\*\Database|*.db
+FileKey5=%LocalAppData%\Corel PaintShop Pro\*\Thumbs|*.*|RECURSE
+FileKey6=%LocalAppData%\Corel\Thumbs|*.*|RECURSE
+RegKey1=HKCU\Software\Corel\PaintShop Pro\X7\CoreMemoryManager\0
+RegKey2=HKCU\Software\Corel\PaintShop Pro\X10\CoreMemoryManager\0
+RegKey3=HKCU\Software\Corel\PhotoDownloader\2\PhotoDownloader\DefaultDownloadFolder
+RegKey4=HKCU\Software\Corel\PhotoDownloader\2\PhotoDownloader\DownloadFolder
 
 [Corel PaintShop Pro 2018 Downloads*]
 LangSecRef=3023
@@ -4913,26 +4925,6 @@ Detect2=HKCU\Software\Corel\PaintShop Pro\X7
 Detect3=HKCU\Software\Corel\PaintShop Pro\X10
 Default=False
 FileKey1=%Pictures%\Corel Auto-Preserve|*.*
-
-[Corel PaintShop Pro*]
-LangSecRef=3023
-Detect1=HKCU\Software\Corel\PhotoDownloader\2
-Detect2=HKCU\Software\Corel\PaintShop Pro\X4
-Detect3=HKCU\Software\Corel\PaintShop Pro\X5
-Detect4=HKCU\Software\Corel\PaintShop Pro\X6
-Detect5=HKCU\Software\Corel\PaintShop Pro\X7
-Detect6=HKCU\Software\Corel\PaintShop Pro\X10
-Default=False
-FileKey1=%AppData%\Corel\PaintShop Photo Pro\13\Cache|*.*|RECURSE
-FileKey2=%LocalAppData%\Corel|*.db;*.PspCache
-FileKey3=%LocalAppData%\Corel\Thumbs|*.*|RECURSE
-FileKey4=%LocalAppData%\Corel PaintShop Pro\*\Database|*.db
-FileKey5=%LocalAppData%\Corel PaintShop Pro\*\Thumbs|*.*|RECURSE
-FileKey6=%LocalAppData%\Corel PaintShop Pro\*\Cache|*.*
-RegKey1=HKCU\Software\Corel\PaintShop Pro\X7\CoreMemoryManager\0
-RegKey2=HKCU\Software\Corel\PhotoDownloader\2\PhotoDownloader\DefaultDownloadFolder
-RegKey3=HKCU\Software\Corel\PhotoDownloader\2\PhotoDownloader\DownloadFolder
-RegKey4=HKCU\Software\Corel\PaintShop Pro\X10\CoreMemoryManager\0
 
 [Corel VideoStudio Pro*]
 LangSecRef=3023
@@ -4952,15 +4944,15 @@ RegKey4=HKCU\Software\Ulead Systems\Corel VideoStudio Pro\17.0\HerRFL
 LangSecRef=3021
 Detect=HKCU\SOFTWARE\Corel\CorelDRAW\17.0
 Default=False
-FileKey1=%ProgramFiles%\Corel\CorelDRAW Graphics Suite X7\Setup|*.*|REMOVESELF
-FileKey2=%CommonAppData%\Bitstream\Font Navigator\6.0\Cache|*.*|RECURSE
-FileKey3=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw\Export|dialog.export.web.xml
-FileKey4=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw\Presets\HTML Export|default.pst
-FileKey5=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw|FindAndReplaceMRU.xml
-FileKey6=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw\PreviewCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Connect|Connect.config
-FileKey8=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Config|corelpdf.ini;capture.ini
-FileKey9=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\PHOTO-PAINT\PreviewCache|*.*|RECURSE
+FileKey1=%CommonAppData%\Bitstream\Font Navigator\6.0\Cache|*.*|RECURSE
+FileKey2=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Config|corelpdf.ini;capture.ini
+FileKey3=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Connect|Connect.config
+FileKey4=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw|FindAndReplaceMRU.xml
+FileKey5=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw\Export|dialog.export.web.xml
+FileKey6=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw\Presets\HTML Export|default.pst
+FileKey7=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw\PreviewCache|*.*|RECURSE
+FileKey8=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\PHOTO-PAINT\PreviewCache|*.*|RECURSE
+FileKey9=%ProgramFiles%\Corel\CorelDRAW Graphics Suite X7\Setup|*.*|REMOVESELF
 RegKey1=HKCU\Software\Bitstream\Font Navigator\6.0\Copy|Folders
 RegKey2=HKCU\Software\Bitstream\Font Navigator\6.0\Move|Folders
 RegKey3=HKCU\Software\Corel\CorelDRAW\17.0\Draw\Application Preferences\Directories|DrawDocsDir
@@ -5061,8 +5053,8 @@ LangSecRef=3024
 DetectFile=%ProgramFiles%\CrystalDiskInfo\Smart
 Default=False
 Warning=This will delete all saved SMART data for history/graph function.
-FileKey1=%ProgramFiles%\CrystalDiskInfo\Smart|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\CrystalDiskInfo\Smart|*.*|RECURSE
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\CrystalDiskInfo\Smart|*.*|RECURSE
+FileKey2=%ProgramFiles%\CrystalDiskInfo\Smart|*.*|RECURSE
 
 [Curse Client*]
 Section=Games
@@ -5347,8 +5339,8 @@ RegKey2=HKCU\Software\DAMN\DAMN NFO Viewer\Recently Viewed Files
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\251170
 Default=False
-FileKey1=%ProgramFiles%\Steam\SteamApps\Common\Damned|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Damned|*.log|RECURSE
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Damned|*.log|RECURSE
+FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Damned|*.log|RECURSE
 
 [Dangerous Waters*]
 Section=Games
@@ -5360,6 +5352,12 @@ FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Dange
 FileKey3=%ProgramFiles%\Sonalysts Combat Simulations\Dangerous Waters|*.log
 FileKey4=%ProgramFiles%\Steam\SteamApps\Common\Dangerous Waters|*.log
 
+[DARK*]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\225360
+Default=False
+FileKey1=%AppData%\Kalypso Media\Dark|log.txt
+
 [Dark Blood Online*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\267790
@@ -5367,12 +5365,6 @@ Default=False
 FileKey1=%AppData%\DarkBlood ServiceST|*.txt
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Dark Blood\logs|*.*|RECURSE
 FileKey3=%ProgramFiles%\Steam\SteamApps\Common\Dark Blood\logs|*.*|RECURSE
-
-[DARK*]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\225360
-Default=False
-FileKey1=%AppData%\Kalypso Media\Dark|log.txt
 
 [Darkspore*]
 Section=Games
@@ -5414,10 +5406,10 @@ Detect=HKCU\Software\Tobit
 Default=False
 FileKey1=%SystemDrive%\David\Apps\Dvgrab\Code|*.chk
 FileKey2=%SystemDrive%\David\Apps\Postman\Code|*.chk
-FileKey3=%SystemDrive%\David\Code|*.old;*.chk;*.log
-FileKey4=%SystemDrive%\David\Tld\COMMON|*DAVID.LOG
-FileKey5=%SystemDrive%\David\Tld\Port\Extra|*.chk
-FileKey6=%SystemDrive%\David\Archive\USER\*\temp|*.*
+FileKey3=%SystemDrive%\David\Archive\USER\*\temp|*.*
+FileKey4=%SystemDrive%\David\Code|*.old;*.chk;*.log
+FileKey5=%SystemDrive%\David\Tld\COMMON|*DAVID.LOG
+FileKey6=%SystemDrive%\David\Tld\Port\Extra|*.chk
 
 [DayZ*]
 Section=Games
@@ -5531,15 +5523,15 @@ FileKey1=%AppData%\Creative\DELL Webcam Center|MO_Log.txt
 FileKey2=%AppData%\PCDr\*\Logs|*.*
 FileKey3=%CommonAppData%\Dell\*\Log|*.*
 FileKey4=%CommonAppData%\Dell\Drivers\*|*.tmp
-FileKey5=%CommonAppData%\PCDr\*\logs|*.log
+FileKey5=%CommonAppData%\PCDr\*\Cache|*.xml
 FileKey6=%CommonAppData%\PCDr\*\Cache\archives|*.*|RECURSE
 FileKey7=%CommonAppData%\PCDr\*\Cache\BUMA|*.*
 FileKey8=%CommonAppData%\PCDr\*\Cache\DriverScan|*.*
-FileKey9=%CommonAppData%\PCDr\*\Cache|*.xml
+FileKey9=%CommonAppData%\PCDr\*\logs|*.log
 FileKey10=%LocalAppData%\Dell\UpdatePackage\Log|*.*
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\Dell\UpdatePackage\Log|*.*
+FileKey11=%LocalAppData%\SupportSoft\DellSupportCenter\*\state\logs|*.*
 FileKey12=%LocalAppData%\VirtualStore\Program Files*\Dell*|*.log|RECURSE
-FileKey13=%LocalAppData%\SupportSoft\DellSupportCenter\*\state\logs|*.*
+FileKey13=%LocalAppData%\VirtualStore\ProgramData\Dell\UpdatePackage\Log|*.*
 FileKey14=%ProgramFiles%\Dell*|*.log|RECURSE
 
 [Dell PC Doctor*]
@@ -5628,19 +5620,19 @@ DetectFile=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Device
 Default=False
 FileKey1=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Device Metadata\dmrccache\downloads|*.tmp
 
-[Device Manager Cache XP*]
-DetectOS=|5.1
-LangSecRef=3025
-Default=False
-Warning=This clears cached drivers of connected devices. As soon as you connect a new device, this file regenerates.
-FileKey1=%WinDir%\inf|INFCACHE.1
-
 [Device Manager Cache*]
 DetectOS=6.0|
 LangSecRef=3025
 Warning=This clears cached drivers of connected devices. As soon as you connect a new device, this file regenerates.
 Default=False
 FileKey1=%WinDir%\System32\DriverStore|INFCACHE.1
+
+[Device Manager Cache XP*]
+DetectOS=|5.1
+LangSecRef=3025
+Default=False
+Warning=This clears cached drivers of connected devices. As soon as you connect a new device, this file regenerates.
+FileKey1=%WinDir%\inf|INFCACHE.1
 
 [DeviceDoctor*]
 LangSecRef=3024
@@ -5704,12 +5696,6 @@ Detect=HKCU\Software\Davide Vitelaru\Digital Janitor
 Default=False
 FileKey1=%AppData%\Digital Janitor|ToSortHistory
 
-[Digsby Chat Logs*]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\Digsby
-Default=False
-FileKey1=%Documents%\Digsby Logs|*.*|RECURSE
-
 [Digsby*]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Digsby
@@ -5717,6 +5703,12 @@ Default=False
 FileKey1=%LocalAppData%\Digsby\Cache|*.*|RECURSE
 FileKey2=%LocalAppData%\Digsby\Logs|*.*|RECURSE
 FileKey3=%LocalAppData%\Digsby\Temp|*.*|RECURSE
+
+[Digsby Chat Logs*]
+LangSecRef=3022
+DetectFile=%ProgramFiles%\Digsby
+Default=False
+FileKey1=%Documents%\Digsby Logs|*.*|RECURSE
 
 [Directory Opus Caches*]
 LangSecRef=3024
@@ -5774,6 +5766,14 @@ Detect=HKCU\Software\Binary Fortress Software\DisplayFusion
 Default=False
 FileKey1=%AppData%\DisplayFusion|DisplayFusionSetup.log;DisplayFusionSetup.exe;DisplayFusion.log;DebugInfo.*
 
+[DivX*]
+LangSecRef=3023
+Detect=HKCU\Software\DivX
+Default=False
+FileKey1=%AppData%\DivX|Font Cache.|RECURSE
+FileKey2=%CommonAppData%\DivX|*.log|RECURSE
+FileKey3=%LocalAppData%\VirtualStore\ProgramData\DivX|*.log|RECURSE
+
 [DivX Movies Cache*]
 LangSecRef=3023
 Detect1=HKLM\Software\DivXNetworks
@@ -5798,20 +5798,12 @@ RegKey3=HKCU\Software\DivX\Settings\Player\PlayerState|LastOpenFileLocation
 RegKey4=HKCU\Software\DivX\Settings\TransferWizard|LastBrwosedDir
 RegKey5=HKCU\Software\DivXNetworks\DivX Player|file
 
-[DivX*]
-LangSecRef=3023
-Detect=HKCU\Software\DivX
-Default=False
-FileKey1=%AppData%\DivX|Font Cache.|RECURSE
-FileKey2=%CommonAppData%\DivX|*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\DivX|*.log|RECURSE
-
 [DLExpert*]
 LangSecRef=3021
 Detect=HKCU\Software\Ying3\DLExpert
 Default=False
-RegKey1=HKCU\Software\Ying3\DLExpert|http
-RegKey2=HKCU\Software\Ying3\DLExpert|ftp
+RegKey1=HKCU\Software\Ying3\DLExpert|ftp
+RegKey2=HKCU\Software\Ying3\DLExpert|http
 RegKey3=HKCU\Software\Ying3\DLExpert\MAIN|ALLFILE
 RegKey4=HKCU\Software\Ying3\DLExpert\MAIN|GOOD
 RegKey5=HKCU\Software\Ying3\DLExpert\MAIN|GOODURL
@@ -5887,6 +5879,13 @@ DetectFile=%SystemDrive%\Dooble
 Default=False
 FileKey1=%SystemDrive%\Dooble\*\.dooble|history.db
 
+[Download App*]
+LangSecRef=3024
+Detect=HKCU\Software\CBS Interactive\Download App
+Default=False
+FileKey1=%AppData%\CBS Interactive\Download App|*.log
+FileKey2=%AppData%\CBS Interactive\Download App\Cache|*.*
+
 [Download App Databases*]
 LangSecRef=3024
 Detect=HKCU\Software\CBS Interactive\Download App
@@ -5898,13 +5897,6 @@ LangSecRef=3024
 Detect=HKCU\Software\CBS Interactive\Download App
 Default=False
 FileKey1=%Documents%\Downloads\Download App|*.*
-
-[Download App*]
-LangSecRef=3024
-Detect=HKCU\Software\CBS Interactive\Download App
-Default=False
-FileKey1=%AppData%\CBS Interactive\Download App|*.log
-FileKey2=%AppData%\CBS Interactive\Download App\Cache|*.*
 
 [Downloaded Installations*]
 LangSecRef=3025
@@ -6053,21 +6045,21 @@ FileKey3=%LocalAppData%\VirtualStore\ProgramData\DriverGenius|*.log
 LangSecRef=3024
 Detect=HKCU\Software\Innovative Solutions\DriverMax
 Default=False
-FileKey1=%LocalAppData%\Innovative Solutions\DriverMax\Agent\Downloded Drivers|*.*
-FileKey2=%LocalAppData%\Innovative Solutions\DriverMax\Agent\Uploads|*.*|RECURSE
-FileKey3=%LocalAppData%\Innovative Solutions\DriverMax\Backup|*.*
-FileKey4=%LocalAppData%\Innovative Solutions\DriverMax\LastScan|*.*
-FileKey5=%LocalAppData%\Innovative Solutions\DriverMax\Temp*|*.*
-FileKey6=%LocalAppData%\Innovative Solutions\DriverMax\Agent|dmxlog.txt;*.tmp
+FileKey1=%LocalAppData%\Innovative Solutions\DriverMax\Agent|dmxlog.txt;*.tmp
+FileKey2=%LocalAppData%\Innovative Solutions\DriverMax\Agent\Downloded Drivers|*.*
+FileKey3=%LocalAppData%\Innovative Solutions\DriverMax\Agent\Uploads|*.*|RECURSE
+FileKey4=%LocalAppData%\Innovative Solutions\DriverMax\Backup|*.*
+FileKey5=%LocalAppData%\Innovative Solutions\DriverMax\LastScan|*.*
+FileKey6=%LocalAppData%\Innovative Solutions\DriverMax\Temp*|*.*
 
 [DriverPack Solution*]
 LangSecRef=3024
 Detect=HKCU\Software\drpsu
 Default=False
 Warning=This will delete your bug report. Use this only if you know what you are doing.
-FileKey1=%WinDir%\Logs\SysInfo|*.*
+FileKey1=%Documents%\DRP-Log|*.*
 FileKey2=%WinDir%\Logs\DRPLog|*.png;*.txt
-FileKey3=%Documents%\DRP-Log|*.*
+FileKey3=%WinDir%\Logs\SysInfo|*.*
 
 [DriverRadarPro*]
 LangSecRef=3024
@@ -6111,12 +6103,24 @@ FileKey1=%LocalAppData%\SlimWare Utilities Inc\DriverUpdate\Logs|*.*|RECURSE
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\DRM
 Default=False
-FileKey1=%CommonAppData%\Microsoft\Windows\DRM\Cache|*.*|RECURSE
-FileKey2=%CommonAppData%\Microsoft\Windows\DRM\PreUpgrade|*.log
-FileKey3=%CommonAppData%\Microsoft\Windows\DRM|*.log
+FileKey1=%CommonAppData%\Microsoft\Windows\DRM|*.log
+FileKey2=%CommonAppData%\Microsoft\Windows\DRM\Cache|*.*|RECURSE
+FileKey3=%CommonAppData%\Microsoft\Windows\DRM\PreUpgrade|*.log
 FileKey4=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\DRM|*.log
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\DRM\Cache|*.*|RECURSE
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\DRM\PreUpgrade|*.log
+
+[Dropbox*]
+LangSecRef=3024
+Detect=HKCU\Software\Dropbox
+Default=False
+FileKey1=%AppData%\DropBox|Filecache.db;SigStore.db
+FileKey2=%AppData%\DropBox\Bin|*.log
+FileKey3=%AppData%\Dropbox\Cache|*.*|RECURSE
+FileKey4=%AppData%\Dropbox\logs|*.*|RECURSE
+FileKey5=%CommonAppData%\Dropbox\Update\Log|*.*
+FileKey6=%LocalAppData%\Dropbox\Logs|*.*|RECURSE
+FileKey7=%ProgramFiles%\Dropbox\Update\Download|*.*|REMOVESELF
 
 [Dropbox Cache*]
 LangSecRef=3024
@@ -6125,18 +6129,6 @@ Default=False
 Warning=This will remove cached versions of modified and deleted files.
 FileKey1=%Documents%\Dropbox\.dropbox.cache|*.*|RECURSE
 FileKey2=%UserProfile%\Dropbox\.dropbox.cache|*.*|RECURSE
-
-[Dropbox*]
-LangSecRef=3024
-Detect=HKCU\Software\Dropbox
-Default=False
-FileKey1=%AppData%\DropBox|Filecache.db;SigStore.db
-FileKey2=%AppData%\DropBox\Bin|*.log
-FileKey3=%AppData%\Dropbox\logs|*.*|RECURSE
-FileKey4=%AppData%\Dropbox\Cache|*.*|RECURSE
-FileKey5=%CommonAppData%\Dropbox\Update\Log|*.*
-FileKey6=%LocalAppData%\Dropbox\Logs|*.*|RECURSE
-FileKey7=%ProgramFiles%\Dropbox\Update\Download|*.*|REMOVESELF
 
 [DU meter*]
 LangSecRef=3022
@@ -6196,6 +6188,13 @@ FileKey4=%ProgramFiles%\dvbdream\Logs|*.*
 FileKey5=%SystemDrive%\dvbdream|*.log;*.bak;*levellog*|RECURSE
 FileKey6=%SystemDrive%\dvbdream\Logs|*.*
 
+[DVBViewer*]
+LangSecRef=3023
+Detect=HKLM\Software\CM&V\DVBViewer
+Default=False
+FileKey1=%CommonAppData%\CMUV\DVBViewer*|*.bak;*.log
+FileKey2=%LocalAppData%\VirtualStore\ProgramData\CMUV\DVBViewer*|*.bak;*.log
+
 [DVBViewer Setup Files*]
 LangSecRef=3023
 Detect=HKLM\Software\CM&V\DVBViewer
@@ -6208,20 +6207,6 @@ FileKey4=%ProgramFiles%\DVBViewer\Remotes|*.*
 FileKey5=%ProgramFiles%\DVBViewer\setup|*.*
 FileKey6=%ProgramFiles%\DVBViewer\Transponders|*.*
 
-[DVBViewer TE2*]
-LangSecRef=3023
-Detect=HKU\.DEFAULT\Software\B2C2, Inc.
-Default=False
-FileKey1=%CommonAppData%\CMUV\DVBViewer TE2|*.bak;*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\CMUV\DVBViewer TE2|*.bak;*.log
-
-[DVBViewer*]
-LangSecRef=3023
-Detect=HKLM\Software\CM&V\DVBViewer
-Default=False
-FileKey1=%CommonAppData%\CMUV\DVBViewer|*.bak;*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\CMUV\DVBViewer|*.bak;*.log
-
 [DVD-Cloner*]
 LangSecRef=3023
 Detect1=HKCU\Software\Dvd-cloner
@@ -6231,11 +6216,11 @@ Default=False
 FileKey1=%AppData%\DVD-Cloner*|*.log
 FileKey2=%CommonAppData%\DVD-Cloner*|*.log
 FileKey3=%Documents%\|Smart.log;Smart_result.log
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\DVD-Cloner*|*.log|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\DVD-Cloner Platinum\*\readcache|*.*
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\DVD-Cloner Platinum\*\readcache|*.*
+FileKey5=%LocalAppData%\VirtualStore\Program Files*\DVD-Cloner*|*.log|RECURSE
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\DVD-Cloner*|*.log
-FileKey7=%ProgramFiles%\DVD-Cloner*|*.log|RECURSE
-FileKey8=%ProgramFiles%\DVD-Cloner Platinum\*\readcache|*.*
+FileKey7=%ProgramFiles%\DVD-Cloner Platinum\*\readcache|*.*
+FileKey8=%ProgramFiles%\DVD-Cloner*|*.log|RECURSE
 FileKey9=%SystemDrive%\|dtdlog.txt
 FileKey10=%WinDir%\system32|dvdtest10024.dat
 
@@ -6245,8 +6230,8 @@ Detect=HKLM\Software\DVD-Ranger
 Default=False
 FileKey1=%CommonAppData%\DVDRanger\DDF626ADdvdcss|*.*
 FileKey2=%CommonAppData%\DVDRanger\Logs|*.*
-FileKey3=%Documents%\DVDRanger\Temp|*.*|REMOVESELF
-FileKey4=%Documents%\DVDRanger\Screenshots|*.*|RECURSE
+FileKey3=%Documents%\DVDRanger\Screenshots|*.*|RECURSE
+FileKey4=%Documents%\DVDRanger\Temp|*.*|REMOVESELF
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\DVDRanger\DDF626ADdvdcss|*.*
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\DVDRanger\Logs|*.*
 FileKey7=%SystemDrive%\DVDRanger|*.*|REMOVESELF
@@ -6283,18 +6268,18 @@ RegKey1=HKCU\Software\FabPlayer|DefaultFile
 LangSecRef=3023
 Detect=HKCU\Software\DVDFab
 Default=False
-FileKey1=%Documents%\DVDFab\Log|*.*|RECURSE
-FileKey2=%Documents%\DVDFab\Temp|*.*|RECURSE
-FileKey3=%Documents%\PcSetup|*.*|RECURSE
-FileKey4=%Documents%\DVDFab*\Log|*.*|RECURSE
-FileKey5=%Documents%\DVDFab*\SceneData|*.*|RECURSE
-FileKey6=%Documents%\DVDFab*\Temp\adPixtureTemp|*.*|RECURSE
-FileKey7=%Documents%\DVDFab*\Temp\MainMovie|*.*|RECURSE
-FileKey8=%Documents%\DVDFab*\Temp\MediaServer|*.*|RECURSE
-FileKey9=%Documents%\DVDFab*\Temp\Record\webService|*.*|RECURSE
-FileKey10=%Documents%\DVDFab*\Temp\ReportCrash|*.*|RECURSE
-FileKey11=%Documents%\DVDFab*\Temp\updateTemp\adPixtureTemp|*.*|RECURSE
-FileKey12=%Documents%\DVDFab*\Temp\updateTemp\updateLog|*.*|RECURSE
+FileKey1=%Documents%\DVDFab*\Log|*.*|RECURSE
+FileKey2=%Documents%\DVDFab*\SceneData|*.*|RECURSE
+FileKey3=%Documents%\DVDFab*\Temp\adPixtureTemp|*.*|RECURSE
+FileKey4=%Documents%\DVDFab*\Temp\MainMovie|*.*|RECURSE
+FileKey5=%Documents%\DVDFab*\Temp\MediaServer|*.*|RECURSE
+FileKey6=%Documents%\DVDFab*\Temp\Record\webService|*.*|RECURSE
+FileKey7=%Documents%\DVDFab*\Temp\ReportCrash|*.*|RECURSE
+FileKey8=%Documents%\DVDFab*\Temp\updateTemp\adPixtureTemp|*.*|RECURSE
+FileKey9=%Documents%\DVDFab*\Temp\updateTemp\updateLog|*.*|RECURSE
+FileKey10=%Documents%\DVDFab\Log|*.*|RECURSE
+FileKey11=%Documents%\DVDFab\Temp|*.*|RECURSE
+FileKey12=%Documents%\PcSetup|*.*|RECURSE
 
 [DVDFab Passkey*]
 LangSecRef=3023
@@ -6308,25 +6293,21 @@ Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\DVDSmith Movie B
 Default=False
 FileKey1=%Documents%\dvdsmith|*.log
 
+[DVDVideoSoft*]
+LangSecRef=3023
+Detect1=HKCU\Software\DVDVideoSoft
+Detect2=HKCU\Software\AppDataLow\Software\DVDVideoSoftTB
+Default=False
+FileKey1=%AppData%\DVDVideoSoft\*\History|*.*|RECURSE
+FileKey2=%AppData%\DVDVideoSoft\*Logs|*.*|RECURSE
+FileKey3=%Documents%\DVDVideoSoft|*log.txt|RECURSE
+FileKey4=%LocalAppData%\DVDVideoSoftTB\Logs|*.*|RECURSE
+
 [DVDVideoSoft Backup*]
 LangSecRef=3024
 Detect=HKCU\Software\DVDVideoSoft
 Default=False
 FileKey1=%AppData%\DVDVideoSoft\Backup|*.*|RECURSE
-
-[DVDVideoSoft Toolbar Logs*]
-LangSecRef=3024
-Detect=HKCU\Software\AppDataLow\Software\DVDVideoSoftTB
-Default=False
-FileKey1=%LocalAppData%\DVDVideoSoftTB\Logs|*.*|RECURSE
-
-[DVDVideoSoft*]
-LangSecRef=3023
-Detect=HKCU\Software\DVDVideoSoft
-Default=False
-FileKey1=%AppData%\DVDVideoSoft\*Logs|*.*|RECURSE
-FileKey2=%Documents%\DVDVideoSoft|*log.txt|RECURSE
-FileKey3=%AppData%\DVDVideoSoft\*\History|*.*|RECURSE
 
 [DVDx*]
 LangSecRef=3023
@@ -6346,16 +6327,16 @@ Detect4=HKLM\Software\DxO
 Detect5=HKLM\Software\DxO Labs
 Detect6=HKLM\Software\DxOLabs
 Default=False
-FileKey1=%Documents%\DxO*\log|*.*
-FileKey2=%Documents%\DxO Optics*Pro * crash*s|*.*
-FileKey3=%Documents%\DxO Optics*Pro * logs|*.*
-FileKey4=%Documents%\DxO PhotoLab logs|*.*
+FileKey1=%Documents%\DxO Optics*Pro * crash*s|*.*
+FileKey2=%Documents%\DxO Optics*Pro * logs|*.*
+FileKey3=%Documents%\DxO PhotoLab logs|*.*
+FileKey4=%Documents%\DxO*\log|*.*
 FileKey5=%LocalAppData%\DxO\DxO PhotoLab *\Cache|*.*|RECURSE
 FileKey6=%LocalAppData%\DxO_Labs\DataCache|*.*|RECURSE
-FileKey7=%LocalAppData%\DxO_Labs\DxO*\CrashReports|*.*
-FileKey8=%LocalAppData%\DxO_Labs\DxO*\Logs|*.*
-FileKey9=%LocalAppData%\DxO_Labs\DxO*\Cache|*.*|RECURSE
-FileKey10=%LocalAppData%\DxO_Labs\DxO*\DiskCache|*.*
+FileKey7=%LocalAppData%\DxO_Labs\DxO*\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\DxO_Labs\DxO*\CrashReports|*.*
+FileKey9=%LocalAppData%\DxO_Labs\DxO*\DiskCache|*.*
+FileKey10=%LocalAppData%\DxO_Labs\DxO*\Logs|*.*
 FileKey11=%LocalAppData%\DxO_Labs\Logs|*.*
 
 [Dyn Updater*]
@@ -6370,10 +6351,10 @@ Section=Games
 Detect=HKCU\Software\EA Games\EA Core
 Default=False
 FileKey1=%CommonAppData%\EA Core\Cache|*.*|REMOVESELF
-FileKey2=%LocalAppData%\EA Core\Cache|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\EA Core\Cache|*.*|REMOVESELF
-FileKey4=%CommonAppData%\EA Logs|*.*
-FileKey5=%CommonAppData%\Electronic Arts\EA Core\logs|*.*
+FileKey2=%CommonAppData%\EA Logs|*.*
+FileKey3=%CommonAppData%\Electronic Arts\EA Core\logs|*.*
+FileKey4=%LocalAppData%\EA Core\Cache|*.*|REMOVESELF
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\EA Core\Cache|*.*|REMOVESELF
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\EA Logs|*.*
 FileKey7=%LocalAppData%\VirtualStore\ProgramData\Electronic Arts\EA Core\logs|*.*
 
@@ -6409,14 +6390,6 @@ FileKey1=%LocalAppData%\VirtualStore\Program Files*\EaseUS\EaseUS Data Recovery 
 FileKey2=%ProgramFiles%\EaseUS\EaseUS Data Recovery Wizard|*.log
 ExcludeKey1=FILE|%ProgramFiles%\EaseUS\EaseUS Data Recovery Wizard\|install.log
 
-[EaseUS MobiSaver for Android*]
-LangSecRef=3021
-Detect=HKLM\Software\EaseUS\Mobisaver for Android
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\EaseUS\EaseUS MobiSaver for Android\bin|CommDbg.txt;Eaolog;easeusue.log;mbs;PR.log
-FileKey2=%ProgramFiles%\EaseUS\EaseUS MobiSaver for Android\bin|CommDbg.txt;Eaolog;easeusue.log;mbs;PR.log
-FileKey3=%SystemDrive%\EaseUS MobiSaver for Android Temp Backup|*.*|RECURSE
-
 [EaseUS MobiSaver*]
 LangSecRef=3021
 Detect=HKLM\Software\EASEUS\EASEUS IPhone Wizard
@@ -6424,6 +6397,14 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\EaseUS\EaseUS MobiSaver\bin|CommDbg.txt;easeusue.log;PR.log
 FileKey2=%ProgramFiles%\EaseUS\EaseUS MobiSaver\bin|CommDbg.txt;easeusue.log;PR.log
 FileKey3=%SystemDrive%\EaseUS MobiSaver Temp Backup|*.*|RECURSE
+
+[EaseUS MobiSaver for Android*]
+LangSecRef=3021
+Detect=HKLM\Software\EaseUS\Mobisaver for Android
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\EaseUS\EaseUS MobiSaver for Android\bin|CommDbg.txt;Eaolog;easeusue.log;mbs;PR.log
+FileKey2=%ProgramFiles%\EaseUS\EaseUS MobiSaver for Android\bin|CommDbg.txt;Eaolog;easeusue.log;mbs;PR.log
+FileKey3=%SystemDrive%\EaseUS MobiSaver for Android Temp Backup|*.*|RECURSE
 
 [EASEUS Partition Master*]
 LangSecRef=3024
@@ -6443,16 +6424,16 @@ FileKey2=%ProgramFiles%\EaseUS\Todo Backup\bin|easeus.log;TbLogsysClient.tblog
 LangSecRef=3024
 Detect=HKLM\Software\East-Tec\east-tec Eraser
 Default=False
-FileKey1=%ProgramFiles%\east-tec Eraser|except.log
-FileKey2=%CommonAppData%\East-Tec\east-tec Eraser\Updates|*.*|RECURSE
+FileKey1=%CommonAppData%\East-Tec\east-tec Eraser\Updates|*.*|RECURSE
+FileKey2=%ProgramFiles%\east-tec Eraser|except.log
 
 [Easy CD-DA Extractor*]
 LangSecRef=3024
 Detect=HKCU\Software\Poikosoft\Easy CD-DA Extractor 8
 Default=False
-RegKey1=HKCU\Software\Poikosoft\Easy CD-DA Extractor 8|k80
-RegKey2=HKCU\Software\Poikosoft\Easy CD-DA Extractor 8|k81
-RegKey3=HKCU\Software\Poikosoft\Easy CD-DA Extractor 8|k8c
+RegKey1=HKCU\Software\Poikosoft\Easy CD-DA Extractor 8|k8c
+RegKey2=HKCU\Software\Poikosoft\Easy CD-DA Extractor 8|k80
+RegKey3=HKCU\Software\Poikosoft\Easy CD-DA Extractor 8|k81
 RegKey4=HKCU\Software\Poikosoft\Easy CD-DA Extractor 8|k91
 RegKey5=HKCU\Software\Poikosoft\Easy CD-DA Extractor 8|k92
 
@@ -6589,12 +6570,12 @@ FileKey1=%AppData%\EndNote|*.log;*.16
 FileKey2=%CommonAppData%\Thomson.ResearchSoft.Installers|*.*|REMOVESELF
 FileKey3=%CommonProgramFiles%\Risxtd|*.LOG;*.txt
 FileKey4=%Documents%\My EndNote Library.Data\Trash|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\EndNote*|*.txt
-FileKey6=%LocalAppData%\VritualStore\Program Files*\Common Files\Risxtd|*.LOG;*.txt
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\EndNote X6\Product-Support\ThirdParty\Apache2|NOTICE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Thomson.ResearchSoft.Installers|*.*|REMOVESELF
-FileKey9=%ProgramFiles%\EndNote*|*.txt
-FileKey10=%ProgramFiles%\EndNote X6\Product-Support\ThirdParty\Apache2|NOTICE
+FileKey5=%LocalAppData%\VirtualStore\Program Files*\EndNote X6\Product-Support\ThirdParty\Apache2|NOTICE
+FileKey6=%LocalAppData%\VirtualStore\Program Files*\EndNote*|*.txt
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\Thomson.ResearchSoft.Installers|*.*|REMOVESELF
+FileKey8=%LocalAppData%\VritualStore\Program Files*\Common Files\Risxtd|*.LOG;*.txt
+FileKey9=%ProgramFiles%\EndNote X6\Product-Support\ThirdParty\Apache2|NOTICE
+FileKey10=%ProgramFiles%\EndNote*|*.txt
 
 [EnhanceMy8*]
 LangSecRef=3024
@@ -6607,8 +6588,8 @@ FileKey2=%AppData%\SeriousBit\EnhanceMy8\Backups|*.*|RECURSE
 Section=Games
 Detect=HKCU\SOFTWARE\Epic Games\EpicGamesLauncher
 Default=False
-FileKey1=%LocalAppData%\EpicGamesLauncher\Saved\Logs|*.log
-FileKey2=%LocalAppData%\EpicGamesLauncher\Saved\Crashes|*.*|REMOVESELF
+FileKey1=%LocalAppData%\EpicGamesLauncher\Saved\Crashes|*.*|REMOVESELF
+FileKey2=%LocalAppData%\EpicGamesLauncher\Saved\Logs|*.log
 FileKey3=%LocalAppData%\EpicGamesLauncher\Saved\webcache|*.*|REMOVESELF
 FileKey4=%LocalAppData%\FortniteGame\Saved\Logs|*.log
 FileKey5=%LocalAppData%\FortniteGame\Saved\webcache|*.*|REMOVESELF
@@ -6626,17 +6607,6 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Eraser|schedlog.txt
 FileKey2=%ProgramFiles%\Eraser*|schedlog.txt
 
-[ESET Online Scanner*]
-LangSecRef=3024
-Detect=HKLM\Software\ESET\ESET Security
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner|log.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner\Modules\data\updfiles\temp|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner\Quarantine|*.*
-FileKey4=%ProgramFiles%\ESET\ESET Online Scanner|log.txt
-FileKey5=%ProgramFiles%\ESET\ESET Online Scanner\Modules\data\updfiles\temp|*.*
-FileKey6=%ProgramFiles%\ESET\ESET Online Scanner\Quarantine|*.*
-
 [ESET*]
 LangSecRef=3021
 Detect=HKLM\Software\ESET\ESET Security
@@ -6648,6 +6618,17 @@ FileKey3=%CommonAppData%\ESET\ESET*\Updfiles|*.*|REMOVESELF
 FileKey4=%LocalAppData%\VirtualStore\ProgramData\ESET\ESET*\Logs|*.*|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\ESET\ESET*\Oldfiles|*.*|RECURSE
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\ESET\ESET*\Updfiles|*.*|REMOVESELF
+
+[ESET Online Scanner*]
+LangSecRef=3024
+Detect=HKLM\Software\ESET\ESET Security
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner|log.txt
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner\Modules\data\updfiles\temp|*.*
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner\Quarantine|*.*
+FileKey4=%ProgramFiles%\ESET\ESET Online Scanner|log.txt
+FileKey5=%ProgramFiles%\ESET\ESET Online Scanner\Modules\data\updfiles\temp|*.*
+FileKey6=%ProgramFiles%\ESET\ESET Online Scanner\Quarantine|*.*
 
 [eSobi*]
 LangSecRef=3022
@@ -6661,8 +6642,8 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma
 Default=False
 FileKey1=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\CLR_v4.0|*.log|RECURSE
+FileKey2=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\CLR_v4.0|*.log|RECURSE
+FileKey3=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\CryptnetUrlCache\*|*.*
 FileKey5=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
 FileKey6=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\PRICache|*.*
@@ -6702,17 +6683,6 @@ DetectFile=%AppData%\EssentialPIM
 Default=False
 FileKey1=%AppData%\EssentialPIM*\Logs|*.*
 
-[Euro Truck Simulator Profile backups*]
-Section=Games
-Detect1=HKCU\Software\SCS Software
-Detect2=HKLM\Software\SCS Software
-Default=False
-Warning=This will delete your Euro Truck Simulator profile backups. A profile backup will regenerate at next start.
-FileKey1=%Documents%\Euro Truck Simulator|backups.txt
-FileKey2=%Documents%\Euro Truck Simulator\profiles*.bak|*.*|REMOVESELF
-FileKey3=%Documents%\Euro Truck Simulator 2|backups.txt
-FileKey4=%Documents%\Euro Truck Simulator 2\profiles*.bak|*.*|REMOVESELF
-
 [Euro Truck Simulator*]
 Section=Games
 Detect1=HKCU\Software\SCS Software
@@ -6720,6 +6690,17 @@ Detect2=HKLM\Software\SCS Software
 DetectFile=%ProgramFiles%\Euro Truck Simulator 2
 Default=False
 FileKey1=%Documents%\Euro Truck Simulator*|*.log;*.crash
+
+[Euro Truck Simulator Profile backups*]
+Section=Games
+Detect1=HKCU\Software\SCS Software
+Detect2=HKLM\Software\SCS Software
+Default=False
+Warning=This will delete your Euro Truck Simulator profile backups. A profile backup will regenerate at next start.
+FileKey1=%Documents%\Euro Truck Simulator|backups.txt
+FileKey2=%Documents%\Euro Truck Simulator 2|backups.txt
+FileKey3=%Documents%\Euro Truck Simulator 2\profiles*.bak|*.*|REMOVESELF
+FileKey4=%Documents%\Euro Truck Simulator\profiles*.bak|*.*|REMOVESELF
 
 [EuroSYSTEMS CoCut Professional 2011*]
 LangSecRef=3021
@@ -6891,15 +6872,6 @@ RegKey19=HKCU\Software\Far18\SavedHistory
 RegKey20=HKCU\Software\Far18\SavedViewHistory
 RegKey21=HKCU\Software\Far18\Viewer\LastPositions
 
-[Farming Simulator Old Autosaves*]
-Section=Games
-Detect=HKLM\Software\SCS Software
-Default=False
-FileKey1=%Documents%\My Games\FarmingSimulator*\savegame*|*.*|REMOVESELF
-ExcludeKey1=PATH|%Documents%\My Games\FarmingSimulator2011\savegame1\|*.*
-ExcludeKey2=PATH|%Documents%\My Games\FarmingSimulator2013\savegame1\|*.*
-ExcludeKey3=PATH|%Documents%\My Games\FarmingSimulator2013\savegameBackup\|*.*
-
 [Farming Simulator*]
 Section=Games
 Detect=HKLM\Software\SCS Software
@@ -6908,6 +6880,15 @@ FileKey1=%Documents%\My Games\FarmingSimulator*|*.txt
 FileKey2=%Documents%\My Games\FarmingSimulator*\pdlc2.1|*.dlc|REMOVESELF
 FileKey3=%Documents%\My Games\FarmingSimulator2011\shader_cache|*.xml|REMOVESELF
 FileKey4=%Documents%\My Games\FarmingSimulator2013\shader_cache|*.shc|REMOVESELF
+
+[Farming Simulator Old Autosaves*]
+Section=Games
+Detect=HKLM\Software\SCS Software
+Default=False
+FileKey1=%Documents%\My Games\FarmingSimulator*\savegame*|*.*|REMOVESELF
+ExcludeKey1=PATH|%Documents%\My Games\FarmingSimulator2011\savegame1\|*.*
+ExcludeKey2=PATH|%Documents%\My Games\FarmingSimulator2013\savegame1\|*.*
+ExcludeKey3=PATH|%Documents%\My Games\FarmingSimulator2013\savegameBackup\|*.*
 
 [Fast Clean Pro*]
 LangSecRef=3024
@@ -7210,27 +7191,27 @@ Default=False
 FileKey1=%AppData%\Foxit Software\Foxit PhantomPDF\FormFiller|AutoComplete.ds
 FileKey2=%AppData%\Foxit Software\RMS|FXRMS_Log.txt
 FileKey3=%LocalAppData%\Foxit PhantomPDF\msilog|*.log
-RegKey1=HKCU\Software\Foxit Software\Foxit PhantomPDF 6.0\Preferences\History
-RegKey2=HKCU\Software\Foxit Software\Foxit PhantomPDF 6.0\RecentFiles
-RegKey3=HKCU\Software\Foxit Software\Foxit PhantomPDF 7.0\MRU\File MRU
-RegKey4=HKCU\Software\Foxit Software\Foxit PhantomPDF 7.0\MRU\Place MRU
-RegKey5=HKCU\Software\Foxit Software\Foxit PhantomPDF 7.0\plugins\JSPlugins
-RegKey6=HKCU\Software\Foxit Software\Foxit PhantomPDF 7.0\Preferences\History
-RegKey7=HKCU\Software\Foxit Software\Foxit PhantomPDF 7.0\Recent File List
-RegKey8=HKCU\Software\Foxit Software\Foxit PhantomPDF 8.0\MRU\File MRU
-RegKey9=HKCU\Software\Foxit Software\Foxit PhantomPDF 8.0\MRU\Place MRU
-RegKey10=HKCU\Software\Foxit Software\Foxit PhantomPDF 8.0\plugins\JSPlugins
-RegKey11=HKCU\Software\Foxit Software\Foxit PhantomPDF 8.0\Preferences\History
-RegKey12=HKCU\Software\Foxit Software\Foxit PhantomPDF 8.0\Recent File List
-RegKey13=HKCU\Software\Foxit Software\Foxit PhantomPDF 8.0\Foxit PhantomPDF Advanced Editor\Recent File List
-RegKey14=HKCU\Software\Foxit Software Company\Foxit PDF Editor|Recent File List
+RegKey1=HKCU\Software\Foxit Software Company\Foxit PDF Editor|Recent File List
+RegKey2=HKCU\Software\Foxit Software\Foxit PhantomPDF 6.0\Preferences\History
+RegKey3=HKCU\Software\Foxit Software\Foxit PhantomPDF 6.0\RecentFiles
+RegKey4=HKCU\Software\Foxit Software\Foxit PhantomPDF 7.0\MRU\File MRU
+RegKey5=HKCU\Software\Foxit Software\Foxit PhantomPDF 7.0\MRU\Place MRU
+RegKey6=HKCU\Software\Foxit Software\Foxit PhantomPDF 7.0\plugins\JSPlugins
+RegKey7=HKCU\Software\Foxit Software\Foxit PhantomPDF 7.0\Preferences\History
+RegKey8=HKCU\Software\Foxit Software\Foxit PhantomPDF 7.0\Recent File List
+RegKey9=HKCU\Software\Foxit Software\Foxit PhantomPDF 8.0\Foxit PhantomPDF Advanced Editor\Recent File List
+RegKey10=HKCU\Software\Foxit Software\Foxit PhantomPDF 8.0\MRU\File MRU
+RegKey11=HKCU\Software\Foxit Software\Foxit PhantomPDF 8.0\MRU\Place MRU
+RegKey12=HKCU\Software\Foxit Software\Foxit PhantomPDF 8.0\plugins\JSPlugins
+RegKey13=HKCU\Software\Foxit Software\Foxit PhantomPDF 8.0\Preferences\History
+RegKey14=HKCU\Software\Foxit Software\Foxit PhantomPDF 8.0\Recent File List
 
 [Foxit Reader 6.0 More*]
 LangSecRef=3021
 Detect=HKCU\Software\Foxit Software\Foxit Reader 6.0
 Default=False
-FileKey1=%LocalAppData%\Foxit Reader|*.TXT;*.zip;*.reg
-FileKey2=%AppData%\Foxit Software\Foxit Reader\StartPage\Start|history.txt
+FileKey1=%AppData%\Foxit Software\Foxit Reader\StartPage\Start|history.txt
+FileKey2=%LocalAppData%\Foxit Reader|*.TXT;*.zip;*.reg
 RegKey1=HKCU\Software\Foxit Software\Foxit Reader 6.0\Preferences\History\Options
 
 [Fractal: Make Blooms Not War*]
@@ -7268,8 +7249,8 @@ FileKey1=%WinDir%\$regcmp$|*.*
 LangSecRef=3021
 DetectFile=%LocalAppData%\FreeCommanderXE
 Default=False
-FileKey1=%ProgramFiles%\FreeCommander XE\backup|*.*|REMOVESELF
-FileKey2=%LocalAppData%\FreeCommanderXE\Settings\Bkp_Settings_*|*.*|REMOVESELF
+FileKey1=%LocalAppData%\FreeCommanderXE\Settings\Bkp_Settings_*|*.*|REMOVESELF
+FileKey2=%ProgramFiles%\FreeCommander XE\backup|*.*|REMOVESELF
 
 [FreeFixer*]
 LangSecRef=3024
@@ -7311,11 +7292,11 @@ FileKey1=%AppData%\Fighters\FULL-DISKfighter\Logs|*.log;*log.txt
 FileKey2=%AppData%\Fighters\Suite\Logs|*log.txt
 FileKey3=%AppData%\Fighters\Tray\Logs|*log.txt
 FileKey4=%CommonAppData%\Common Toolkit Suite\Tools\Logs|*.log
-FileKey5=%CommonAppData%\Fighters\FULL-DISKfighter\Logs|*.log
-FileKey6=%CommonAppData%\Fighters\*\Logs|*.log
+FileKey5=%CommonAppData%\Fighters\*\Logs|*.log
+FileKey6=%CommonAppData%\Fighters\FULL-DISKfighter\Logs|*.log
 FileKey7=%LocalAppData%\VirtualStore\ProgramData\Common Toolkit Suite\Tools\Logs|*.log
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Fighters\FULL-DISKfighter\Logs|*.log
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Fighters\*\Logs|*.log
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\Fighters\*\Logs|*.log
+FileKey9=%LocalAppData%\VirtualStore\ProgramData\Fighters\FULL-DISKfighter\Logs|*.log
 
 [Full Bore*]
 Section=Games
@@ -7363,47 +7344,47 @@ Detect3=HKCU\Software\Game Maker\Version 6
 Detect4=HKCU\Software\Game Maker\Version 7
 Detect5=HKCU\Software\Game Maker\Version 8
 Default=False
-RegKey1=HKCU\Software\Game Maker 4\Preferences|Recent0
-RegKey2=HKCU\Software\Game Maker 4\Preferences|Recent1
-RegKey3=HKCU\Software\Game Maker 4\Preferences|Recent2
-RegKey4=HKCU\Software\Game Maker 4\Preferences|Recent3
-RegKey5=HKCU\Software\Game Maker 4\Preferences|GameDir
-RegKey6=HKCU\Software\Game Maker\Version 5\Preferences|Recent0
-RegKey7=HKCU\Software\Game Maker\Version 5\Preferences|Recent1
-RegKey8=HKCU\Software\Game Maker\Version 5\Preferences|Recent2
-RegKey9=HKCU\Software\Game Maker\Version 5\Preferences|Recent3
-RegKey10=HKCU\Software\Game Maker\Version 5\Preferences|Recent4
-RegKey11=HKCU\Software\Game Maker\Version 5\Preferences|Recent5
-RegKey12=HKCU\Software\Game Maker\Version 5\Preferences|Recent6
-RegKey13=HKCU\Software\Game Maker\Version 5\Preferences|Recent7
-RegKey14=HKCU\Software\Game Maker\Version 5\Preferences|GameDir
-RegKey15=HKCU\Software\Game Maker\Version 6\Preferences|Recent0
-RegKey16=HKCU\Software\Game Maker\Version 6\Preferences|Recent1
-RegKey17=HKCU\Software\Game Maker\Version 6\Preferences|Recent2
-RegKey18=HKCU\Software\Game Maker\Version 6\Preferences|Recent3
-RegKey19=HKCU\Software\Game Maker\Version 6\Preferences|Recent4
-RegKey20=HKCU\Software\Game Maker\Version 6\Preferences|Recent5
-RegKey21=HKCU\Software\Game Maker\Version 6\Preferences|Recent6
-RegKey22=HKCU\Software\Game Maker\Version 6\Preferences|Recent7
-RegKey23=HKCU\Software\Game Maker\Version 6\Preferences|GameDir
-RegKey24=HKCU\Software\Game Maker\Version 7\Preferences|Recent0
-RegKey25=HKCU\Software\Game Maker\Version 7\Preferences|Recent1
-RegKey26=HKCU\Software\Game Maker\Version 7\Preferences|Recent2
-RegKey27=HKCU\Software\Game Maker\Version 7\Preferences|Recent3
-RegKey28=HKCU\Software\Game Maker\Version 7\Preferences|Recent4
-RegKey29=HKCU\Software\Game Maker\Version 7\Preferences|Recent5
-RegKey30=HKCU\Software\Game Maker\Version 7\Preferences|Recent6
-RegKey31=HKCU\Software\Game Maker\Version 7\Preferences|Recent7
-RegKey32=HKCU\Software\Game Maker\Version 7\Preferences|GameDir
-RegKey33=HKCU\Software\Game Maker\Version 8\Preferences|Recent0
-RegKey34=HKCU\Software\Game Maker\Version 8\Preferences|Recent1
-RegKey35=HKCU\Software\Game Maker\Version 8\Preferences|Recent2
-RegKey36=HKCU\Software\Game Maker\Version 8\Preferences|Recent3
-RegKey37=HKCU\Software\Game Maker\Version 8\Preferences|Recent4
-RegKey38=HKCU\Software\Game Maker\Version 8\Preferences|Recent5
-RegKey39=HKCU\Software\Game Maker\Version 8\Preferences|Recent6
-RegKey40=HKCU\Software\Game Maker\Version 8\Preferences|Recent7
-RegKey41=HKCU\Software\Game Maker\Version 8\Preferences|GameDir
+RegKey1=HKCU\Software\Game Maker 4\Preferences|GameDir
+RegKey2=HKCU\Software\Game Maker 4\Preferences|Recent0
+RegKey3=HKCU\Software\Game Maker 4\Preferences|Recent1
+RegKey4=HKCU\Software\Game Maker 4\Preferences|Recent2
+RegKey5=HKCU\Software\Game Maker 4\Preferences|Recent3
+RegKey6=HKCU\Software\Game Maker\Version 5\Preferences|GameDir
+RegKey7=HKCU\Software\Game Maker\Version 5\Preferences|Recent0
+RegKey8=HKCU\Software\Game Maker\Version 5\Preferences|Recent1
+RegKey9=HKCU\Software\Game Maker\Version 5\Preferences|Recent2
+RegKey10=HKCU\Software\Game Maker\Version 5\Preferences|Recent3
+RegKey11=HKCU\Software\Game Maker\Version 5\Preferences|Recent4
+RegKey12=HKCU\Software\Game Maker\Version 5\Preferences|Recent5
+RegKey13=HKCU\Software\Game Maker\Version 5\Preferences|Recent6
+RegKey14=HKCU\Software\Game Maker\Version 5\Preferences|Recent7
+RegKey15=HKCU\Software\Game Maker\Version 6\Preferences|GameDir
+RegKey16=HKCU\Software\Game Maker\Version 6\Preferences|Recent0
+RegKey17=HKCU\Software\Game Maker\Version 6\Preferences|Recent1
+RegKey18=HKCU\Software\Game Maker\Version 6\Preferences|Recent2
+RegKey19=HKCU\Software\Game Maker\Version 6\Preferences|Recent3
+RegKey20=HKCU\Software\Game Maker\Version 6\Preferences|Recent4
+RegKey21=HKCU\Software\Game Maker\Version 6\Preferences|Recent5
+RegKey22=HKCU\Software\Game Maker\Version 6\Preferences|Recent6
+RegKey23=HKCU\Software\Game Maker\Version 6\Preferences|Recent7
+RegKey24=HKCU\Software\Game Maker\Version 7\Preferences|GameDir
+RegKey25=HKCU\Software\Game Maker\Version 7\Preferences|Recent0
+RegKey26=HKCU\Software\Game Maker\Version 7\Preferences|Recent1
+RegKey27=HKCU\Software\Game Maker\Version 7\Preferences|Recent2
+RegKey28=HKCU\Software\Game Maker\Version 7\Preferences|Recent3
+RegKey29=HKCU\Software\Game Maker\Version 7\Preferences|Recent4
+RegKey30=HKCU\Software\Game Maker\Version 7\Preferences|Recent5
+RegKey31=HKCU\Software\Game Maker\Version 7\Preferences|Recent6
+RegKey32=HKCU\Software\Game Maker\Version 7\Preferences|Recent7
+RegKey33=HKCU\Software\Game Maker\Version 8\Preferences|GameDir
+RegKey34=HKCU\Software\Game Maker\Version 8\Preferences|Recent0
+RegKey35=HKCU\Software\Game Maker\Version 8\Preferences|Recent1
+RegKey36=HKCU\Software\Game Maker\Version 8\Preferences|Recent2
+RegKey37=HKCU\Software\Game Maker\Version 8\Preferences|Recent3
+RegKey38=HKCU\Software\Game Maker\Version 8\Preferences|Recent4
+RegKey39=HKCU\Software\Game Maker\Version 8\Preferences|Recent5
+RegKey40=HKCU\Software\Game Maker\Version 8\Preferences|Recent6
+RegKey41=HKCU\Software\Game Maker\Version 8\Preferences|Recent7
 
 [Games for Windows Live DirectX*]
 Section=Games
@@ -7428,8 +7409,8 @@ Detect1=HKCR\GSM_gsba
 Detect2=HKCR\GSM_gsdu
 Detect3=HKCR\GSM_gsms
 Default=False
-FileKey1=%AppData%\GameSave Manager*\TaskLogs|*.*
-FileKey2=%AppData%\GameSave Manager*\*Cache*|*.*
+FileKey1=%AppData%\GameSave Manager*\*Cache*|*.*
+FileKey2=%AppData%\GameSave Manager*\TaskLogs|*.*
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\GameSave Manager*\settings|*.log;ScanResults.txt|RECURSE
 FileKey4=%ProgramFiles%\GameSave Manager*\settings|*.log;ScanResults.txt|RECURSE
 
@@ -7457,16 +7438,16 @@ FileKey3=%CommonAppData%\GarenaMessenger\cache\customAvatar\buddy|*.*
 FileKey4=%CommonAppData%\GarenaMessenger\cache\emoticon|*.*
 FileKey5=%CommonAppData%\GarenaMessenger\cache\screencapture|*.*
 FileKey6=%CommonAppData%\GarenaMessenger\garena.game.plugins|*.tmp
-FileKey7=%CommonAppData%\GarenaMessenger\UpdateManager|*.*|RECURSE
-FileKey8=%CommonAppData%\GarenaMessenger\update|*.*|RECURSE
+FileKey7=%CommonAppData%\GarenaMessenger\update|*.*|RECURSE
+FileKey8=%CommonAppData%\GarenaMessenger\UpdateManager|*.*|RECURSE
 FileKey9=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger|im.log;im.log.*
 FileKey10=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\cache\clan|*.*|RECURSE
 FileKey11=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\cache\customAvatar\buddy|*.*
 FileKey12=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\cache\emoticon|*.*
 FileKey13=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\cache\screencapture|*.*
 FileKey14=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\garena.game.plugins|*.tmp
-FileKey15=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\UpdateManager|*.*|RECURSE
-FileKey16=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\update|*.*|RECURSE
+FileKey15=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\update|*.*|RECURSE
+FileKey16=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\UpdateManager|*.*|RECURSE
 
 [Garmin Express*]
 LangSecRef=3024
@@ -7511,13 +7492,13 @@ FileKey1=%AppData%\188F1432-103A-4ffb-80F1-36B633C5C9E1|*.*|REMOVESELF
 FileKey2=%AppData%\34BE82C4-E596-4e99-A191-52C6199EBF69|*.*|REMOVESELF
 FileKey3=%AppData%\9223B3E6-70DD-4e2f-965B-DD8E02D2E20B|*.*|REMOVESELF
 FileKey4=%AppData%\Downloaded Installations|*.*|REMOVESELF
-FileKey5=%CommonAppData%\188F1432-103A-4ffb-80F1-36B633C5C9E1|*.*|REMOVESELF
-FileKey6=%CommonAppData%\34BE82C4-E596-4e99-A191-52C6199EBF69|*.*|REMOVESELF
-FileKey7=%CommonAppData%\9223B3E6-70DD-4e2f-965B-DD8E02D2E20B|*.*|REMOVESELF
-FileKey8=%CommonAppData%\9727E41D-AD6A-47cd-B9BC-CF630B6013FD|*.*|REMOVESELF
-FileKey9=%CommonAppData%\A73B37F8-7A4D-41f4-98A8-7F608CE8B98F|*.*|REMOVESELF
-FileKey10=%CommonAppData%\E1864A66-75E3-486a-BD95-D1B7D99A84A7|*.*|REMOVESELF
-FileKey11=%CommonAppData%\{755AC846-7372-4AC8-8550-C52491DAA8BD}|*.*|REMOVESELF
+FileKey5=%CommonAppData%\{755AC846-7372-4AC8-8550-C52491DAA8BD}|*.*|REMOVESELF
+FileKey6=%CommonAppData%\188F1432-103A-4ffb-80F1-36B633C5C9E1|*.*|REMOVESELF
+FileKey7=%CommonAppData%\34BE82C4-E596-4e99-A191-52C6199EBF69|*.*|REMOVESELF
+FileKey8=%CommonAppData%\9223B3E6-70DD-4e2f-965B-DD8E02D2E20B|*.*|REMOVESELF
+FileKey9=%CommonAppData%\9727E41D-AD6A-47cd-B9BC-CF630B6013FD|*.*|REMOVESELF
+FileKey10=%CommonAppData%\A73B37F8-7A4D-41f4-98A8-7F608CE8B98F|*.*|REMOVESELF
+FileKey11=%CommonAppData%\E1864A66-75E3-486a-BD95-D1B7D99A84A7|*.*|REMOVESELF
 FileKey12=%LocalAppData%\Downloaded Installations|*.*|REMOVESELF
 FileKey13=%ProgramFiles%\188F1432-103A-4ffb-80F1-36B633C5C9E1|*.*|REMOVESELF
 FileKey14=%ProgramFiles%\34BE82C4-E596-4e99-A191-52C6199EBF69|*.*|REMOVESELF
@@ -7554,8 +7535,8 @@ LangSecRef=3022
 DetectFile=%AppData%\Genieo
 Default=False
 FileKey1=%AppData%\Genieo\log|*.*|RECURSE
-FileKey2=%AppData%\Genieo\tmp|*.*|RECURSE
-FileKey3=%AppData%\Genieo\sp_cache|*.*|RECURSE
+FileKey2=%AppData%\Genieo\sp_cache|*.*|RECURSE
+FileKey3=%AppData%\Genieo\tmp|*.*|RECURSE
 
 [Genymobile Logs*]
 LangSecRef=3024
@@ -7656,8 +7637,7 @@ FileKey1=%Documents%\My Games\Gigantic\RxGame\Logs|*.log;*.dmg|RECURSE
 LangSecRef=3022
 Detect=HKCU\Software\ShalSoft\GigaTribe
 Default=False
-FileKey1=%LocalAppData%\Shalsoft\Gigatribe\*\ressources|*.*|RECURSE
-FileKey2=%LocalAppData%\Shalsoft\Gigatribe\*\resources|*.*|RECURSE
+FileKey1=%LocalAppData%\Shalsoft\Gigatribe\*\re*sources|*.*|RECURSE
 
 [GIMP 2.8 More*]
 LangSecRef=3021
@@ -7783,9 +7763,9 @@ Detect2=HKCU\Software\Google\Google Earth Pro
 Detect3=HKLM\Software\Google\Google Earth Plus
 Detect4=HKLM\Software\Google\Google Earth Pro
 Default=False
-FileKey1=%LocalLowAppData%\Google\GoogleEarth|*.tmp;*.log|RECURSE
-FileKey2=%LocalLowAppData%\Google\GoogleEarth\unified_cache_leveldb_*|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Google\GoogleEarth\client|*.log
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Google\GoogleEarth\client|*.log
+FileKey2=%LocalLowAppData%\Google\GoogleEarth|*.tmp;*.log|RECURSE
+FileKey3=%LocalLowAppData%\Google\GoogleEarth\unified_cache_leveldb_*|*.*|REMOVESELF
 FileKey4=%ProgramFiles%\Google\GoogleEarth\client|*.log
 
 [Google GBScreensaver*]
@@ -7835,8 +7815,8 @@ RegKey1=HKCU\Software\Google\Google Video Player\MRUList
 LangSecRef=3023
 DetectFile=%ProgramFiles%\GoPlayer
 Default=False
-FileKey1=%ProgramFiles%\GoPlayer|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\GoPlayer|*.log
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\GoPlayer|*.log
+FileKey2=%ProgramFiles%\GoPlayer|*.log
 
 [Gotham City Impostors*]
 Section=Games
@@ -7917,18 +7897,13 @@ Detect=HKCU\Software\Novell\Messenger
 Default=False
 FileKey1=%LocalAppData%\Novell\GroupWise Messenger\history\%username%|*.*
 
-[Growl History*]
-LangSecRef=3024
-Detect=HKCU\Software\Growl
-Default=False
-FileKey1=%LocalAppData%\Growl\*\History|*.*|RECURSE
-
 [Growl*]
 LangSecRef=3024
 Detect=HKCU\Software\Growl
 Default=False
-FileKey1=%LocalAppData%\Growl\*\ImageCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Growl\*\Log|*.*|RECURSE
+FileKey1=%LocalAppData%\Growl\*\History|*.*|RECURSE
+FileKey2=%LocalAppData%\Growl\*\ImageCache|*.*|RECURSE
+FileKey3=%LocalAppData%\Growl\*\Log|*.*|RECURSE
 
 [GSpot*]
 LangSecRef=3024
@@ -8022,10 +7997,10 @@ FileKey2=%LocalAppData%\VirtualStore\ProgramData\AltrixSoft\Hard Drive Inspector
 LangSecRef=3024
 Detect=HKLM\SOFTWARE\Hauppauge
 Default=False
-FileKey1=%SystemDrive%\|hcwDriverInstall.txt
-FileKey2=%Public%\WinTV|Settings-old.xml
-FileKey3=%Public%\WinTV\Channel Database|hcwChanDB_5-lastgood.mdb
-FileKey4=%Public%\WinTV\Logs\minidump|*.*|RECURSE
+FileKey1=%Public%\WinTV|Settings-old.xml
+FileKey2=%Public%\WinTV\Channel Database|hcwChanDB_5-lastgood.mdb
+FileKey3=%Public%\WinTV\Logs\minidump|*.*|RECURSE
+FileKey4=%SystemDrive%\|hcwDriverInstall.txt
 
 [HDD Health*]
 LangSecRef=3022
@@ -8115,13 +8090,13 @@ Detect3=HKCU\Software\HitMan Pro 3
 Detect4=HKLM\SOFTWARE\HitmanPro
 Default=False
 FileKey1=%CommonAppData%\HitmanPro\Logs|*.*
-FileKey2=%ProgramFiles%\Hitman Pro*\downloads|*.*
-FileKey3=%ProgramFiles%\Hitman Pro*\logs|*.htm
-FileKey4=%ProgramFiles%\Hitman Pro*\updates|*.*
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Hitman Pro*\downloads|*.*
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Hitman Pro*\logs|*.htm
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Hitman Pro*\updates|*.*
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\HitmanPro\Logs|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Hitman Pro*\downloads|*.*
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Hitman Pro*\logs|*.htm
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\Hitman Pro*\updates|*.*
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\HitmanPro\Logs|*.*
+FileKey6=%ProgramFiles%\Hitman Pro*\downloads|*.*
+FileKey7=%ProgramFiles%\Hitman Pro*\logs|*.htm
+FileKey8=%ProgramFiles%\Hitman Pro*\updates|*.*
 
 [Holiday Express*]
 Section=Games
@@ -8279,8 +8254,8 @@ LangSecRef=3024
 DetectFile1=%SystemDrive%\swsetup
 DetectFile2=%SystemDrive%\HP Universal Print Driver
 Default=False
-FileKey1=%SystemDrive%\swsetup|*.*|REMOVESELF
-FileKey2=%SystemDrive%\HP Universal Print Driver|*.*|REMOVESELF
+FileKey1=%SystemDrive%\HP Universal Print Driver|*.*|REMOVESELF
+FileKey2=%SystemDrive%\swsetup|*.*|REMOVESELF
 
 [HP Logs*]
 LangSecRef=3021
@@ -8403,10 +8378,10 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\HuluLLC.HuluPlus_fphbd361v8tya
 Default=False
 FileKey1=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\Temp|*.*
-FileKey3=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey4=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\TempState|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\LocalState|*.tmp|RECURSE
+FileKey2=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey3=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\Temp|*.*
+FileKey4=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\LocalState|*.tmp|RECURSE
+FileKey5=%LocalAppData%\Packages\HuluLLC.HuluPlus_*\TempState|*.*|RECURSE
 ExcludeKey1=FILE|%LocalAppData%\Packages\HuluLLC.HuluPlus_*\AC\INetCache\|container.dat
 
 [Huru Beach Party*]
@@ -8426,11 +8401,11 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\19120CensoredUser.HyperforYouTube_c0tqyanwsgfn6
 DetectFile=%LocalAppData%\Packages\19120CensoredUser.HyperforYouTube_c0tqyanwsgfn6
 Default=False
-FileKey1=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey2=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\*.HyperforYouTube_*\TempState|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\*.HyperforYouTube_*\LocalState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey4=%LocalAppData%\Packages\*.HyperforYouTube_*\LocalState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\*.HyperforYouTube_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\19120CensoredUser.HyperforYouTube_c0tqyanwsgfn6\SearchHistory
 
 [HyperSnap 7*]
@@ -8464,8 +8439,8 @@ FileKey1=%LocalAppData%\|IconCache.db
 LangSecRef=3024
 Detect=HKCU\Software\MiTeC\Icon Explorer
 Default=False
-RegKey1=HKCU\Software\MiTeC\Icon Explorer\4.x\wnd_icoexp_Main|ShellTree_StartInFolder
-RegKey2=HKCU\Software\MiTeC\Icon Explorer\4.x\wnd_icoexp_Main|de_Text
+RegKey1=HKCU\Software\MiTeC\Icon Explorer\4.x\wnd_icoexp_Main|de_Text
+RegKey2=HKCU\Software\MiTeC\Icon Explorer\4.x\wnd_icoexp_Main|ShellTree_StartInFolder
 
 [IconCool Editor*]
 LangSecRef=3024
@@ -8487,14 +8462,6 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\ID Security Suite\ID Privacy Shield\logs|*.*|RECURSE
 FileKey2=%ProgramFiles%\ID Security Suite\ID Privacy Shield\logs|*.*|RECURSE
 
-[IDEA History*]
-LangSecRef=3021
-Detect1=HKCU\Software\JetBrains\IntelliJ IDEA
-Detect2=HKCU\Software\JetBrains\IntelliJ IDEA Community Edition
-Default=False
-FileKey1=%UserProfile%\.IdeaC*\System\LocalHistory|*.*
-FileKey2=%UserProfile%\.IntelliJIdea12\system\LocalHistory|*.*
-
 [IDEA*]
 LangSecRef=3021
 Detect1=HKCU\Software\JetBrains\IntelliJ IDEA
@@ -8506,6 +8473,14 @@ FileKey3=%UserProfile%\.IdeaC*\System\tmp|*.*|RECURSE
 FileKey4=%UserProfile%\.IntelliJIdea12\system\Caches|*.*
 FileKey5=%UserProfile%\.IntelliJIdea12\system\log|*.*
 FileKey6=%UserProfile%\.IntelliJIdea12\system\tmp|*.*|RECURSE
+
+[IDEA History*]
+LangSecRef=3021
+Detect1=HKCU\Software\JetBrains\IntelliJ IDEA
+Detect2=HKCU\Software\JetBrains\IntelliJ IDEA Community Edition
+Default=False
+FileKey1=%UserProfile%\.IdeaC*\System\LocalHistory|*.*
+FileKey2=%UserProfile%\.IntelliJIdea12\system\LocalHistory|*.*
 
 [IdeaSoft Scrapbooks Plus 1.0*]
 LangSecRef=3021
@@ -8623,11 +8598,11 @@ ExcludeKey1=FILE|%AppData%\iMobie\PhoneClean\iMobieConfig\|ConfigReg.ini
 LangSecRef=3024
 DetectFile=%AppData%\iMobie\PhoneRescue
 Default=False
-FileKey1=%AppData%\iMobie\PhoneRescue\AutoUpdate|*.*|RECURSE
-FileKey2=%AppData%\iMobie\PhoneRescue\Configue|Settings.plist
-FileKey3=%AppData%\iMobie\PhoneRescue\ErrorLog|*.*|RECURSE
-FileKey4=%AppData%\iMobie\PhoneRescue\Files|*.*|RECURSE
-FileKey5=%AppData%\iMobie\PhoneRescue|iTunesPrefs
+FileKey1=%AppData%\iMobie\PhoneRescue|iTunesPrefs
+FileKey2=%AppData%\iMobie\PhoneRescue\AutoUpdate|*.*|RECURSE
+FileKey3=%AppData%\iMobie\PhoneRescue\Configue|Settings.plist
+FileKey4=%AppData%\iMobie\PhoneRescue\ErrorLog|*.*|RECURSE
+FileKey5=%AppData%\iMobie\PhoneRescue\Files|*.*|RECURSE
 
 [iMobie PhoneTrans Pro*]
 LangSecRef=3024
@@ -8643,8 +8618,8 @@ ExcludeKey1=FILE|%AppData%\iMobie\PhoneTrans\iMobieConfig\|ConfigReg.ini
 LangSecRef=3023
 Detect=HKCU\Software\ImTOO\iPad Video Converter
 Default=False
-FileKey1=%ProgramFiles%\ImTOO\iPad Video Converter|*.log;ERRORLOG.TXT
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\ImTOO\iPad Video Converter|*.log;ERRORLOG.TXT
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\ImTOO\iPad Video Converter|*.log;ERRORLOG.TXT
+FileKey2=%ProgramFiles%\ImTOO\iPad Video Converter|*.log;ERRORLOG.TXT
 
 [ImTOO Video Converter Ultimate*]
 LangSecRef=3023
@@ -8667,8 +8642,8 @@ FileKey2=%AppData%\IMVU|*.db;mini.dmp.bak;*.pickle;*.jpg;*.txt;*.log.*;*.log
 FileKey3=%AppData%\IMVU\*Cache|*.*|REMOVESELF
 FileKey4=%AppData%\IMVUClient|*.icns|RECURSE
 FileKey5=%AppData%\IMVUClient\installer|*.*|RECURSE
-FileKey6=%AppData%\IMVUClient\ui\profile\cache|*.*|REMOVESELF
-FileKey7=%AppData%\IMVUClient\ui\profile|*.sqlite;*.js;*.dat;*.mfl
+FileKey6=%AppData%\IMVUClient\ui\profile|*.sqlite;*.js;*.dat;*.mfl
+FileKey7=%AppData%\IMVUClient\ui\profile\cache|*.*|REMOVESELF
 
 [Incredimail*]
 LangSecRef=3022
@@ -8697,8 +8672,8 @@ FileKey3=%UserProfile%\|.recently-used.xbel
 LangSecRef=3022
 Detect=HKCU\Software\Inky
 Default=False
-FileKey1=%LocalAppData%\Inky|data_*;f_*;index;*.log
-FileKey2=%LocalAppData%\Arcode\Plugin|*.log|RECURSE
+FileKey1=%LocalAppData%\Arcode\Plugin|*.log|RECURSE
+FileKey2=%LocalAppData%\Inky|data_*;f_*;index;*.log
 FileKey3=%LocalAppData%\Inky\Local Storage|*.*
 
 [Inno Setup*]
@@ -8744,18 +8719,14 @@ Detect=HKCU\Software\MetaGeek, LLC\inSSIDer Home
 Default=False
 FileKey1=%LocalAppData%\MetaGeek,_LLC|ConnectionErrorLog;MetaGeek-OUI.backup
 
-[InstallShield Installation Information Logs*]
-LangSecRef=3024
-Detect=HKCU\Software\InstallShield
-DetectFile=%ProgramFiles%\Installshield Installation Information
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\InstallShield Installation Information|*.log|RECURSE
-FileKey2=%ProgramFiles%\InstallShield Installation Information|*.log|RECURSE
-
-[InstallShield Professional*]
+[InstallShield*]
 LangSecRef=3021
 Detect=HKCU\Software\InstallShield
 Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\InstallShield Installation Information|*.log|RECURSE
+FileKey2=%ProgramFiles%\|_ISTMP1.DIR
+FileKey3=%ProgramFiles%\InstallShield Installation Information|*.log|RECURSE
+FileKey4=%SystemDrive%\|_ISTMP*.DIR
 RegKey1=HKCU\Software\InstallShield\16.0\Professional\Recent File List
 RegKey2=HKCU\Software\InstallShield\17.0\Professional\Recent File List
 RegKey3=HKCU\Software\InstallShield\18.0\Professional\Recent File List
@@ -8767,13 +8738,6 @@ RegKey8=HKCU\Software\InstallShield\InstallShield Professional\6.0\IsCabVu|MRU1
 RegKey9=HKCU\Software\InstallShield\InstallShield Professional\6.0\IsCabVu|MRU2
 RegKey10=HKCU\Software\InstallShield\InstallShield Professional\6.0\IsCabVu|MRU3
 RegKey11=HKCU\Software\InstallShield\InstallShield Professional\6.0\IsCabVu|MRU4
-
-[InstallShield*]
-LangSecRef=3024
-Detect=HKCU\Software\InstallShield
-Default=False
-FileKey1=%ProgramFiles%\|_ISTMP1.DIR
-FileKey2=%SystemDrive%\|_ISTMP*.DIR
 
 [Instant Dungeon!*]
 Section=Games
@@ -8843,11 +8807,11 @@ Default=False
 FileKey1=%CommonAppData%\intel|*.log|REMOVESELF
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Intel\InfInst|*.*|REMOVESELF
 FileKey3=%ProgramFiles%\Intel\InfInst|*.*|REMOVESELF
-FileKey4=%UserProfile%\Intel\Logs|*.log
-FileKey5=%WinDir%\debug\intel\logs|*.*|REMOVESELF
-FileKey6=%WinDir%\SysWOW64\config\systemprofile\Intel\Logs|*.*|REMOVESELF
+FileKey4=%SystemDrive%\Intel\Logs|*.log
+FileKey5=%UserProfile%\Intel\Logs|*.log
+FileKey6=%WinDir%\debug\intel\logs|*.*|REMOVESELF
 FileKey7=%WinDir%\System32\config\systemprofile\Intel\Logs|*.*|REMOVESELF
-FileKey8=%SystemDrive%\Intel\Logs|*.log
+FileKey8=%WinDir%\SysWOW64\config\systemprofile\Intel\Logs|*.*|REMOVESELF
 
 [Intel Rapid Storage Technology Logs*]
 LangSecRef=3021
@@ -8872,8 +8836,8 @@ FileKey2=%ProgramFiles%\Inter-Tel|*.log|RECURSE
 Section=Games
 DetectFile=%CommonAppData%\InterAction studios\CI2rmdemo
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\ProgramData\InterAction studios\CI2rmdemo|*.log|RECURSE
-FileKey2=%CommonAppData%\InterAction studios\CI2rmdemo|*.log|RECURSE
+FileKey1=%CommonAppData%\InterAction studios\CI2rmdemo|*.log|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\ProgramData\InterAction studios\CI2rmdemo|*.log|RECURSE
 
 [Internet Business Promoter*]
 LangSecRef=3022
@@ -8886,85 +8850,102 @@ LangSecRef=3022
 Detect=HKCU\Software\DownloadManager
 Default=False
 Warning=This will delete unfinished downloads.
-FileKey1=%AppData%\IDM\DwnlData|*.*|REMOVESELF
-FileKey2=%AppData%\IDM|*.Log
+FileKey1=%AppData%\IDM|*.Log
+FileKey2=%AppData%\IDM\DwnlData|*.*|REMOVESELF
 FileKey3=%ProgramFiles%\Internet Download Manager|*.log
-RegKey1=HKCU\Software\DownloadManager\maxID
-RegKey2=HKCU\Software\DownloadManager\1
-RegKey3=HKCU\Software\DownloadManager\2
-RegKey4=HKCU\Software\DownloadManager\3
-RegKey5=HKCU\Software\DownloadManager\4
-RegKey6=HKCU\Software\DownloadManager\5
-RegKey7=HKCU\Software\DownloadManager\6
-RegKey8=HKCU\Software\DownloadManager\7
-RegKey9=HKCU\Software\DownloadManager\8
-RegKey10=HKCU\Software\DownloadManager\9
-RegKey11=HKCU\Software\DownloadManager\10
-RegKey12=HKCU\Software\DownloadManager\11
-RegKey13=HKCU\Software\DownloadManager\12
-RegKey14=HKCU\Software\DownloadManager\13
-RegKey15=HKCU\Software\DownloadManager\14
-RegKey16=HKCU\Software\DownloadManager\15
-RegKey17=HKCU\Software\DownloadManager\16
-RegKey18=HKCU\Software\DownloadManager\17
-RegKey19=HKCU\Software\DownloadManager\18
-RegKey20=HKCU\Software\DownloadManager\19
-RegKey21=HKCU\Software\DownloadManager\20
-RegKey22=HKCU\Software\DownloadManager\21
-RegKey23=HKCU\Software\DownloadManager\22
-RegKey24=HKCU\Software\DownloadManager\23
-RegKey25=HKCU\Software\DownloadManager\24
-RegKey26=HKCU\Software\DownloadManager\25
-RegKey27=HKCU\Software\DownloadManager\26
-RegKey28=HKCU\Software\DownloadManager\27
-RegKey29=HKCU\Software\DownloadManager\28
-RegKey30=HKCU\Software\DownloadManager\29
-RegKey31=HKCU\Software\DownloadManager\30
-RegKey32=HKCU\Software\DownloadManager\31
-RegKey33=HKCU\Software\DownloadManager\32
-RegKey34=HKCU\Software\DownloadManager\33
-RegKey35=HKCU\Software\DownloadManager\34
-RegKey36=HKCU\Software\DownloadManager\35
-RegKey37=HKCU\Software\DownloadManager\36
-RegKey38=HKCU\Software\DownloadManager\37
-RegKey39=HKCU\Software\DownloadManager\38
-RegKey40=HKCU\Software\DownloadManager\39
-RegKey41=HKCU\Software\DownloadManager\40
-RegKey42=HKCU\Software\DownloadManager\41
-RegKey43=HKCU\Software\DownloadManager\42
-RegKey44=HKCU\Software\DownloadManager\43
-RegKey45=HKCU\Software\DownloadManager\44
-RegKey46=HKCU\Software\DownloadManager\45
-RegKey47=HKCU\Software\DownloadManager\46
-RegKey48=HKCU\Software\DownloadManager\47
-RegKey49=HKCU\Software\DownloadManager\48
-RegKey50=HKCU\Software\DownloadManager\49
-RegKey51=HKCU\Software\DownloadManager\50
-RegKey52=HKCU\Software\DownloadManager\51
-RegKey53=HKCU\Software\DownloadManager\52
-RegKey54=HKCU\Software\DownloadManager\53
-RegKey55=HKCU\Software\DownloadManager\54
-RegKey56=HKCU\Software\DownloadManager\55
-RegKey57=HKCU\Software\DownloadManager\56
-RegKey58=HKCU\Software\DownloadManager\57
-RegKey59=HKCU\Software\DownloadManager\58
-RegKey60=HKCU\Software\DownloadManager\59
-RegKey61=HKCU\Software\DownloadManager\60
-RegKey62=HKCU\Software\DownloadManager\61
-RegKey63=HKCU\Software\DownloadManager\62
-RegKey64=HKCU\Software\DownloadManager\63
-RegKey65=HKCU\Software\DownloadManager\64
-RegKey66=HKCU\Software\DownloadManager\65
-RegKey67=HKCU\Software\DownloadManager\66
-RegKey68=HKCU\Software\DownloadManager\67
-RegKey69=HKCU\Software\DownloadManager\68
-RegKey70=HKCU\Software\DownloadManager\69
-RegKey71=HKCU\Software\DownloadManager\70
-RegKey72=HKCU\Software\DownloadManager\71
-RegKey73=HKCU\Software\DownloadManager\72
-RegKey74=HKCU\Software\DownloadManager\73
-RegKey75=HKCU\Software\DownloadManager\74
-RegKey76=HKCU\Software\DownloadManager\75
+RegKey1=HKCU\Software\DownloadManager\1
+RegKey2=HKCU\Software\DownloadManager\2
+RegKey3=HKCU\Software\DownloadManager\3
+RegKey4=HKCU\Software\DownloadManager\4
+RegKey5=HKCU\Software\DownloadManager\5
+RegKey6=HKCU\Software\DownloadManager\6
+RegKey7=HKCU\Software\DownloadManager\7
+RegKey8=HKCU\Software\DownloadManager\8
+RegKey9=HKCU\Software\DownloadManager\9
+RegKey10=HKCU\Software\DownloadManager\10
+RegKey11=HKCU\Software\DownloadManager\11
+RegKey12=HKCU\Software\DownloadManager\12
+RegKey13=HKCU\Software\DownloadManager\13
+RegKey14=HKCU\Software\DownloadManager\14
+RegKey15=HKCU\Software\DownloadManager\15
+RegKey16=HKCU\Software\DownloadManager\16
+RegKey17=HKCU\Software\DownloadManager\17
+RegKey18=HKCU\Software\DownloadManager\18
+RegKey19=HKCU\Software\DownloadManager\19
+RegKey20=HKCU\Software\DownloadManager\20
+RegKey21=HKCU\Software\DownloadManager\21
+RegKey22=HKCU\Software\DownloadManager\22
+RegKey23=HKCU\Software\DownloadManager\23
+RegKey24=HKCU\Software\DownloadManager\24
+RegKey25=HKCU\Software\DownloadManager\25
+RegKey26=HKCU\Software\DownloadManager\26
+RegKey27=HKCU\Software\DownloadManager\27
+RegKey28=HKCU\Software\DownloadManager\28
+RegKey29=HKCU\Software\DownloadManager\29
+RegKey30=HKCU\Software\DownloadManager\30
+RegKey31=HKCU\Software\DownloadManager\31
+RegKey32=HKCU\Software\DownloadManager\32
+RegKey33=HKCU\Software\DownloadManager\33
+RegKey34=HKCU\Software\DownloadManager\34
+RegKey35=HKCU\Software\DownloadManager\35
+RegKey36=HKCU\Software\DownloadManager\36
+RegKey37=HKCU\Software\DownloadManager\37
+RegKey38=HKCU\Software\DownloadManager\38
+RegKey39=HKCU\Software\DownloadManager\39
+RegKey40=HKCU\Software\DownloadManager\40
+RegKey41=HKCU\Software\DownloadManager\41
+RegKey42=HKCU\Software\DownloadManager\42
+RegKey43=HKCU\Software\DownloadManager\43
+RegKey44=HKCU\Software\DownloadManager\44
+RegKey45=HKCU\Software\DownloadManager\45
+RegKey46=HKCU\Software\DownloadManager\46
+RegKey47=HKCU\Software\DownloadManager\47
+RegKey48=HKCU\Software\DownloadManager\48
+RegKey49=HKCU\Software\DownloadManager\49
+RegKey50=HKCU\Software\DownloadManager\50
+RegKey51=HKCU\Software\DownloadManager\51
+RegKey52=HKCU\Software\DownloadManager\52
+RegKey53=HKCU\Software\DownloadManager\53
+RegKey54=HKCU\Software\DownloadManager\54
+RegKey55=HKCU\Software\DownloadManager\55
+RegKey56=HKCU\Software\DownloadManager\56
+RegKey57=HKCU\Software\DownloadManager\57
+RegKey58=HKCU\Software\DownloadManager\58
+RegKey59=HKCU\Software\DownloadManager\59
+RegKey60=HKCU\Software\DownloadManager\60
+RegKey61=HKCU\Software\DownloadManager\61
+RegKey62=HKCU\Software\DownloadManager\62
+RegKey63=HKCU\Software\DownloadManager\63
+RegKey64=HKCU\Software\DownloadManager\64
+RegKey65=HKCU\Software\DownloadManager\65
+RegKey66=HKCU\Software\DownloadManager\66
+RegKey67=HKCU\Software\DownloadManager\67
+RegKey68=HKCU\Software\DownloadManager\68
+RegKey69=HKCU\Software\DownloadManager\69
+RegKey70=HKCU\Software\DownloadManager\70
+RegKey71=HKCU\Software\DownloadManager\71
+RegKey72=HKCU\Software\DownloadManager\72
+RegKey73=HKCU\Software\DownloadManager\73
+RegKey74=HKCU\Software\DownloadManager\74
+RegKey75=HKCU\Software\DownloadManager\75
+RegKey76=HKCU\Software\DownloadManager\maxID
+
+[Internet Explorer*]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\windows_ie_ac_001
+DetectFile=%LocalAppData%\Packages\windows_ie_ac_001
+Default=False
+FileKey1=%LocalAppData%\Packages\windows_ie_ac_*\AC\AppCache|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\windows_ie_ac_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\windows_ie_ac_*\AC\PRICache|*.*
+FileKey7=%LocalAppData%\Packages\windows_ie_ac_*\AC\Temp|*.*
+FileKey8=%LocalAppData%\Packages\windows_ie_ac_*\LocalState\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\windows_ie_ac_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\windows_ie_ac_*\TempState|*.*|RECURSE
+RegKey1=HKCR\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\windows_ie_ac_001\Internet Explorer\DOMStorage
 
 [Internet Explorer More*]
 LangSecRef=3022
@@ -8978,8 +8959,8 @@ FileKey5=%LocalAppData%\Microsoft\SmartScreen|*.tmp
 FileKey6=%LocalAppData%\Microsoft\Windows\*Cache*|*.*|RECURSE
 FileKey7=%LocalLowAppData%\Microsoft\Internet Explorer\iconcache|*.*|RECURSE
 FileKey8=%LocalLowAppData%\Microsoft\Windows\AppCache|*.*|RECURSE
-FileKey9=%SystemDrive%\Documents and Settings\Default User\Application Data\Microsoft\Internet Explorer|brndlog.bak;brndlog.txt
-FileKey10=%SystemDrive%\Documents and Settings\*Service\IETldCache|*.*|RECURSE
+FileKey9=%SystemDrive%\Documents and Settings\*Service\IETldCache|*.*|RECURSE
+FileKey10=%SystemDrive%\Documents and Settings\Default User\Application Data\Microsoft\Internet Explorer|brndlog.bak;brndlog.txt
 FileKey11=%WinDir%\ServiceProfiles\*Service\AppData\Roaming\Microsoft\Windows\IETldCache|*.*|RECURSE
 FileKey12=%WinDir%\System32\config\Systemprofile\AppData\Local\Microsoft\Windows\INetCache|*.*|RECURSE
 FileKey13=%WinDir%\System32\config\SystemProfile\AppData\LocalLow\Microsoft\Internet Explorer|brndlog.bak;brndlog.txt
@@ -9002,23 +8983,6 @@ Detect=HKCU\Software\Microsoft\Internet Explorer
 Default=False
 Warning=This will clear the saved passwords in the Windows Mail App
 FileKey1=%LocalAppData%\Microsoft\Vault\*|*.vcrd
-
-[Internet Explorer*]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\windows_ie_ac_001
-DetectFile=%LocalAppData%\Packages\windows_ie_ac_001
-Default=False
-FileKey1=%LocalAppData%\Packages\windows_ie_ac_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\windows_ie_ac_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey5=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\windows_ie_ac_*\AC\PRICache|*.*
-FileKey7=%LocalAppData%\Packages\windows_ie_ac_*\AC\Temp|*.*
-FileKey8=%LocalAppData%\Packages\windows_ie_ac_*\LocalState\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\windows_ie_ac_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\windows_ie_ac_*\TempState|*.*|RECURSE
-RegKey1=HKCR\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\windows_ie_ac_001\Internet Explorer\DOMStorage
 
 [Intuit Data Protect*]
 LangSecRef=3024
@@ -9049,18 +9013,18 @@ FileKey1=%AppData%\Intuit*|*.log|RECURSE
 FileKey2=%CommonAppData%\|*.bc
 FileKey3=%CommonAppData%\Intuit*|*.log|RECURSE
 FileKey4=%CommonAppData%\Intuit\Common\Metrix\*\Logs|*.*
-FileKey5=%CommonAppData%\Intuit\Common\Update Service\*\Logs|*.*
-FileKey6=%CommonAppData%\Intuit\Common\QuickBaseClient\*\Logs|*.*
+FileKey5=%CommonAppData%\Intuit\Common\QuickBaseClient\*\Logs|*.*
+FileKey6=%CommonAppData%\Intuit\Common\Update Service\*\Logs|*.*
 FileKey7=%CommonAppData%\Intuit\TurboTax\MSI\*\Logs|*.*
 FileKey8=%CommonProgramFiles%\Intuit\Internet Client|Msdun13.exe
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\TurboTax*|*.txt
-FileKey10=%LocalAppData%\VirtualStore\ProgramData|*.bc
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\Intuit*|*.log|RECURSE
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\Intuit\Common\Metrix\*\Logs|*.*
-FileKey13=%LocalAppData%\VirtualStore\ProgramData\Intuit\Common\Update Service\*\Logs|*.*
+FileKey9=%LocalAppData%\VirtualStore\Program Files*\Common Files\Intuit\Internet Client|Msdun13.exe
+FileKey10=%LocalAppData%\VirtualStore\Program Files*\TurboTax*|*.txt
+FileKey11=%LocalAppData%\VirtualStore\ProgramData|*.bc
+FileKey12=%LocalAppData%\VirtualStore\ProgramData\Intuit*|*.log|RECURSE
+FileKey13=%LocalAppData%\VirtualStore\ProgramData\Intuit\Common\Metrix\*\Logs|*.*
 FileKey14=%LocalAppData%\VirtualStore\ProgramData\Intuit\Common\QuickBaseClient\*\Logs|*.*
-FileKey15=%LocalAppData%\VirtualStore\ProgramData\Intuit\TurboTax\MSI\*\Logs|*.*
-FileKey16=%LocalAppData%\VirtualStore\Program Files*\Common Files\Intuit\Internet Client|Msdun13.exe
+FileKey15=%LocalAppData%\VirtualStore\ProgramData\Intuit\Common\Update Service\*\Logs|*.*
+FileKey16=%LocalAppData%\VirtualStore\ProgramData\Intuit\TurboTax\MSI\*\Logs|*.*
 FileKey17=%ProgramFiles%\TurboTax*|*.txt
 
 [IObit Advanced SystemCare Logs*]
@@ -9068,9 +9032,9 @@ LangSecRef=3024
 DetectFile1=%AppData%\IObit\Advanced SystemCare V5
 DetectFile2=%CommonAppData%\IObit\Advanced SystemCare V*
 Default=False
-FileKey1=%AppData%\IObit\Advanced SystemCare V5\Log|*.*|RECURSE
-FileKey2=%AppData%\IObit\Advanced SystemCare *|*.log
-FileKey3=%AppData%\IObit\Advanced SystemCare *\Boottime|*.log
+FileKey1=%AppData%\IObit\Advanced SystemCare *|*.log
+FileKey2=%AppData%\IObit\Advanced SystemCare *\Boottime|*.log
+FileKey3=%AppData%\IObit\Advanced SystemCare V5\Log|*.*|RECURSE
 FileKey4=%CommonAppData%\IObit\Advanced SystemCare V6\Log|*.*|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\Program Files*\IObit\Advanced SystemCare *|*.log;*.txt
 FileKey6=%LocalAppData%\VirtualStore\Program Files*\IObit\Advanced SystemCare 6\BootTimeLog|*.log
@@ -9130,6 +9094,15 @@ Default=False
 FileKey1=%AppData%\IObit\Driver Booster|*.log|RECURSE
 FileKey2=%ProgramFiles%\IObit\Driver Booster|*.log
 
+[IObit Game Booster*]
+LangSecRef=3024
+DetectFile=%ProgramFiles%\IObit\Game Booster 3
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3|*.log
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3\Update|Update.tmp
+FileKey3=%ProgramFiles%\IObit\Game Booster 3|*.log
+FileKey4=%ProgramFiles%\IObit\Game Booster 3\Update|Update.tmp
+
 [IObit Game Booster 3 GameBox*]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\IObit\Game Booster 3
@@ -9151,15 +9124,6 @@ DetectFile=%ProgramFiles%\IObit\Game Booster 3
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3\FPS|*.*|RECURSE
 FileKey2=%ProgramFiles%\IObit\Game Booster 3\FPS|*.*|RECURSE
-
-[IObit Game Booster*]
-LangSecRef=3024
-DetectFile=%ProgramFiles%\IObit\Game Booster 3
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3\Update|Update.tmp
-FileKey3=%ProgramFiles%\IObit\Game Booster 3|*.log
-FileKey4=%ProgramFiles%\IObit\Game Booster 3\Update|Update.tmp
 
 [IObit KB Downloader*]
 LangSecRef=3024
@@ -9301,13 +9265,6 @@ DetectFile=%AppData%\iZotope\iZotope RX 2 Session Data
 Default=False
 FileKey1=%AppData%\iZotope\iZotope RX 2 Session Data|*.*|RECURSE
 
-[Jabbear Chat History*]
-LangSecRef=3022
-Detect=HKCU\Software\Jabbear
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Jabbear\Users|*.dat;*.html|RECURSE
-FileKey2=%ProgramFiles%\Jabbear\Users|*.dat;*.html|RECURSE
-
 [Jabbear*]
 LangSecRef=3022
 Detect=HKCU\Software\Jabbear
@@ -9318,6 +9275,13 @@ FileKey3=%LocalAppData%\VirtualStore\Program Files*\Jabbear\cachedir|*.*|RECURSE
 FileKey4=%ProgramFiles%\Jabbear|*.log|RECURSE
 FileKey5=%ProgramFiles%\Jabbear\avatars|*.*|RECURSE
 FileKey6=%ProgramFiles%\Jabbear\cachedir|*.*|RECURSE
+
+[Jabbear Chat History*]
+LangSecRef=3022
+Detect=HKCU\Software\Jabbear
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Jabbear\Users|*.dat;*.html|RECURSE
+FileKey2=%ProgramFiles%\Jabbear\Users|*.dat;*.html|RECURSE
 
 [Jagex Cache*]
 Section=Games
@@ -9475,8 +9439,8 @@ ExcludeKey2=PATH|%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*\cfg\|
 LangSecRef=3021
 DetectFile=%UserProfile%\.jedit
 Default=False
-FileKey1=%UserProfile%\.jedit\jars-cache|*.*|RECURSE
-FileKey2=%UserProfile%\.jedit|*.log|RECURSE
+FileKey1=%UserProfile%\.jedit|*.log|RECURSE
+FileKey2=%UserProfile%\.jedit\jars-cache|*.*|RECURSE
 
 [JetBrains dotPeek v1.1*]
 LangSecRef=3024
@@ -9524,18 +9488,18 @@ Default=False
 FileKey1=%LocalAppData%\TechSmith\Jing\DataStore|*.*|RECURSE
 FileKey2=%LocalAppData%\TechSmith\Jing\Temp|*.*|RECURSE
 
-[Jitsi Chat/File History*]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\Jitsi
-Default=False
-FileKey1=%AppData%\Jitsi\History*|*.*|RECURSE
-
 [Jitsi*]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Jitsi
 Default=False
 FileKey1=%AppData%\Jitsi\avatarcache|*.*|RECURSE
 FileKey2=%AppData%\Jitsi\Log|*.*|RECURSE
+
+[Jitsi Chat/File History*]
+LangSecRef=3022
+DetectFile=%ProgramFiles%\Jitsi
+Default=False
+FileKey1=%AppData%\Jitsi\History*|*.*|RECURSE
 
 [Joboshare DVD Toolkit*]
 LangSecRef=3023
@@ -9613,16 +9577,6 @@ DetectFile=%AppData%\Kalypso Media\Launcher
 Default=False
 FileKey1=%AppData%\Kalypso Media\Launcher|log_appdata.txt;log.txt
 
-[Kaspersky Now*]
-Section=3031
-Default=False
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\KasperskyLab.KasperskyNow_8jx5e25qw3tdc
-FileKey1=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Microsoft\CLR_v4.0_32\UsageLogs|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Microsoft\CLR_v4.0_32|*.log
-FileKey4=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\LocalCache|*.*|RECURSE
-
 [Kaspersky*]
 LangSecRef=3024
 Detect=HKCU\Software\KasperskyLab
@@ -9636,6 +9590,16 @@ FileKey5=%LocalAppData%\VirtualStore\ProgramData\Kaspersky Lab\*\Bases\Cache|*.*
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\Kaspersky Lab\*\Data\Updater\Temporary Files|*.*|RECURSE
 FileKey7=%LocalAppData%\VirtualStore\ProgramData\Kaspersky Lab\*\Temp|*.*
 FileKey8=%ProgramFiles%\Kaspersky Lab\NetworkAgent\~dumps|*.*
+
+[Kaspersky Now*]
+Section=3031
+Default=False
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\KasperskyLab.KasperskyNow_8jx5e25qw3tdc
+FileKey1=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Microsoft\CLR_v4.0_32|*.log
+FileKey3=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Microsoft\CLR_v4.0_32\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\LocalCache|*.*|RECURSE
 
 [Kate's Video Toolkit Logs*]
 LangSecRef=3023
@@ -9732,9 +9696,9 @@ LangSecRef=3023
 DetectFile=%AppData%\kodi
 Default=False
 FileKey1=%AppData%\kodi|*.log;*.dmp
-FileKey2=%AppData%\kodi\addons\packages|*.*|RECURSE
-FileKey3=%AppData%\kodi\cache|*.*|RECURSE
-FileKey4=%AppData%\kodi*\userdata\thumbnails|*.*|RECURSE
+FileKey2=%AppData%\kodi*\userdata\thumbnails|*.*|RECURSE
+FileKey3=%AppData%\kodi\addons\packages|*.*|RECURSE
+FileKey4=%AppData%\kodi\cache|*.*|RECURSE
 
 [Koffix Blocker*]
 LangSecRef=3024
@@ -9765,8 +9729,8 @@ FileKey1=%CommonAppData%\GFI Software\LanGuard 10|newfileslog.*
 FileKey2=%CommonAppData%\GFI Software\LanGuard 10\Cache|*.*|REMOVESELF
 FileKey3=%CommonAppData%\GFI Software\LanGuard 10\DebugLogs|*.*|RECURSE
 FileKey4=%CommonAppData%\GFI Software\LanGuard 10\OperationalLogs|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10\Cache|*.*|REMOVESELF
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10|newfileslog.*
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10|newfileslog.*
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10\Cache|*.*|REMOVESELF
 FileKey7=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10\DebugLogs|*.*|RECURSE
 FileKey8=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10\OperationalLogs|*.*|RECURSE
 
@@ -9830,16 +9794,16 @@ FileKey2=%LocalAppData%\Learn2.com\strunner\StCache|*.*|RECURSE
 LangSecRef=3023
 Detect=HKCU\Software\Leawo Software\SoftwarePassport\Leawo Prof. Media
 Default=False
-FileKey1=%LocalAppData%\Leawo Prof\cache|*.*|RECURSE
-FileKey2=%AppData%\Leawo\Prof. Media|*.xml
-FileKey3=%AppData%\Leawo\Prof. Media\Burn|*.log
-FileKey4=%AppData%\Leawo\Prof. Media\Burn\MenuTemplate\Cache|*.*|RECURSE
-FileKey5=%AppData%\Leawo\Prof. Media\CrashReport|*.*|RECURSE
-FileKey6=%AppData%\Leawo\Prof. Media\Download|*.dat;*.db;*log;*.xml
-FileKey7=%AppData%\Leawo\Prof. Media\Download\Thumbnails|*.*|RECURSE
-FileKey8=%AppData%\Leawo\Prof. Media\Download\WebCache|*.*|RECURSE
-FileKey9=%AppData%\Leawo\Prof. Media\Download\WebFiles|*.*|RECURSE
-FileKey10=%AppData%\Leawo\Prof. Media\Log|*.*|RECURSE
+FileKey1=%AppData%\Leawo\Prof. Media|*.xml
+FileKey2=%AppData%\Leawo\Prof. Media\Burn|*.log
+FileKey3=%AppData%\Leawo\Prof. Media\Burn\MenuTemplate\Cache|*.*|RECURSE
+FileKey4=%AppData%\Leawo\Prof. Media\CrashReport|*.*|RECURSE
+FileKey5=%AppData%\Leawo\Prof. Media\Download|*.dat;*.db;*log;*.xml
+FileKey6=%AppData%\Leawo\Prof. Media\Download\Thumbnails|*.*|RECURSE
+FileKey7=%AppData%\Leawo\Prof. Media\Download\WebCache|*.*|RECURSE
+FileKey8=%AppData%\Leawo\Prof. Media\Download\WebFiles|*.*|RECURSE
+FileKey9=%AppData%\Leawo\Prof. Media\Log|*.*|RECURSE
+FileKey10=%LocalAppData%\Leawo Prof\cache|*.*|RECURSE
 
 [Leawo Video Converter*]
 LangSecRef=3023
@@ -9888,24 +9852,18 @@ LangSecRef=3021
 DetectFile=%LocalAppData%\Lexware
 Default=False
 FileKey1=%AppData%\Lexware|*.log|RECURSE
-FileKey2=%CommonAppData%\Lexware\logs|*.*|REMOVESELF
+FileKey2=%CommonAppData%\Lexware|*.log;*.logx|RECURSE
 FileKey3=%CommonAppData%\Lexware\elster\Log|*.*|REMOVESELF
-FileKey4=%CommonAppData%\Lexware|*.log;*.logx|RECURSE
+FileKey4=%CommonAppData%\Lexware\logs|*.*|REMOVESELF
 FileKey5=%LocalAppData%\Lexware|*.log;*.logx|RECURSE
 FileKey6=%LocalAppData%\VirtualStore\Program Files*\Common Files\Lexware|*.log|RECURSE
 FileKey7=%LocalAppData%\VirtualStore\Program Files*\Lexware|*.log|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Lexware\logs|*.*|REMOVESELF
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Lexware|*.log;*.logx|RECURSE
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Lexware\elster\Log|*.*|REMOVESELF
-FileKey11=%SystemDrive%\|LxDasi.Log
-FileKey12=%ProgramFiles%\Common Files\Lexware|*.log|RECURSE
-FileKey13=%ProgramFiles%\Lexware|*.log|RECURSE
-
-[LibreOffice program_old*]
-LangSecRef=3021
-Detect=HKLM\Software\LibreOffice
-Default=False
-FileKey1=%ProgramFiles%\LibreOffice *.*\program_old*|*.*|REMOVESELF
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\Lexware|*.log;*.logx|RECURSE
+FileKey9=%LocalAppData%\VirtualStore\ProgramData\Lexware\elster\Log|*.*|REMOVESELF
+FileKey10=%LocalAppData%\VirtualStore\ProgramData\Lexware\logs|*.*|REMOVESELF
+FileKey11=%ProgramFiles%\Common Files\Lexware|*.log|RECURSE
+FileKey12=%ProgramFiles%\Lexware|*.log|RECURSE
+FileKey13=%SystemDrive%\|LxDasi.Log
 
 [LibreOffice*]
 LangSecRef=3021
@@ -9915,6 +9873,7 @@ FileKey1=%AppData%\LibreOffice\*\User\backup|*.*
 FileKey2=%AppData%\LibreOffice\*\user\extensions\shared|log.*
 FileKey3=%AppData%\LibreOffice\*\User\temp|*.*
 FileKey4=%AppData%\LibreOffice\*\User\uno_packages\cache|log.*
+FileKey5=%ProgramFiles%\LibreOffice *.*\program_old*|*.*|REMOVESELF
 
 [LifeCam*]
 LangSecRef=3031
@@ -9956,16 +9915,16 @@ FileKey2=%UserProfile%\Incomplete|*.*|RECURSE
 LangSecRef=3024
 Detect=HKCU\Software\Sanderson Forensics\LinkAlyzer
 Default=False
-RegKey1=HKCU\Software\Sanderson Forensics\LinkAlyzer|LastSaveFolder
-RegKey2=HKCU\Software\Sanderson Forensics\LinkAlyzer|LastOpenFolder
+RegKey1=HKCU\Software\Sanderson Forensics\LinkAlyzer|LastOpenFolder
+RegKey2=HKCU\Software\Sanderson Forensics\LinkAlyzer|LastSaveFolder
 
 [Listary*]
 LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Listary_is1
 Default=False
 FileKey1=%AppData%\Listary\CrashRpt|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Listary|*.log
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Listary|*.log
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Listary|*.log
+FileKey3=%ProgramFiles%\Listary|*.log
 
 [Loadout*]
 Section=Games
@@ -10023,32 +9982,32 @@ FileKey6=%WinDir%\SysWOW64\config\systemprofile\AppData\LocalLow\Microsoft\Crypt
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%WinDir%\System32\config\SystemProfile\Cookies|*.*|RECURSE
-FileKey2=%WinDir%\System32\config\systemprofile\AppData\Roaming\Microsoft\Windows\Cookies|*.*|RECURSE
+FileKey1=%WinDir%\System32\config\systemprofile\AppData\Roaming\Microsoft\Windows\Cookies|*.*|RECURSE
+FileKey2=%WinDir%\System32\config\SystemProfile\Cookies|*.*|RECURSE
 FileKey3=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\Microsoft\Windows\Cookies|*.*|RECURSE
 
 [LocalSystem History*]
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%WinDir%\System32\config\SystemProfile\History|*.*|RECURSE
-FileKey2=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\History|*.*|RECURSE
+FileKey1=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\History|*.*|RECURSE
+FileKey2=%WinDir%\System32\config\SystemProfile\History|*.*|RECURSE
 FileKey3=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\Microsoft\Windows\History|*.*|RECURSE
 
 [LocalSystem Temp Files*]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%WinDir%\System32\config\SystemProfile\Local Settings\Temp|*.*|RECURSE
-FileKey2=%WinDir%\System32\config\systemprofile\AppData\Local\Temp|*.*|RECURSE
+FileKey1=%WinDir%\System32\config\systemprofile\AppData\Local\Temp|*.*|RECURSE
+FileKey2=%WinDir%\System32\config\SystemProfile\Local Settings\Temp|*.*|RECURSE
 FileKey3=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Temp|*.*|RECURSE
 
 [LocalSystem Temporary Internet Files*]
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%WinDir%\System32\config\SystemProfile\Local Settings\Temporary Internet Files|*.*|RECURSE
-FileKey2=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\Temporary Internet Files|*.*|RECURSE
+FileKey1=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\Temporary Internet Files|*.*|RECURSE
+FileKey2=%WinDir%\System32\config\SystemProfile\Local Settings\Temporary Internet Files|*.*|RECURSE
 FileKey3=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\Temporary Internet Files|*.*|RECURSE
 
 [Lock App*]
@@ -10359,13 +10318,13 @@ DetectFile=%ProgramFiles%\Malwarebytes Anti-Malware\mbam.exe
 Default=False
 Warning=You must manually and temporarily turn off Malwarebytes "self-protection" to remove the logs.
 FileKey1=%AppData%\Malwarebytes\Malwarebytes' Anti-Malware\Logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Malwarebytes\Malwarebytes*Anti-Malware\Logs|*.*
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Malwarebytes\Malwarebytes' Anti-Malware|mbam-setup.exe
-FileKey4=%CommonAppData%\Malwarebytes\Malwarebytes*Anti-Malware\Logs|*.*
-FileKey5=%CommonAppData%\Malwarebytes\Malwarebytes' Anti-Malware|mbam-setup.exe
-FileKey6=%CommonAppData%\Malwarebytes\MBAMService|*.log;*.bak
-FileKey7=%CommonAppData%\Malwarebytes\MBAMService\logs|*.*
-FileKey8=%CommonAppData%\Malwarebytes\MBAMService\ScanResults|*.*
+FileKey2=%CommonAppData%\Malwarebytes\Malwarebytes' Anti-Malware|mbam-setup.exe
+FileKey3=%CommonAppData%\Malwarebytes\Malwarebytes*Anti-Malware\Logs|*.*
+FileKey4=%CommonAppData%\Malwarebytes\MBAMService|*.log;*.bak
+FileKey5=%CommonAppData%\Malwarebytes\MBAMService\logs|*.*
+FileKey6=%CommonAppData%\Malwarebytes\MBAMService\ScanResults|*.*
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\Malwarebytes\Malwarebytes*Anti-Malware|mbam-setup.exe
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\Malwarebytes\Malwarebytes*Anti-Malware\Logs|*.*
 
 [ManiaPlanet Cache*]
 Section=Games
@@ -10379,9 +10338,9 @@ LangSecRef=3023
 Detect1=HKLM\Software\ManyCam
 Detect2=HKCU\Software\ManyCam
 Default=False
-FileKey1=%LocalAppData%\ManyCam|*.log|RECURSE
-FileKey2=%LocalAppData%\ManyCam\cache\gallery|*.*|RECURSE
-FileKey3=%AppData%\ManyCam\Settings\MoviesThumbnails|*.*|RECURSE
+FileKey1=%AppData%\ManyCam\Settings\MoviesThumbnails|*.*|RECURSE
+FileKey2=%LocalAppData%\ManyCam|*.log|RECURSE
+FileKey3=%LocalAppData%\ManyCam\cache\gallery|*.*|RECURSE
 
 [Maps*]
 DetectOS=10.0|
@@ -10408,10 +10367,10 @@ FileKey2=%ProgramFiles%\Groove Games\Marine Sharpshooter 3|*.dmp;*.mdmp|RECURSE
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Mass Downloader
 Default=False
-FileKey1=%ProgramFiles%\Mass Downloader|*.bak;massdown.dat;history.dat|RECURSE
-FileKey2=%ProgramFiles%\Mass Downloader\Index|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Mass Downloader|*.bak;massdown.dat;history.dat|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Mass Downloader\Index|*.*|RECURSE
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Mass Downloader|*.bak;massdown.dat;history.dat|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Mass Downloader\Index|*.*|RECURSE
+FileKey3=%ProgramFiles%\Mass Downloader|*.bak;massdown.dat;history.dat|RECURSE
+FileKey4=%ProgramFiles%\Mass Downloader\Index|*.*|RECURSE
 
 [Mass Effect*]
 Section=Games
@@ -10454,6 +10413,14 @@ FileKey3=%Documents%\Maxprog\iCash\XML Dumps|*.*|REMOVESELF
 FileKey4=%LocalAppData%\VirtualStore\Program Files*\iCash\vlogs|*.*|REMOVESELF
 FileKey5=%ProgramFiles%\iCash\vlogs|*.*|REMOVESELF
 
+[Maxthon Browser*]
+LangSecRef=3022
+Detect1=HKCU\Software\Maxthon
+Detect2=HKCU\Software\Maxthon2
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Maxthon*\Temp|*.*
+FileKey2=%ProgramFiles%\Maxthon*\Temp|*.*
+
 [Maxthon Browser 3 Backups*]
 LangSecRef=3022
 Detect=HKCU\Software\Maxthon3
@@ -10483,14 +10450,6 @@ LangSecRef=3022
 Detect=HKCU\Software\Maxthon3
 Default=False
 FileKey1=%AppData%\Maxthon3\Users\*\LocalStorage|*.*|RECURSE
-
-[Maxthon Browser*]
-LangSecRef=3022
-Detect1=HKCU\Software\Maxthon
-Detect2=HKCU\Software\Maxthon2
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Maxthon*\Temp|*.*
-FileKey2=%ProgramFiles%\Maxthon*\Temp|*.*
 
 [McAfee*]
 LangSecRef=3024
@@ -10561,7 +10520,7 @@ FileKey6=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\PRICache|*
 FileKey7=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Temp|*.*
 FileKey8=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\Cache|*.*|RECURSE
 FileKey9=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\*Microsoft.Media.PlayReadyClient_*\TempState|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\TempState|*.*|RECURSE
 
 [Media Player Classic More*]
 LangSecRef=3023
@@ -10737,12 +10696,12 @@ LangSecRef=3021
 Detect1=HKCU\Software\Impact\Microangelo
 Detect2=HKCU\Software\Eclipsit\Microangelo\Toolset 6
 Default=False
-RegKey1=HKCU\Software\Impact\Microangelo\Animator\MRU List
-RegKey2=HKCU\Software\Impact\Microangelo\Librarian\MRU List
-RegKey3=HKCU\Software\Impact\Microangelo\Studio\MRU List
-RegKey4=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Animator\MRU List
-RegKey5=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Librarian\MRU List
-RegKey6=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Studio\MRU List
+RegKey1=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Animator\MRU List
+RegKey2=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Librarian\MRU List
+RegKey3=HKCU\Software\Eclipsit\Microangelo\Toolset 6\Studio\MRU List
+RegKey4=HKCU\Software\Impact\Microangelo\Animator\MRU List
+RegKey5=HKCU\Software\Impact\Microangelo\Librarian\MRU List
+RegKey6=HKCU\Software\Impact\Microangelo\Studio\MRU List
 
 [Microsoft Bing Bar*]
 LangSecRef=3021
@@ -10763,14 +10722,14 @@ Detect=HKCU\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\Sy
 DetectFile=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!00*\INetCookies|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!00*\MicrosoftEdge\Cookies|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!00*\Microsoft\CryptnetUrlCache|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!00*\Microsoft\CryptnetUrlCache|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!00*\MicrosoftEdge\Cookies|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\Microsoft\CryptnetUrlCache|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\Cookies|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\DataStore\Indexed\Data|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\ImageStore|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\user\Default\datastore\Data\nouser1\*\DBStore|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\user\Default\datastore\Data\nouser1\*\Favorites|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\datastore\Data\nouser1\*\DBStore|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\datastore\Data\nouser1\*\Favorites|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\DataStore\Indexed\Data|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\ImageStore|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AppData\User\Default\Indexed DB|*.edb;*.jfm;*.jrs;*.log
 FileKey11=%UserProfile%\MicrosoftEdgeBackups\backups\*|*.*|REMOVESELF
 ExcludeKey1=PATH|%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\user\Default\datastore\Data\nouser1\*\DBStore\|*.edb;*.jfm
@@ -10842,8 +10801,8 @@ LangSecRef=3021
 Detect=HKCU\Software\Microsoft\Microsoft Antimalware
 Default=False
 FileKey1=%CommonAppData%\Microsoft\Microsoft Antimalware\LocalCopy|*.*|RECURSE
-FileKey2=%CommonAppData%\Microsoft\Microsoft Antimalware\Scans\History\Service|*.log|RECURSE
-FileKey3=%CommonAppData%\Microsoft\Microsoft Antimalware\Network Inspection System\Support|NisLog.txt.bak
+FileKey2=%CommonAppData%\Microsoft\Microsoft Antimalware\Network Inspection System\Support|NisLog.txt.bak
+FileKey3=%CommonAppData%\Microsoft\Microsoft Antimalware\Scans\History\Service|*.log|RECURSE
 FileKey4=%CommonAppData%\Microsoft\Microsoft Security Client\Support|MSSecurityClient*.log
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft Antimalware\LocalCopy|*.*|RECURSE
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft Antimalware\Scans\History\Service|*.log|RECURSE
@@ -10910,17 +10869,11 @@ Detect=HKLM\Software\Midori
 Default=False
 FileKey1=%LocalAppData%\Midori|session.xbel
 
-[Migration Wizard logs*]
+[Migration Wizard*]
 LangSecRef=3025
 DetectFile=%WinDir%\System32\migwiz\migwiz.exe
 Default=False
 FileKey1=%LocalAppData%\MigWiz|*.*|REMOVESELF
-
-[Migration Wizard*]
-LangSecRef=3025
-DetectFile=%LocalAppData%\MigWiz
-Default=False
-FileKey1=%LocalAppData%\MigWiz|*.log;miglog.xml
 
 [MiKTeX Logs*]
 LangSecRef=3021
@@ -10928,8 +10881,8 @@ Detect=HKCU\Software\MiKTeX.org\MiKTeX
 Default=False
 FileKey1=%CommonAppData%\MiKTeX\*\miktex\log|*.log
 FileKey2=%LocalAppData%\MiKTeX\*\miktex\log|*.log
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\MiKTeX\*\miktex\log|*.log
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\MiKTeX\miktex\config|*.log
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\MiKTeX\miktex\config|*.log
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\MiKTeX\*\miktex\log|*.log
 FileKey5=%ProgramFiles%\MiKTeX\miktex\config|*.log
 
 [Minecraft*]
@@ -10942,18 +10895,18 @@ FileKey3=%AppData%\.minecraft\debug|*.*
 FileKey4=%AppData%\.minecraft\stats|*.old
 FileKey5=%AppData%\java|*.*|REMOVESELF
 
-[Miranda IM Chat Log*]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\Miranda IM
-Default=False
-FileKey1=%AppData%\Miranda IM\Profiles\*\Logs\Chat|*.*|REMOVESELF
-
 [Miranda IM*]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Miranda IM
 Default=False
 FileKey1=%AppData%\Miranda IM\Profiles|*.*|REMOVESELF
 FileKey2=%AppData%\Miranda IM\Profiles\*\Logs\Chat|*.*|RECURSE
+
+[Miranda IM Chat Log*]
+LangSecRef=3022
+DetectFile=%ProgramFiles%\Miranda IM
+Default=False
+FileKey1=%AppData%\Miranda IM\Profiles\*\Logs\Chat|*.*|REMOVESELF
 
 [mIRC Logs*]
 LangSecRef=3022
@@ -11033,11 +10986,11 @@ FileKey2=%LocalAppData%\Deusty\Mojo|crash*.txt
 LangSecRef=3023
 DetectFile=%AppData%\Molotov
 Default=False
-FileKey1=%AppData%\Molotov\Cache|*.*
-FileKey2=%AppData%\Molotov\databases|*.*
-FileKey3=%AppData%\Molotov\GPUCache|*.*
-FileKey4=%AppData%\Molotov\IndexedDB|*.*|RECURSE
-FileKey5=%AppData%\Molotov|Cookies;Cookies-journal;QuotaManager;QuotaManager-journal
+FileKey1=%AppData%\Molotov|Cookies;Cookies-journal;QuotaManager;QuotaManager-journal
+FileKey2=%AppData%\Molotov\Cache|*.*
+FileKey3=%AppData%\Molotov\databases|*.*
+FileKey4=%AppData%\Molotov\GPUCache|*.*
+FileKey5=%AppData%\Molotov\IndexedDB|*.*|RECURSE
 FileKey6=%LocalAppData%\Molotov|SquirrelSetup.log
 
 [MoreTerra*]
@@ -11083,9 +11036,9 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Mount&Blade*|rgl_log.txt|RECURSE
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Napoleonic Wars|rgl_log.txt|RECURSE
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Mount&Blade*|rgl_log.txt|RECURSE
-FileKey4=%ProgramFiles%\Steam\steamapps\common\Mount&Blade*|rgl_log.txt|RECURSE
-FileKey5=%ProgramFiles%\Mount&Blade*|rgl_log.txt|RECURSE
-FileKey6=%ProgramFiles%\Napoleonic Wars|rgl_log.txt|RECURSE
+FileKey4=%ProgramFiles%\Mount&Blade*|rgl_log.txt|RECURSE
+FileKey5=%ProgramFiles%\Napoleonic Wars|rgl_log.txt|RECURSE
+FileKey6=%ProgramFiles%\Steam\steamapps\common\Mount&Blade*|rgl_log.txt|RECURSE
 
 [Mousotron*]
 LangSecRef=3021
@@ -11148,13 +11101,6 @@ DetectFile=%LocalAppData%\MPlayer
 Default=False
 FileKey1=%LocalAppData%\MPlayer|*.cache-3
 
-[MS AntiMalware More*]
-LangSecRef=3025
-Detect=HKLM\Software\Microsoft\Microsoft Antimalware
-Default=False
-FileKey1=%SystemDrive%\Documents and Settings\NetworkService*\Temp|MpCmdRun.log
-FileKey2=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Temp|MpCmdRun.log
-
 [MS AntiMalware*]
 LangSecRef=3025
 Default=False
@@ -11170,6 +11116,8 @@ FileKey7=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft antimalware
 FileKey8=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft antimalware\scans\history\results\resource|*.*|REMOVESELF
 FileKey9=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft antimalware\scans\history\results\System|*.*|REMOVESELF
 FileKey10=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft antimalware\support|*.log
+FileKey11=%SystemDrive%\Documents and Settings\NetworkService*\Temp|MpCmdRun.log
+FileKey12=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Temp|MpCmdRun.log
 
 [MS Backup Logs*]
 LangSecRef=3025
@@ -11416,22 +11364,22 @@ FileKey1=%LocalAppData%\VirtualStore\Program Files*\Microsoft SQL Server\*\MSSQL
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Microsoft SQL Server\*\Setup Bootstrap\LOG|*.*|RECURSE
 FileKey3=%ProgramFiles%\Microsoft SQL Server\*\MSSQL\Log|*ERRORLOG*;*.*|RECURSE
 FileKey4=%ProgramFiles%\Microsoft SQL Server\*\Setup Bootstrap\LOG|*.*|RECURSE
-RegKey1=HKCU\Software\Microsoft\Microsoft SQL Server\80\Tools\Shell\FileMRUList
-RegKey2=HKCU\Software\Microsoft\Microsoft SQL Server\80\Tools\Shell\ProjectMRUList
-RegKey3=HKCU\Software\Microsoft\Microsoft SQL Server\90\Tools\Shell\FileMRUList
-RegKey4=HKCU\Software\Microsoft\Microsoft SQL Server\90\Tools\Shell\ProjectMRUList
-RegKey5=HKCU\Software\Microsoft\Microsoft SQL Server\100\Tools\Shell\FileMRUList
-RegKey6=HKCU\Software\Microsoft\Microsoft SQL Server\100\Tools\Shell\ProjectMRUList
-RegKey7=HKCU\Software\Microsoft\Microsoft SQL Server\110\Tools\Shell\ProjectMRUList
-RegKey8=HKCU\Software\Microsoft\Microsoft SQL Server\110\Tools\Shell\FileMRUList
-RegKey9=HKLM\Software\Microsoft\Microsoft SQL Server\80\Tools\Shell\FileMRUList
-RegKey10=HKLM\Software\Microsoft\Microsoft SQL Server\80\Tools\Shell\ProjectMRUList
-RegKey11=HKLM\Software\Microsoft\Microsoft SQL Server\90\Tools\Shell\FileMRUList
-RegKey12=HKLM\Software\Microsoft\Microsoft SQL Server\90\Tools\Shell\ProjectMRUList
-RegKey13=HKLM\Software\Microsoft\Microsoft SQL Server\100\Tools\Shell\FileMRUList
-RegKey14=HKLM\Software\Microsoft\Microsoft SQL Server\100\Tools\Shell\ProjectMRUList
-RegKey15=HKLM\Software\Microsoft\Microsoft SQL Server\110\Tools\Shell\FileMRUList
-RegKey16=HKLM\Software\Microsoft\Microsoft SQL Server\110\Tools\Shell\ProjectMRUList
+RegKey1=HKCU\Software\Microsoft\Microsoft SQL Server\100\Tools\Shell\FileMRUList
+RegKey2=HKCU\Software\Microsoft\Microsoft SQL Server\100\Tools\Shell\ProjectMRUList
+RegKey3=HKCU\Software\Microsoft\Microsoft SQL Server\110\Tools\Shell\FileMRUList
+RegKey4=HKCU\Software\Microsoft\Microsoft SQL Server\110\Tools\Shell\ProjectMRUList
+RegKey5=HKCU\Software\Microsoft\Microsoft SQL Server\80\Tools\Shell\FileMRUList
+RegKey6=HKCU\Software\Microsoft\Microsoft SQL Server\80\Tools\Shell\ProjectMRUList
+RegKey7=HKCU\Software\Microsoft\Microsoft SQL Server\90\Tools\Shell\FileMRUList
+RegKey8=HKCU\Software\Microsoft\Microsoft SQL Server\90\Tools\Shell\ProjectMRUList
+RegKey9=HKLM\Software\Microsoft\Microsoft SQL Server\100\Tools\Shell\FileMRUList
+RegKey10=HKLM\Software\Microsoft\Microsoft SQL Server\100\Tools\Shell\ProjectMRUList
+RegKey11=HKLM\Software\Microsoft\Microsoft SQL Server\110\Tools\Shell\FileMRUList
+RegKey12=HKLM\Software\Microsoft\Microsoft SQL Server\110\Tools\Shell\ProjectMRUList
+RegKey13=HKLM\Software\Microsoft\Microsoft SQL Server\80\Tools\Shell\FileMRUList
+RegKey14=HKLM\Software\Microsoft\Microsoft SQL Server\80\Tools\Shell\ProjectMRUList
+RegKey15=HKLM\Software\Microsoft\Microsoft SQL Server\90\Tools\Shell\FileMRUList
+RegKey16=HKLM\Software\Microsoft\Microsoft SQL Server\90\Tools\Shell\ProjectMRUList
 
 [MS UserScanProfiles*]
 LangSecRef=3025
@@ -11635,29 +11583,29 @@ FileKey1=%LocalAppData%\PerfWatson|*.*
 LangSecRef=3021
 Detect=HKCU\Software\Microsoft\VisualStudio
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Microsoft Visual Studio *\*\Logs|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Microsoft Visual Studio *\*\Logs|*.*|REMOVESELF
-FileKey3=%LocalAppData%\Microsoft\VisualStudio\SettingsLogs|*.*|RECURSE
+FileKey1=%LocalAppData%\Microsoft\VisualStudio\SettingsLogs|*.*|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Microsoft Visual Studio *\*\Logs|*.*|REMOVESELF
+FileKey3=%ProgramFiles%\Microsoft Visual Studio *\*\Logs|*.*|REMOVESELF
 
 [MS Visual Studio MRU*]
 LangSecRef=3021
 Detect1=HKCU\Software\Microsoft\VisualStudio
 Default=False
 RegKey1=HKCU\Software\Microsoft\VisualStudio\9.0\FileMRUList
-RegKey2=HKCU\Software\Microsoft\VisualStudio\9.0\ProjectMRUList
-RegKey3=HKCU\Software\Microsoft\VisualStudio\9.0\LastLoadedSolution
+RegKey2=HKCU\Software\Microsoft\VisualStudio\9.0\LastLoadedSolution
+RegKey3=HKCU\Software\Microsoft\VisualStudio\9.0\ProjectMRUList
 RegKey4=HKCU\Software\Microsoft\VisualStudio\10.0\FileMRUList
-RegKey5=HKCU\Software\Microsoft\VisualStudio\10.0\ProjectMRUList
-RegKey6=HKCU\Software\Microsoft\VisualStudio\10.0\LastLoadedSolution
+RegKey5=HKCU\Software\Microsoft\VisualStudio\10.0\LastLoadedSolution
+RegKey6=HKCU\Software\Microsoft\VisualStudio\10.0\ProjectMRUList
 RegKey7=HKCU\Software\Microsoft\VisualStudio\11.0\FileMRUList
-RegKey8=HKCU\Software\Microsoft\VisualStudio\11.0\ProjectMRUList
-RegKey9=HKCU\Software\Microsoft\VisualStudio\11.0\LastLoadedSolution
+RegKey8=HKCU\Software\Microsoft\VisualStudio\11.0\LastLoadedSolution
+RegKey9=HKCU\Software\Microsoft\VisualStudio\11.0\ProjectMRUList
 RegKey10=HKCU\Software\Microsoft\VisualStudio\12.0\FileMRUList
-RegKey11=HKCU\Software\Microsoft\VisualStudio\12.0\ProjectMRUList
-RegKey12=HKCU\Software\Microsoft\VisualStudio\12.0\LastLoadedSolution
+RegKey11=HKCU\Software\Microsoft\VisualStudio\12.0\LastLoadedSolution
+RegKey12=HKCU\Software\Microsoft\VisualStudio\12.0\ProjectMRUList
 RegKey13=HKCU\Software\Microsoft\VisualStudio\14.0\FileMRUList
-RegKey14=HKCU\Software\Microsoft\VisualStudio\14.0\ProjectMRUList
-RegKey15=HKCU\Software\Microsoft\VisualStudio\14.0\LastLoadedSolution
+RegKey14=HKCU\Software\Microsoft\VisualStudio\14.0\LastLoadedSolution
+RegKey15=HKCU\Software\Microsoft\VisualStudio\14.0\ProjectMRUList
 
 [MS Visual Studio NuGet Cache*]
 LangSecRef=3021
@@ -11671,11 +11619,11 @@ FileKey3=%UserProfile%\.nuget|*.*|RECURSE
 LangSecRef=3021
 Detect=HKCU\Software\Microsoft\VisualStudio
 Default=False
-FileKey1=%LocalAppData%\Microsoft\VisualStudio\*\Extensions|*.cache
-FileKey2=%LocalAppData%\Microsoft\VisualStudio\*\ImageLibrary|*.cache
-FileKey3=%LocalAppData%\Microsoft\VisualStudio\*\Notifications|*.cache
-FileKey4=%LocalAppData%\Microsoft\VisualStudio\*\ComponentModelCache|*.*
-FileKey5=%LocalAppData%\Microsoft\VisualStudio\*\MEFCacheBackup|*.*
+FileKey1=%LocalAppData%\Microsoft\VisualStudio\*\ComponentModelCache|*.*
+FileKey2=%LocalAppData%\Microsoft\VisualStudio\*\Extensions|*.cache
+FileKey3=%LocalAppData%\Microsoft\VisualStudio\*\ImageLibrary|*.cache
+FileKey4=%LocalAppData%\Microsoft\VisualStudio\*\MEFCacheBackup|*.*
+FileKey5=%LocalAppData%\Microsoft\VisualStudio\*\Notifications|*.cache
 FileKey6=%LocalAppData%\Microsoft\VisualStudio\*\TextMateCache|*.*
 
 [MS Visual Studio Search History*]
@@ -11844,48 +11792,27 @@ RegKey159=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Replace 16
 RegKey160=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Replace 17
 RegKey161=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Replace 18
 RegKey162=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Replace 19
-RegKey163=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find
-RegKey164=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 0
-RegKey165=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 1
-RegKey166=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 2
-RegKey167=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 3
-RegKey168=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 4
-RegKey169=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 5
-RegKey170=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 6
-RegKey171=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 7
-RegKey172=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 8
-RegKey173=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 9
-RegKey174=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 10
-RegKey175=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 11
-RegKey176=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 12
-RegKey177=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 13
-RegKey178=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 14
-RegKey179=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 15
-RegKey180=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 16
-RegKey181=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 17
-RegKey182=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 18
-RegKey183=HKCU\Software\Microsoft\VisualStudio\12.0\Find|Find 19
-RegKey184=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace
-RegKey185=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 0
-RegKey186=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 1
-RegKey187=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 2
-RegKey188=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 3
-RegKey189=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 4
-RegKey190=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 5
-RegKey191=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 6
-RegKey192=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 7
-RegKey193=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 8
-RegKey194=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 9
-RegKey195=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 10
-RegKey196=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 11
-RegKey197=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 12
-RegKey198=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 13
-RegKey199=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 14
-RegKey200=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 15
-RegKey201=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 16
-RegKey202=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 17
-RegKey203=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 18
-RegKey204=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 19
+RegKey163=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace
+RegKey164=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 0
+RegKey165=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 1
+RegKey166=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 2
+RegKey167=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 3
+RegKey168=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 4
+RegKey169=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 5
+RegKey170=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 6
+RegKey171=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 7
+RegKey172=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 8
+RegKey173=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 9
+RegKey174=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 10
+RegKey175=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 11
+RegKey176=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 12
+RegKey177=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 13
+RegKey178=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 14
+RegKey179=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 15
+RegKey180=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 16
+RegKey181=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 17
+RegKey182=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 18
+RegKey183=HKCU\Software\Microsoft\VisualStudio\14.0\Find|Replace 19
 
 [MS Visual Studio Website Cache*]
 LangSecRef=3021
@@ -11982,8 +11909,8 @@ Default=False
 RegKey1=HKLM\Software\Classes\.mpf
 RegKey2=HKLM\Software\Classes\CLSID\{3F2BBC05-40DF-11D2-9455-00104BC936FF}
 RegKey3=HKLM\Software\Classes\MPR.DocHostUIHandler
-RegKey4=HKLM\SYSTEM\CurrentControlSet\Services\block_reader
-RegKey5=HKLM\SYSTEM\CurrentControlSet\enum\root\legacy_block_reader
+RegKey4=HKLM\SYSTEM\CurrentControlSet\enum\root\legacy_block_reader
+RegKey5=HKLM\SYSTEM\CurrentControlSet\Services\block_reader
 
 [MultiBit Logs*]
 LangSecRef=3023
@@ -12002,8 +11929,8 @@ FileKey2=%ProgramFiles%\MultiHasher|*.txt;*.zip|RECURSE
 LangSecRef=3021
 Detect=HKCU\Software\Teorex\MultiViewInpaint
 Default=False
-RegKey1=HKCU\Software\Teorex\MultiViewInpaint\RecentFileList
-RegKey2=HKCU\Software\Teorex\MultiViewInpaint\Recent File List
+RegKey1=HKCU\Software\Teorex\MultiViewInpaint\Recent File List
+RegKey2=HKCU\Software\Teorex\MultiViewInpaint\RecentFileList
 
 [Mumble Console Log*]
 LangSecRef=3022
@@ -12142,10 +12069,10 @@ Detect1=HKLM\Software\Big Fish Games\Persistence\Install\F7664T1L1
 Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\My Singing Monsters1.1
 DetectFile=%ProgramFiles%\My Singing Monsters
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\My Singing Monsters|*.log;*.txt|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\*\My Singing Monsters|*.log;*.txt|RECURSE
-FileKey3=%ProgramFiles%\My Singing Monsters|dotnetfx35setup.exe;vcredist_x86.exe;*.log;*.txt|RECURSE
-FileKey4=%ProgramFiles%\*\My Singing Monsters|dotnetfx35setup.exe;*.html;*.PNG;vcredist_x86.exe;*.log;*.txt|RECURSE
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\*\My Singing Monsters|*.log;*.txt|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\My Singing Monsters|*.log;*.txt|RECURSE
+FileKey3=%ProgramFiles%\*\My Singing Monsters|dotnetfx35setup.exe;*.html;*.PNG;vcredist_x86.exe;*.log;*.txt|RECURSE
+FileKey4=%ProgramFiles%\My Singing Monsters|dotnetfx35setup.exe;vcredist_x86.exe;*.log;*.txt|RECURSE
 
 [MyCraft*]
 Section=Games
@@ -12219,8 +12146,8 @@ Detect1=HKLM\Software\Big Fish Games\Persistence\Install\F7041T1L1
 Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Nancy Drew - Secret of Shadow Ranch - Plus Guide1.0
 DetectFile=%ProgramFiles%\Nancy Drew*
 Default=False
-FileKey1=%ProgramFiles%\Nancy Drew*|dxwebsetup.exe;*.html
-FileKey2=%ProgramFiles%\*\Nancy Drew*|dxwebsetup.exe;*.html
+FileKey1=%ProgramFiles%\*\Nancy Drew*|dxwebsetup.exe;*.html
+FileKey2=%ProgramFiles%\Nancy Drew*|dxwebsetup.exe;*.html
 
 [Natural Selection 2*]
 Section=Games
@@ -12228,8 +12155,8 @@ Detect=HKCU\Software\Valve\Steam\Apps\4920
 DetectFile=%ProgramFiles%\Steam\steamapps\common\Natural Selection 2
 Default=False
 Warning=Fixes corrupt cache & cleans cache bloat. The first game & map launch will take longer to load.
-FileKey1=%AppData%\Natural Selection 2\cache|*.*|RECURSE
-FileKey2=%AppData%\Natural Selection 2|log.txt
+FileKey1=%AppData%\Natural Selection 2|log.txt
+FileKey2=%AppData%\Natural Selection 2\cache|*.*|RECURSE
 
 [NBC News*]
 LangSecRef=3031
@@ -12237,11 +12164,11 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_amdjbdaxqsje6
 Default=False
 FileKey1=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\PRICache|*.*
-FileKey4=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Temp|*.*
-FileKey5=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\TempState|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Microsoft\CLR_v4.0|*.log
+FileKey2=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Microsoft\CLR_v4.0|*.log
+FileKey3=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\PRICache|*.*
+FileKey5=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Temp|*.*
+FileKey6=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\TempState|*.*|RECURSE
 
 [Neostar CMS Station Client Logs*]
 LangSecRef=3024
@@ -12256,87 +12183,87 @@ LangSecRef=3021
 Detect1=HKLM\Software\Nero\Nero 11\Nero11Suite
 Detect2=HKLM\Software\Nero\Nero 12\Nero12Suite
 Default=False
-FileKey1=%CommonAppData%\Nero\PeakFiles|*.tmp
-FileKey2=%AppData%\Nero\Nero Burning ROM|*.log
-FileKey3=%AppData%\Nero\Nero *\Nero BackItUp\Cache|*.*
-FileKey4=%AppData%\Nero\Nero *\Nero Burning ROM|*.log
-FileKey5=%AppData%\Nero\Nero *\Nero Recode\AnalysisData|*.dat
-FileKey6=%AppData%\Nero\Nero *\Nero Recode\Thumbs|*.*
-FileKey7=%AppData%\Nero\Nero *\Nero Vision\NVFACache|*.*
-FileKey8=%AppData%\Nero\Nero *\Nero Vision|*.txt;*.bin
-FileKey9=%AppData%\Nero\Nero *\Nero3D|*.log
+FileKey1=%AppData%\Nero\Nero *\Nero BackItUp\Cache|*.*
+FileKey2=%AppData%\Nero\Nero *\Nero Burning ROM|*.log
+FileKey3=%AppData%\Nero\Nero *\Nero Recode\AnalysisData|*.dat
+FileKey4=%AppData%\Nero\Nero *\Nero Recode\Thumbs|*.*
+FileKey5=%AppData%\Nero\Nero *\Nero Vision|*.txt;*.bin
+FileKey6=%AppData%\Nero\Nero *\Nero Vision\NVFACache|*.*
+FileKey7=%AppData%\Nero\Nero *\Nero3D|*.log
+FileKey8=%AppData%\Nero\Nero Burning ROM|*.log
+FileKey9=%CommonAppData%\Nero\PeakFiles|*.tmp
 FileKey10=%LocalAppData%\Nero\Nero *\Nero Vision\Cache|*.*
 FileKey11=%LocalAppData%\Nero\Nero *\Nero Vision\Cache\GraphicObjectCache|*.*
 FileKey12=%LocalAppData%\VirtualStore\ProgramData\Nero\PeakFiles|*.tmp
-RegKey1=HKCU\Software\Nero\Nero Blu-ray Player\Settings|DefFolder
-RegKey2=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Compilation|VolumeLabelAutoTemplate
-RegKey3=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Compilation|VolumeLabelUDFTemplate
-RegKey4=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Compilation|VolumeLabelISOTemplate
-RegKey5=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Compilation|VolumelabelJolietTemplate
-RegKey6=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Recent File List
-RegKey7=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Settings|WorkingDir
+RegKey1=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Compilation|VolumeLabelAutoTemplate
+RegKey2=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Compilation|VolumeLabelISOTemplate
+RegKey3=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Compilation|VolumelabelJolietTemplate
+RegKey4=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Compilation|VolumeLabelUDFTemplate
+RegKey5=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Recent File List
+RegKey6=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Settings|EncodingLastDir
+RegKey7=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Settings|NeroCompilation
 RegKey8=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Settings|TrackSaveDir
-RegKey9=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Settings|EncodingLastDir
-RegKey10=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Settings|NeroCompilation
-RegKey11=HKCU\Software\Nero\Nero 11\Nero CoverDesigner\Recent File List
-RegKey12=HKCU\Software\Nero\Nero 11\Nero Express\Compilation|VolumeLabelAutoTemplate
-RegKey13=HKCU\Software\Nero\Nero 11\Nero Express\Compilation|VolumeLabelISOTemplate
-RegKey14=HKCU\Software\Nero\Nero 11\Nero Express\Compilation|VolumelabelJolietTemplate
-RegKey15=HKCU\Software\Nero\Nero 11\Nero Express\Compilation|VolumeLabelUDFTemplate
-RegKey16=HKCU\Software\Nero\Nero 11\Nero Express\Recent File List
-RegKey17=HKCU\Software\Nero\Nero 11\Nero Express\Settings|BootImageDir
-RegKey18=HKCU\Software\Nero\Nero 11\Nero Express\Settings|BrowserDir
-RegKey19=HKCU\Software\Nero\Nero 11\Nero Express\Settings|ImageDir
-RegKey20=HKCU\Software\Nero\Nero 11\Nero Express\Settings|WorkingDir
-RegKey21=HKCU\Software\Nero\Nero 11\Nero Express\General|OFDLastAudioDir
-RegKey22=HKCU\Software\Nero\Nero 11\Nero Express\General|OFDLastISODir
-RegKey23=HKCU\Software\Nero\Nero 11\Nero Express\General|OFDLastVideoDVDKey
-RegKey24=HKCU\Software\Nero\Nero 11\Nero Express\Settings|NeroCompilation
-RegKey25=HKCU\Software\Nero\Nero 11\Nero Express\Settings|TrackSaveDir
-RegKey26=HKCU\Software\Nero\Nero 11\Nero Toolkit\DiscSpeed\Capture|Folder
-RegKey27=HKCU\Software\Nero\Nero 11\Nero Toolkit\DiscSpeed\Save|Folder
-RegKey28=HKCU\Software\Nero\Nero 11\Nero Vision\Application|AudioDir
-RegKey29=HKCU\Software\Nero\Nero 11\Nero Vision\Application|CaptureDir
-RegKey30=HKCU\Software\Nero\Nero 11\Nero Vision\Application|DocDir
-RegKey31=HKCU\Software\Nero\Nero 11\Nero Vision\Application|ExportAudioDir
-RegKey32=HKCU\Software\Nero\Nero 11\Nero Vision\Application|ExportVideoDir
-RegKey33=HKCU\Software\Nero\Nero 11\Nero Vision\Application|ImportVideoDir
-RegKey34=HKCU\Software\Nero\Nero 11\Nero Vision\Application|MediaDir
-RegKey35=HKCU\Software\Nero\Nero 11\Nero Vision\Application|PicDir
-RegKey36=HKCU\Software\Nero\Nero 11\Nero Vision\Application|PicSaveDir
-RegKey37=HKCU\Software\Nero\Nero 11\Nero Vision\Application|TmpDir
-RegKey38=HKCU\Software\Nero\Nero 11\Nero Vision\Application|VideoDir
-RegKey39=HKCU\Software\Nero\Nero 11\Nero WaveEditor\Directories|Last
-RegKey40=HKCU\Software\Nero\Nero 11\Nero WaveEditor\Recent File List
-RegKey41=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Compilation|VolumeLabelAutoTemplate
-RegKey42=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Compilation|VolumeLabelUDFTemplate
-RegKey43=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Compilation|VolumeLabelISOTemplate
-RegKey44=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Compilation|VolumelabelJolietTemplate
-RegKey45=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Settings|WorkingDir
-RegKey46=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Settings|TrackSaveDir
-RegKey47=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Settings|EncodingLastDir
-RegKey48=HKCU\Software\Nero\Nero 12\Nero Express\Compilation|VolumeLabelAutoTemplate
-RegKey49=HKCU\Software\Nero\Nero 12\Nero Express\Compilation|VolumeLabelISOTemplate
-RegKey50=HKCU\Software\Nero\Nero 12\Nero Express\Compilation|VolumelabelJolietTemplate
-RegKey51=HKCU\Software\Nero\Nero 12\Nero Express\Compilation|VolumeLabelUDFTemplate
-RegKey52=HKCU\Software\Nero\Nero 12\Nero Express\Settings|BootImageDir
-RegKey53=HKCU\Software\Nero\Nero 12\Nero Express\Settings|ImageDir
-RegKey54=HKCU\Software\Nero\Nero 12\Nero Express\Settings|NeroCompilation
-RegKey55=HKCU\Software\Nero\Nero 12\Nero Express\Settings|TrackSaveDir
-RegKey56=HKCU\Software\Nero\Nero 12\Nero Toolkit\DiscSpeed\Capture|Folder
-RegKey57=HKCU\Software\Nero\Nero 12\Nero Toolkit\DiscSpeed\Save|Folder
-RegKey58=HKCU\Software\Nero\Nero 12\Nero Vision\Application|AudioDir
-RegKey59=HKCU\Software\Nero\Nero 12\Nero Vision\Application|CaptureDir
-RegKey60=HKCU\Software\Nero\Nero 12\Nero Vision\Application|DocDir
-RegKey61=HKCU\Software\Nero\Nero 12\Nero Vision\Application|ExportAudioDir
-RegKey62=HKCU\Software\Nero\Nero 12\Nero Vision\Application|ExportVideoDir
-RegKey63=HKCU\Software\Nero\Nero 12\Nero Vision\Application|ImportVideoDir
-RegKey64=HKCU\Software\Nero\Nero 12\Nero Vision\Application|MediaDir
-RegKey65=HKCU\Software\Nero\Nero 12\Nero Vision\Application|PicDir
-RegKey66=HKCU\Software\Nero\Nero 12\Nero Vision\Application|PicSaveDir
-RegKey67=HKCU\Software\Nero\Nero 12\Nero Vision\Application|TmpDir
-RegKey68=HKCU\Software\Nero\Nero 12\Nero Vision\Application|VideoDir
-RegKey69=HKCU\Software\Nero\Nero 12\Nero WaveEditor\Directories|Last
+RegKey9=HKCU\Software\Nero\Nero 11\Nero Burning ROM\Settings|WorkingDir
+RegKey10=HKCU\Software\Nero\Nero 11\Nero CoverDesigner\Recent File List
+RegKey11=HKCU\Software\Nero\Nero 11\Nero Express\Compilation|VolumeLabelAutoTemplate
+RegKey12=HKCU\Software\Nero\Nero 11\Nero Express\Compilation|VolumeLabelISOTemplate
+RegKey13=HKCU\Software\Nero\Nero 11\Nero Express\Compilation|VolumelabelJolietTemplate
+RegKey14=HKCU\Software\Nero\Nero 11\Nero Express\Compilation|VolumeLabelUDFTemplate
+RegKey15=HKCU\Software\Nero\Nero 11\Nero Express\General|OFDLastAudioDir
+RegKey16=HKCU\Software\Nero\Nero 11\Nero Express\General|OFDLastISODir
+RegKey17=HKCU\Software\Nero\Nero 11\Nero Express\General|OFDLastVideoDVDKey
+RegKey18=HKCU\Software\Nero\Nero 11\Nero Express\Recent File List
+RegKey19=HKCU\Software\Nero\Nero 11\Nero Express\Settings|BootImageDir
+RegKey20=HKCU\Software\Nero\Nero 11\Nero Express\Settings|BrowserDir
+RegKey21=HKCU\Software\Nero\Nero 11\Nero Express\Settings|ImageDir
+RegKey22=HKCU\Software\Nero\Nero 11\Nero Express\Settings|NeroCompilation
+RegKey23=HKCU\Software\Nero\Nero 11\Nero Express\Settings|TrackSaveDir
+RegKey24=HKCU\Software\Nero\Nero 11\Nero Express\Settings|WorkingDir
+RegKey25=HKCU\Software\Nero\Nero 11\Nero Toolkit\DiscSpeed\Capture|Folder
+RegKey26=HKCU\Software\Nero\Nero 11\Nero Toolkit\DiscSpeed\Save|Folder
+RegKey27=HKCU\Software\Nero\Nero 11\Nero Vision\Application|AudioDir
+RegKey28=HKCU\Software\Nero\Nero 11\Nero Vision\Application|CaptureDir
+RegKey29=HKCU\Software\Nero\Nero 11\Nero Vision\Application|DocDir
+RegKey30=HKCU\Software\Nero\Nero 11\Nero Vision\Application|ExportAudioDir
+RegKey31=HKCU\Software\Nero\Nero 11\Nero Vision\Application|ExportVideoDir
+RegKey32=HKCU\Software\Nero\Nero 11\Nero Vision\Application|ImportVideoDir
+RegKey33=HKCU\Software\Nero\Nero 11\Nero Vision\Application|MediaDir
+RegKey34=HKCU\Software\Nero\Nero 11\Nero Vision\Application|PicDir
+RegKey35=HKCU\Software\Nero\Nero 11\Nero Vision\Application|PicSaveDir
+RegKey36=HKCU\Software\Nero\Nero 11\Nero Vision\Application|TmpDir
+RegKey37=HKCU\Software\Nero\Nero 11\Nero Vision\Application|VideoDir
+RegKey38=HKCU\Software\Nero\Nero 11\Nero WaveEditor\Directories|Last
+RegKey39=HKCU\Software\Nero\Nero 11\Nero WaveEditor\Recent File List
+RegKey40=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Compilation|VolumeLabelAutoTemplate
+RegKey41=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Compilation|VolumeLabelISOTemplate
+RegKey42=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Compilation|VolumelabelJolietTemplate
+RegKey43=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Compilation|VolumeLabelUDFTemplate
+RegKey44=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Settings|EncodingLastDir
+RegKey45=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Settings|TrackSaveDir
+RegKey46=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Settings|WorkingDir
+RegKey47=HKCU\Software\Nero\Nero 12\Nero Express\Compilation|VolumeLabelAutoTemplate
+RegKey48=HKCU\Software\Nero\Nero 12\Nero Express\Compilation|VolumeLabelISOTemplate
+RegKey49=HKCU\Software\Nero\Nero 12\Nero Express\Compilation|VolumelabelJolietTemplate
+RegKey50=HKCU\Software\Nero\Nero 12\Nero Express\Compilation|VolumeLabelUDFTemplate
+RegKey51=HKCU\Software\Nero\Nero 12\Nero Express\Settings|BootImageDir
+RegKey52=HKCU\Software\Nero\Nero 12\Nero Express\Settings|ImageDir
+RegKey53=HKCU\Software\Nero\Nero 12\Nero Express\Settings|NeroCompilation
+RegKey54=HKCU\Software\Nero\Nero 12\Nero Express\Settings|TrackSaveDir
+RegKey55=HKCU\Software\Nero\Nero 12\Nero Toolkit\DiscSpeed\Capture|Folder
+RegKey56=HKCU\Software\Nero\Nero 12\Nero Toolkit\DiscSpeed\Save|Folder
+RegKey57=HKCU\Software\Nero\Nero 12\Nero Vision\Application|AudioDir
+RegKey58=HKCU\Software\Nero\Nero 12\Nero Vision\Application|CaptureDir
+RegKey59=HKCU\Software\Nero\Nero 12\Nero Vision\Application|DocDir
+RegKey60=HKCU\Software\Nero\Nero 12\Nero Vision\Application|ExportAudioDir
+RegKey61=HKCU\Software\Nero\Nero 12\Nero Vision\Application|ExportVideoDir
+RegKey62=HKCU\Software\Nero\Nero 12\Nero Vision\Application|ImportVideoDir
+RegKey63=HKCU\Software\Nero\Nero 12\Nero Vision\Application|MediaDir
+RegKey64=HKCU\Software\Nero\Nero 12\Nero Vision\Application|PicDir
+RegKey65=HKCU\Software\Nero\Nero 12\Nero Vision\Application|PicSaveDir
+RegKey66=HKCU\Software\Nero\Nero 12\Nero Vision\Application|TmpDir
+RegKey67=HKCU\Software\Nero\Nero 12\Nero Vision\Application|VideoDir
+RegKey68=HKCU\Software\Nero\Nero 12\Nero WaveEditor\Directories|Last
+RegKey69=HKCU\Software\Nero\Nero Blu-ray Player\Settings|DefFolder
 
 [Net Vampire*]
 LangSecRef=3022
@@ -12383,13 +12310,13 @@ DetectFile=%LocalAppData%\Packages\4DF9E0F8.Netflix_mcm4njqhnhss8
 Default=False
 FileKey1=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\PRICache|*.*
-FileKey4=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Temp|*.*
-FileKey5=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\TempState|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState|*.tmp|RECURSE
-FileKey7=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState\LiveTile|*.*
-FileKey8=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey9=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AppData\Indexed DB|*.log
+FileKey3=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey4=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\PRICache|*.*
+FileKey5=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Temp|*.*
+FileKey6=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AppData\Indexed DB|*.log
+FileKey7=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState|*.tmp|RECURSE
+FileKey8=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState\LiveTile|*.*
+FileKey9=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\4DF9E0F8.Netflix_mcm4njqhnhss8\SearchHistory
 
 [NETGEAR Genie*]
@@ -12435,8 +12362,8 @@ FileKey2=%WinDir%\ServiceProfiles\NetworkService\AppData\LocalLow\Microsoft\Cryp
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%SystemDrive%\Documents and Settings\NetworkService\Cookies|*.*|RECURSE
-FileKey2=%SystemDrive%\Documents and Settings\NetworkService.NT*\Cookies|*.*|RECURSE
+FileKey1=%SystemDrive%\Documents and Settings\NetworkService.NT*\Cookies|*.*|RECURSE
+FileKey2=%SystemDrive%\Documents and Settings\NetworkService\Cookies|*.*|RECURSE
 FileKey3=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Temp\Cookies|*.*|RECURSE
 FileKey4=%WinDir%\ServiceProfiles\NetworkService\AppData\Roaming\Microsoft\Windows\Cookies|*.*|RECURSE
 
@@ -12450,28 +12377,28 @@ FileKey1=%WinDir%\ServiceProfiles\NetworkService\debug|*.log
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%SystemDrive%\Documents and Settings\NetworkService\Local Settings\History|*.*|RECURSE
-FileKey2=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\History|*.*|RECURSE
+FileKey1=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\History|*.*|RECURSE
+FileKey2=%SystemDrive%\Documents and Settings\NetworkService\Local Settings\History|*.*|RECURSE
 FileKey3=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\History|*.*|RECURSE
 
 [NetworkService Temp Files*]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%SystemDrive%\Documents and Settings\NetworkService\Local Settings\Temp|*.*|RECURSE
-FileKey2=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\Temp|*.*|RECURSE
+FileKey1=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\Temp|*.*|RECURSE
+FileKey2=%SystemDrive%\Documents and Settings\NetworkService\Local Settings\Temp|*.*|RECURSE
 FileKey3=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Temp|*.*|RECURSE
 
 [NetworkService Temporary Internet Files*]
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
-FileKey1=%SystemDrive%\Documents and Settings\NetworkService\Local Settings\Content.IE5|*.*|RECURSE
-FileKey2=%SystemDrive%\Documents and Settings\NetworkService\Local Settings\Temporary Internet Files|*.*|RECURSE
-FileKey3=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\Content.IE5|*.*|RECURSE
-FileKey4=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\Temporary Internet Files|*.*|RECURSE
-FileKey5=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\Temporary Internet Files|*.*|RECURSE
-FileKey6=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\Content.IE5|*.*|RECURSE
+FileKey1=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\Content.IE5|*.*|RECURSE
+FileKey2=%SystemDrive%\Documents and Settings\NetworkService.NT*\Local Settings\Temporary Internet Files|*.*|RECURSE
+FileKey3=%SystemDrive%\Documents and Settings\NetworkService\Local Settings\Content.IE5|*.*|RECURSE
+FileKey4=%SystemDrive%\Documents and Settings\NetworkService\Local Settings\Temporary Internet Files|*.*|RECURSE
+FileKey5=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\Content.IE5|*.*|RECURSE
+FileKey6=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\Temporary Internet Files|*.*|RECURSE
 
 [Neverwinter*]
 Section=Games
@@ -12487,8 +12414,8 @@ Section=Games
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\New Yankee 3 - In Santas ServiceFinal
 Default=False
 FileKey1=%AppData%\AlawarEntertainment|*_log.html|RECURSE
-FileKey2=%ProgramFiles%\New Yankee 3 - In Santas Service|*.nfo
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\New Yankee 3 - In Santas Service|*.nfo
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\New Yankee 3 - In Santas Service|*.nfo
+FileKey3=%ProgramFiles%\New Yankee 3 - In Santas Service|*.nfo
 
 [Newsbin Pro*]
 LangSecRef=3021
@@ -12553,11 +12480,11 @@ FileKey1=%LocalAppData%\Nikon\Capture NX\ThumbnailCache|*.*|RECURSE
 LangSecRef=3023
 Detect=HKLM\Software\Nikon\MCA2\ViewNX 2
 Default=False
-FileKey1=%LocalAppData%\Nikon\ViewNX 2\Cache|*.*
-FileKey2=%LocalAppData%\Nikon\mPT\*\CacheData\Original|*.*
-FileKey3=%LocalAppData%\Nikon\mPT\*\CacheData\Others|*.*
-FileKey4=%LocalAppData%\Nikon\mPT\*\CacheData\Screen|*.*
-FileKey5=%LocalAppData%\Nikon\mPT\*\CacheData\Thumbnail|*.*
+FileKey1=%LocalAppData%\Nikon\mPT\*\CacheData\Original|*.*
+FileKey2=%LocalAppData%\Nikon\mPT\*\CacheData\Others|*.*
+FileKey3=%LocalAppData%\Nikon\mPT\*\CacheData\Screen|*.*
+FileKey4=%LocalAppData%\Nikon\mPT\*\CacheData\Thumbnail|*.*
+FileKey5=%LocalAppData%\Nikon\ViewNX 2\Cache|*.*
 
 [Nimbuzz Logs*]
 LangSecRef=3022
@@ -12584,15 +12511,9 @@ Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\NirSoft RegScann
 DetectFile=%ProgramFiles%\Nirsoft\regscanner.exe
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\NirSoft|report.html
-FileKey2=%ProgramFiles%\NirSoft|report.html
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\NirSoft\x64|report.html
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\NirSoft\x64|report.html
+FileKey3=%ProgramFiles%\NirSoft|report.html
 FileKey4=%ProgramFiles%\NirSoft\x64|report.html
-
-[Nitro PDF Reader Logs*]
-LangSecRef=3024
-Detect=HKCU\Software\Nitro PDF\Reader
-Default=False
-FileKey1=%AppData%\Nitro|*.log*;*Log.txt*|RECURSE
 
 [Nitro PDF Reader*]
 LangSecRef=3024
@@ -12600,6 +12521,7 @@ Detect=HKCU\Software\Nitro PDF\Reader
 Default=False
 RegKey1=HKCU\Software\Nitro PDF\Reader\1.0\Recent File List
 RegKey2=HKCU\Software\Nitro PDF\Reader\2.0\Recent File List
+FileKey1=%AppData%\Nitro|*.log*;*Log.txt*|RECURSE
 
 [Nitrous Backups*]
 Section=Games
@@ -12620,25 +12542,20 @@ DetectFile=%LocalAppData%\Nokia\Nokia Music*
 Default=False
 FileKey1=%LocalAppData%\Nokia\Nokia Music*|*.log
 
-[Nokia Software Updater Cache - Old Versions*]
-LangSecRef=3021
-DetectFile1=%CommonAppData%\Nokia\Nokia Service Layer\A
-DetectFile2=%CommonProgramFiles%\Nokia\Service Layer\A
-Default=False
-Warning=This will remove all files stored by old versions of Nokia Software Updater, which are no longer supported.
-FileKey1=%CommonAppData%\Nokia\Nokia Service Layer\A|*.*|REMOVESELF
-FileKey2=%CommonProgramFiles%\Nokia\Service Layer\A|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Nokia\Nokia Service Layer\A|*.*|REMOVESELF
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Common Files\Nokia\Service Layer\A|*.*|REMOVESELF
-
 [Nokia Software Updater Cache*]
 LangSecRef=3021
 Detect1=HKCU\Software\Nokia\NSU3
 Detect2=HKLM\Software\Nokia\Nokia Suite
+DetectFile1=%CommonAppData%\Nokia\Nokia Service Layer\A
+DetectFile2=%CommonProgramFiles%\Nokia\Service Layer\A
 Default=False
 Warning=This will remove Nokia phone firmwares, applications and other files stored by Nokia Suite Updater. Files will be re-downloaded when updating phone.
-FileKey1=%LocalAppData%\Nokia\NSU3\NOSSU2|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Nokia\Nokia Suite\NOSSU2|*.*|RECURSE
+FileKey1=%CommonAppData%\Nokia\Nokia Service Layer\A|*.*|REMOVESELF
+FileKey2=%CommonProgramFiles%\Nokia\Service Layer\A|*.*|REMOVESELF
+FileKey3=%LocalAppData%\Nokia\NSU3\NOSSU2|*.*|RECURSE
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\Common Files\Nokia\Service Layer\A|*.*|REMOVESELF
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\Nokia\Nokia Service Layer\A|*.*|REMOVESELF
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Nokia\Nokia Suite\NOSSU2|*.*|RECURSE
 ExcludeKey1=FILE|%LocalAppData%\Nokia\NSU3\NOSSU2\|usergroups.cfg
 ExcludeKey2=PATH|%LocalAppData%\Nokia\NSU3\NOSSU2\Flash\|*.*
 
@@ -12750,27 +12667,27 @@ Detect=HKCU\Software\Valve\Steam\Apps\17710
 Default=False
 FileKey1=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\config\html|*.*|RECURSE
 FileKey2=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\cache|*.*|RECURSE
-FileKey3=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\materials\temp|*.vtf|RECURSE
-FileKey4=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\downloads|*.*|RECURSE
+FileKey3=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\downloads|*.*|RECURSE
+FileKey4=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\materials\temp|*.vtf|RECURSE
 
 [Nuclear Dawn Custom Content*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\17710
 Default=False
 Warning=Fixes version mismatches, removes old custom map versions and removes old content. Re-download from server requried.
-FileKey1=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\models|*.*|RECURSE
+FileKey1=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps|*corner*;*roadwork*;*rock*;*frost*;*mars*|RECURSE
 FileKey2=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\materials\models|*.*|RECURSE
 FileKey3=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\materials\sprites|*.*|RECURSE
-FileKey4=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\sound\quake|*.*|RECURSE
-FileKey5=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps|*corner*;*roadwork*;*rock*;*frost*;*mars*|RECURSE
+FileKey4=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\models|*.*|RECURSE
+FileKey5=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\sound\quake|*.*|RECURSE
 
 [Nuclear Dawn Demos/Screenshots*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\17710
 Default=False
 Warning=This will remove all demos and screenshots which are not uploaded to steam cloud.
-FileKey1=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps|*.dem*|RECURSE
-FileKey2=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\donedemos|*.*|RECURSE
+FileKey1=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\donedemos|*.*|RECURSE
+FileKey2=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps|*.dem*|RECURSE
 FileKey3=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\screenshots|*.*|RECURSE
 
 [Nuclear Dawn Developer Files*]
@@ -12778,15 +12695,15 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\17710
 Default=False
 Warning=This will remove content used by game, map and community developers.
-FileKey1=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\sdk_content|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\sdk_tools|*.*|REMOVESELF
-FileKey3=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\platform\AddOns|*.*|RECURSE
-FileKey4=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\scripts\vehicles|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\bin|*bsp*;*vtex*;SDKLauncher.exe;modelbrowser.exe|RECURSE
+FileKey2=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps|*example*|RECURSE
+FileKey3=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps\ai_data|nd_codetest.nav|RECURSE
+FileKey4=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\scripts\scripted_props|*.*|REMOVESELF
 FileKey5=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\scripts\units|*.*|REMOVESELF
-FileKey6=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\scripts\scripted_props|*.*|REMOVESELF
-FileKey7=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps|*example*|RECURSE
-FileKey8=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps\ai_data|nd_codetest.nav|RECURSE
-FileKey9=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\bin|*bsp*;*vtex*;SDKLauncher.exe;modelbrowser.exe|RECURSE
+FileKey6=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\scripts\vehicles|*.*|REMOVESELF
+FileKey7=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\platform\AddOns|*.*|RECURSE
+FileKey8=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\sdk_content|*.*|REMOVESELF
+FileKey9=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\sdk_tools|*.*|REMOVESELF
 
 [Nuclear Dawn Mac/Linux Binaries*]
 Section=Games
@@ -12808,82 +12725,36 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\17710
 Default=False
 Warning=This will prevent running of Nuclear Dawn Tutorials but will free over 850mb of disk space.
-FileKey1=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\media|*tutorial*|RECURSE
-FileKey2=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps|*training*|RECURSE
-FileKey3=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps\ai_data|*training*|RECURSE
+FileKey1=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps|*training*|RECURSE
+FileKey2=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps\ai_data|*training*|RECURSE
+FileKey3=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\media|*tutorial*|RECURSE
 FileKey4=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\sound\voices\tutorial|*.*|REMOVESELF
-
-[NVIDIA Cache*]
-LangSecRef=3024
-Detect=HKLM\Software\NVIDIA Corporation
-Default=False
-FileKey1=%AppData%\NVIDIA\*Cache|*.*|RECURSE
-
-[NVIDIA GFExperience*]
-LangSecRef=3024
-Detect=HKLM\SOFTWARE\NVIDIA Corporation\Global\GFExperience
-DetectFile1=%CommonAppData%\NVIDIA Corporation\GeForce Experience
-DetectFile2=%LocalAppData%\NVIDIA Corporation\NVIDIA GeForce Experience
-DetectFile3=%ProgramFiles%\NVIDIA Corporation\NVIDIA GeForce Experience
-Default=False
-FileKey1=%SystemDrive%\NvidiaLogging\GFExperience|GridClientLog.log*|RECURSE
-FileKey2=%CommonAppData%\NVIDIA Corporation\*GeForce Experience\Logs|*.log
-FileKey3=%CommonAppData%\NVIDIA Corporation\Downloader|*.*|RECURSE
-FileKey4=%CommonAppData%\NVIDIA Corporation\GeForce Experience\Update|*.*|RECURSE
-FileKey5=%CommonAppData%\NVIDIA Corporation\GfeBridges|*.log
-FileKey6=%CommonAppData%\NVIDIA Corporation\GFExperience|*.log
-FileKey7=%CommonAppData%\NVIDIA Corporation\nvstreamsvc|*.log
-FileKey8=%CommonAppData%\NVIDIA Corporation\ShadowPlay|*.log;*.bak;*.stat
-FileKey9=%CommonAppData%\NVIDIA\NvBackend\Updatus\DownloadManager|*.*
-FileKey10=%CommonAppData%\NVIDIA\Updatus\DownloadManager|*.*
-FileKey11=%LocalAppData%\NVIDIA Corporation\GFExperience|*.log
-FileKey12=%LocalAppData%\NVIDIA Corporation\ShadowPlay|*.bak;*.log;*.old
-FileKey13=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\*GeForce Experience\Logs|*.log
-FileKey14=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\Downloader|*.*|RECURSE
-FileKey15=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\GeForce Experience\Update|*.*|RECURSE
-FileKey16=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\GfeBridges|*.log
-FileKey17=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\GFExperience|*.log
-FileKey18=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\NetService|*.*|RECURSE
-FileKey19=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\nvstreamsvc|*.log
-FileKey20=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\ShadowPlay|*.bak;*.log;*.old;*.stat
-FileKey21=%LocalAppData%\VirtualStore\ProgramData\NVIDIA\NvBackend\Updatus\DownloadManager|*.*
-FileKey22=%LocalAppData%\VirtualStore\ProgramData\NVIDIA\Updatus\DownloadManager|*.*
 
 [NVIDIA*]
 LangSecRef=3024
 Detect=HKLM\Software\NVIDIA Corporation
 Default=False
-FileKey1=%CommonAppData%\NVIDIA|*.log;*.log_backup1|RECURSE
-FileKey2=%CommonAppData%\Nvidia|Resource.old
-FileKey3=%CommonAppData%\NVIDIA\NvBackend|*.log|RECURSE
-FileKey4=%CommonAppData%\Nvidia\NvBackend\Updat*s|*.bak
-FileKey5=%CommonAppData%\Nvidia\Updat*s|*.bak
-FileKey6=%CommonAppData%\NVIDIA Corporation|*.log
-FileKey7=%CommonAppData%\NVIDIA Corporation\NetService|*.*|RECURSE
-FileKey8=%CommonAppData%\NVIDIA Corporation\NvTelemetry|*.bak;*.log;*.old
-FileKey9=%CommonAppData%\NVIDIA Corporation\Nvstapisvr|*.bak;*.log;*.old
-FileKey10=%CommonAppData%\NVIDIA Corporation\nvStereoInstaller|*.log;*.old
-FileKey11=%CommonAppData%\NVIDIA Corporation\nvsdk|*.bak;*.log;*.old
-FileKey12=%CommonAppData%\NVIDIA Corporation\NvVAD|*.bak;*.log;*.old
-FileKey13=%LocalAppData%\NVIDIA\NvBackend|*.log;*.bak
-FileKey14=%LocalAppData%\NVIDIA Corporation\*\CefCache|*.log;*.bak;Cookies;Cookies-journal;QuotaManager;QuotaManager-journal
-FileKey15=%LocalAppData%\NVIDIA Corporation\*\CefCache\*Cache|*.*|RECURSE
-FileKey16=%LocalAppData%\NVIDIA Corporation\GfeSDK|*.log;*.bak
-FileKey17=%LocalAppData%\NVIDIA Corporation\NvNode|*.bak;*.log;*.old
-FileKey18=%LocalAppData%\NVIDIA Corporation\NvProfileUpdater|*.bak;*.log;*.old
-FileKey19=%LocalAppData%\NVIDIA Corporation\NvTelemetry|*.bak;*.log;*.old
-FileKey20=%LocalAppData%\NVIDIA Corporation\NvTmMon|*.bak;*.log;*.old
-FileKey21=%LocalAppData%\NVIDIA Corporation\NvTmRep|*.bak;*.log;*.old
-FileKey22=%LocalAppData%\NVIDIA Corporation\NvVAD|*.bak;*.log;*.old
-FileKey23=%LocalAppData%\VirtualStore\Program Files*\NVIDIA Corporation\NetworkAccessManager\Apache Group\Apache2\logs|*.*
-FileKey24=%LocalAppData%\VirtualStore\ProgramData*\NVIDIA|*.log;*.log_backup1|RECURSE
-FileKey25=%LocalAppData%\VirtualStore\ProgramData*\NVIDIA\NvBackend|*.log|RECURSE
-FileKey26=%LocalAppData%\VirtualStore\ProgramData*\NVIDIA Corporation\NvTelemetry|*.log;*.bak
-FileKey27=%LocalAppData%\VirtualStore\ProgramData\Nvidia|Resource.old
-FileKey28=%LocalAppData%\VirtualStore\ProgramData\Nvidia\NvBackend\Updat*s|*.bak
-FileKey29=%LocalAppData%\VirtualStore\ProgramData\Nvidia\Updat*s|*.bak
-FileKey30=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\NetService|*.*|RECURSE
-FileKey31=%ProgramFiles%\NVIDIA Corporation\NetworkAccessManager\Apache Group\Apache2\logs|*.*
+FileKey1=%AppData%\NVIDIA\*Cache|*.*|RECURSE
+FileKey2=%CommonAppData%\NVIDIA|*.log;*.log_backup1;Resource.old;*.bak|RECURSE
+FileKey3=%CommonAppData%\NVIDIA Corporation|*.log;*bak;*log.*;*.old;*.stat|RECURSE
+FileKey4=%CommonAppData%\NVIDIA Corporation\Downloader|*.*|RECURSE
+FileKey5=%CommonAppData%\NVIDIA Corporation\GeForce Experience\Update|*.*|RECURSE
+FileKey6=%CommonAppData%\NVIDIA\NvBackend\Updatus\DownloadManager|*.*
+FileKey7=%CommonAppData%\NVIDIA\Updatus\DownloadManager|*.*
+FileKey8=%LocalAppData%\NVIDIA Corporation|*.log;*.bak;*.old|RECURSE
+FileKey9=%LocalAppData%\NVIDIA Corporation\*\CefCache|*.log;*.bak;Cookies;Cookies-journal;QuotaManager;QuotaManager-journal
+FileKey10=%LocalAppData%\NVIDIA Corporation\*\CefCache\*Cache|*.*|RECURSE
+FileKey11=%LocalAppData%\NVIDIA\NvBackend|*.log;*.bak
+FileKey12=%LocalAppData%\VirtualStore\Program Files*\NVIDIA Corporation\NetworkAccessManager\Apache Group\Apache2\logs|*.*
+FileKey13=%LocalAppData%\VirtualStore\ProgramData\NVIDIA|*.log;*.log_backup1;Resource.old;*.bak|RECURSE
+FileKey14=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation|*.log;*bak;*log.*;*.old;*.stat|RECURSE
+FileKey15=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\Downloader|*.*|RECURSE
+FileKey16=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\GeForce Experience\Update|*.*|RECURSE
+FileKey17=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\NetService|*.*|RECURSE
+FileKey18=%LocalAppData%\VirtualStore\ProgramData\NVIDIA\NvBackend\Updatus\DownloadManager|*.*
+FileKey19=%LocalAppData%\VirtualStore\ProgramData\NVIDIA\Updatus\DownloadManager|*.*
+FileKey20=%ProgramFiles%\NVIDIA Corporation\NetworkAccessManager\Apache Group\Apache2\logs|*.*
+FileKey21=%SystemDrive%\NvidiaLogging\GFExperience|GridClientLog.log*|RECURSE
 
 [O&O Defrag*]
 LangSecRef=3024
@@ -12938,19 +12809,19 @@ Detect3=HKCU\Software\Microsoft\Office\15.0\Common
 Detect4=HKCU\Software\Microsoft\Office\16.0\Common
 Default=False
 FileKey1=%Documents%\|~*.ppt;~*.pptx;~*.doc;~*.docx|RECURSE
-FileKey2=%LocalAppData%\Microsoft\Office\*\OfficeFileCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Microsoft\Office\*|OneNoteOfflineCache.onecache
-FileKey4=%LocalAppData%\Microsoft\OneNote\*\OneNoteOfflineCache_Files|*.*|RECURSE
-FileKey5=%LocalAppData%\Microsoft\OneNote\*|OneNoteOfflineCache.onecache
-RegKey1=HKCU\Software\Microsoft\Office\Common|FontBmpCache
-RegKey2=HKCU\Software\Microsoft\Office\12.0\Common\Internet|UseRWHlinkNavigation
-RegKey3=HKCU\Software\Microsoft\Office\12.0\Word\Reading Locations
-RegKey4=HKCU\Software\Microsoft\Office\14.0\Common\Internet|UseRWHlinkNavigation
-RegKey5=HKCU\Software\Microsoft\Office\14.0\Word\Reading Locations
-RegKey6=HKCU\Software\Microsoft\Office\15.0\Common\Internet|UseRWHlinkNavigation
-RegKey7=HKCU\Software\Microsoft\Office\15.0\Word\Reading Locations
-RegKey8=HKCU\Software\Microsoft\Office\16.0\Common\Internet|UseRWHlinkNavigation
-RegKey9=HKCU\Software\Microsoft\Office\16.0\Word\Reading Locations
+FileKey2=%LocalAppData%\Microsoft\Office\*|OneNoteOfflineCache.onecache
+FileKey3=%LocalAppData%\Microsoft\Office\*\OfficeFileCache|*.*|RECURSE
+FileKey4=%LocalAppData%\Microsoft\OneNote\*|OneNoteOfflineCache.onecache
+FileKey5=%LocalAppData%\Microsoft\OneNote\*\OneNoteOfflineCache_Files|*.*|RECURSE
+RegKey1=HKCU\Software\Microsoft\Office\12.0\Common\Internet|UseRWHlinkNavigation
+RegKey2=HKCU\Software\Microsoft\Office\12.0\Word\Reading Locations
+RegKey3=HKCU\Software\Microsoft\Office\14.0\Common\Internet|UseRWHlinkNavigation
+RegKey4=HKCU\Software\Microsoft\Office\14.0\Word\Reading Locations
+RegKey5=HKCU\Software\Microsoft\Office\15.0\Common\Internet|UseRWHlinkNavigation
+RegKey6=HKCU\Software\Microsoft\Office\15.0\Word\Reading Locations
+RegKey7=HKCU\Software\Microsoft\Office\16.0\Common\Internet|UseRWHlinkNavigation
+RegKey8=HKCU\Software\Microsoft\Office\16.0\Word\Reading Locations
+RegKey9=HKCU\Software\Microsoft\Office\Common|FontBmpCache
 
 [Office Password Recovery*]
 LangSecRef=3024
@@ -12976,10 +12847,10 @@ FileKey2=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\Microsoft\Cryptne
 FileKey3=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\Temp|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\TokenBroker\Cache|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local|msodata*.dat
-FileKey6=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0|*.onecache
-FileKey7=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0\OneNote*Cache_Files|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\Office\16.0\WebServiceCache\AllUsers\office*client.microsoft.com|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\Office\OTele|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\Office\16.0\WebServiceCache\AllUsers\office*client.microsoft.com|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\Office\OTele|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0|*.onecache
+FileKey9=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0\OneNote*Cache_Files|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Office.OneNote_8wekyb3d8bbwe\SearchHistory
 
@@ -13099,13 +12970,6 @@ Default=False
 FileKey1=%CommonAppData%\Sony Corporation\OpenMG|*.log
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Sony Corporation\OpenMG|*.log
 
-[OpenOffice.org Setup Files*]
-LangSecRef=3021
-Detect1=HKLM\Software\OpenOffice
-Detect2=HKLM\Software\OpenOffice.org
-Default=False
-FileKey1=%UserProfile%\Desktop|OpenOffice.org * Installation Files|RECURSE
-
 [OpenOffice.org*]
 LangSecRef=3021
 Detect1=HKLM\Software\OpenOffice
@@ -13117,6 +12981,13 @@ FileKey3=%AppData%\OpenOffice*\*\user\registry\cache|*.*
 FileKey4=%AppData%\OpenOffice*\*\user\registry\data\org\openoffice\Office|Views.xcu;Writer.xcu;Common.xcu;Histories.xcu
 FileKey5=%AppData%\OpenOffice*\*\user\registry\data\org\openoffice\ucb|Hierarchy.xcu;Store.xcu
 FileKey6=%ProgramFiles%\OpenOffice*\share\uno_packages\cache\uno_packages|*.tmp;*.log;log.txt
+
+[OpenOffice.org Setup Files*]
+LangSecRef=3021
+Detect1=HKLM\Software\OpenOffice
+Detect2=HKLM\Software\OpenOffice.org
+Default=False
+FileKey1=%UserProfile%\Desktop|OpenOffice.org * Installation Files|RECURSE
 
 [OpenRA Logs*]
 Section=Games
@@ -13197,12 +13068,6 @@ Detect2=HKCU\SOFTWARE\Robot Entertainment\Orcs Must Die! Unchained
 Default=False
 FileKey1=%Documents%\My Games\Orcs Must Die Unchained\SpitfireGame\Logs|*.log;*.dmg|RECURSE
 
-[Origin Installers*]
-Section=Games
-Detect=HKLM\Software\Classes\Origin
-Default=False
-FileKey1=%ProgramFiles%\Origin Games|*.cab;vc_red.msi;gfwlivesetup.exe;GamesExplorerIntegrationTool.exe;install.ini;globdata.ini;vcredist.bmp;vc_red.exe;install.exe;install.res.*.dll;eula.*.txt;vcredist_x64.exe;dotNetFx40_Full_setup.exe;dotNetFx40_Full_x86_x64.exe;xnafx40_redist.msi;DSETUP.DLL;oalinst.exe;DXSETUP.EXE;dsetup32.dll;dotnetfx3setup;vcredist_x86.exe;dxwebsetup.exe;xnafx31_redist.msi;dotNetFx35setup.exe;dotnetfx35.exe|RECURSE
-
 [Origin*]
 Section=Games
 Detect=HKLM\Software\Classes\Origin
@@ -13210,12 +13075,18 @@ Default=False
 FileKey1=%CommonAppData%\Origin\*Cache|*.*|RECURSE
 FileKey2=%CommonAppData%\Origin\Logs|*.*
 FileKey3=%CommonAppData%\Origin\Telemetry|*.*
-FileKey4=%LocalAppData%\Origin\Web Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\Origin\Origin\cache|*.*|RECURSE
+FileKey4=%LocalAppData%\Origin\Origin\cache|*.*|RECURSE
+FileKey5=%LocalAppData%\Origin\Web Cache|*.*|RECURSE
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\Origin\*Cache|*.*|RECURSE
 FileKey7=%LocalAppData%\VirtualStore\ProgramData\Origin\Logs|*.*
 FileKey8=%LocalAppData%\VirtualStore\ProgramData\Origin\Telemetry|*.*
 FileKey9=%SystemDrive%\|shared.log
+
+[Origin Installers*]
+Section=Games
+Detect=HKLM\Software\Classes\Origin
+Default=False
+FileKey1=%ProgramFiles%\Origin Games|*.cab;vc_red.msi;gfwlivesetup.exe;GamesExplorerIntegrationTool.exe;install.ini;globdata.ini;vcredist.bmp;vc_red.exe;install.exe;install.res.*.dll;eula.*.txt;vcredist_x64.exe;dotNetFx40_Full_setup.exe;dotNetFx40_Full_x86_x64.exe;xnafx40_redist.msi;DSETUP.DLL;oalinst.exe;DXSETUP.EXE;dsetup32.dll;dotnetfx3setup;vcredist_x86.exe;dxwebsetup.exe;xnafx31_redist.msi;dotNetFx35setup.exe;dotnetfx35.exe|RECURSE
 
 [Osmos Logs*]
 Section=Games
@@ -13285,8 +13156,8 @@ Section=Games
 DetectFile=%Documents%\Overwatch
 Default=False
 FileKey1=%Documents%\Overwatch\Logs|*.*|RECURSE
-FileKey2=%ProgramFiles%\Overwatch\WebBrowserProxy\cache\browser|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Overwatch\WebBrowserProxy\cache\browser|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Overwatch\WebBrowserProxy\cache\browser|*.*
+FileKey3=%ProgramFiles%\Overwatch\WebBrowserProxy\cache\browser|*.*
 
 [OVH HubiC cache*]
 LangSecRef=3021
@@ -13298,14 +13169,14 @@ FileKey1=%LocalAppData%\OVH\hubiC-browser\cache\data7|*.*|RECURSE
 LangSecRef=3021
 Detect=HKCU\Software\ej-technologies
 Default=False
-FileKey1=%ProgramFiles%\Oxygen XML Editor 14|*.properties;*.log
-FileKey2=%ProgramFiles%\Oxygen XML Editor 14\.install4j|*.log
-FileKey3=%ProgramFiles%\Oxygen XML Editor 14\dicts|*.txt;*.html
-FileKey4=%ProgramFiles%\Oxygen XML Editor 14\lib|*.txt|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Oxygen XML Editor 14|*.properties;*.log
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Oxygen XML Editor 14\.install4j|*.log
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Oxygen XML Editor 14\dicts|*.txt;*.html
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\Oxygen XML Editor 14\lib|*.txt|RECURSE
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Oxygen XML Editor 14|*.properties;*.log
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Oxygen XML Editor 14\.install4j|*.log
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Oxygen XML Editor 14\dicts|*.txt;*.html
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\Oxygen XML Editor 14\lib|*.txt|RECURSE
+FileKey5=%ProgramFiles%\Oxygen XML Editor 14|*.properties;*.log
+FileKey6=%ProgramFiles%\Oxygen XML Editor 14\.install4j|*.log
+FileKey7=%ProgramFiles%\Oxygen XML Editor 14\dicts|*.txt;*.html
+FileKey8=%ProgramFiles%\Oxygen XML Editor 14\lib|*.txt|RECURSE
 ExcludeKey1=FILE|%ProgramFiles%\Oxygen XML Editor 14\.install4j\|files.log
 
 [Pacific Storm*]
@@ -13480,8 +13351,8 @@ FileKey5=%WinDir%\System32\sysprep\Panther\IE|diagerr.xml;diagwrn.xml;*.log
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Paragon Software\Hard Disk Manager 12 Suite
 Default=False
-FileKey1=%ProgramFiles%\Paragon Software\Hard Disk Manager 12 Suite|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Paragon Software\Hard Disk Manager 12 Suite|*.log
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Paragon Software\Hard Disk Manager 12 Suite|*.log
+FileKey2=%ProgramFiles%\Paragon Software\Hard Disk Manager 12 Suite|*.log
 
 [Paragon Hard Disk Manager 14 Suite*]
 LangSecRef=3024
@@ -13515,9 +13386,9 @@ FileKey25=%LocalAppData%\VirtualStore\ProgramData\vmcreate|*.log
 FileKey26=%ProgramFiles%\Paragon Software\Hard Disk Manager 14 Suite\*|BioNtLog.txt;cdb.log;fdisk.txt;pwlog.txt;stubact.log
 FileKey27=%ProgramFiles%\Paragon Software\Hard Disk Manager 14 Suite\*\symmpi*|*.txt
 FileKey28=%SystemDrive%\Documents and Settings\LocalService|objsrv.log
-FileKey29=%WinDir%\Logs\Paragon\Client|*.log
-FileKey30=%WinDir%\Logs\Paragon Software\UimSetup|*.log
-FileKey31=%WinDir%\Logs\Paragon Software\VssRequester|*.log
+FileKey29=%WinDir%\Logs\Paragon Software\UimSetup|*.log
+FileKey30=%WinDir%\Logs\Paragon Software\VssRequester|*.log
+FileKey31=%WinDir%\Logs\Paragon\Client|*.log
 
 [Paragon Partition Manager 2014*]
 LangSecRef=3024
@@ -13542,8 +13413,8 @@ FileKey16=%LocalAppData%\VirtualStore\ProgramData\logsaver|*.log
 FileKey17=%LocalAppData%\VirtualStore\ProgramData\redistpart|*.log
 FileKey18=%ProgramFiles%\Paragon Software\*\program|BioNtLog.txt;cdb.log;fdisk.txt;pwlog.txt;stubact.log
 FileKey19=%SystemDrive%\Documents and Settings\LocalService|objsrv.log
-FileKey20=%WinDir%\Logs\Paragon\Client|*.log
-FileKey21=%WinDir%\Logs\Paragon Software\VssRequester|*.log
+FileKey20=%WinDir%\Logs\Paragon Software\VssRequester|*.log
+FileKey21=%WinDir%\Logs\Paragon\Client|*.log
 
 [Paragon Total Defrag 2010*]
 LangSecRef=3021
@@ -13559,18 +13430,18 @@ Default=False
 Warning=This will cause you to redownload the Paramount Dynamic RSS file.
 FileKey1=%LocalAppData%\Microsoft\Feeds|http~c~f~fthemeserver~dmicrosoft~dcom~fdefault~daspx~mp=Paramount&c=Dynamic&m=en-US~
 
-[Paranormal Agency*]
-Section=Games
-DetectFile=%AppData%\Shape Games\Paranormal_v*
-Default=False
-FileKey1=%AppData%\Shame Games\Paranormal_v*\logs|*.*
-
 [Paranormal*]
 Section=Games
 DetectFile=%ProgramFiles%\Desura\Common\paranormal
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Desura\Common\paranormal\UDKGame\Logs|*.*
 FileKey2=%ProgramFiles%\Desura\Common\paranormal\UDKGame\Logs|*.*
+
+[Paranormal Agency*]
+Section=Games
+DetectFile=%AppData%\Shape Games\Paranormal_v*
+Default=False
+FileKey1=%AppData%\Shame Games\Paranormal_v*\logs|*.*
 
 [Partner Application*]
 LangSecRef=3022
@@ -13585,8 +13456,8 @@ Detect1=HKCU\Software\GrindingGearGames\Path of Exile
 Detect2=HKCU\Software\Valve\Steam\Apps\238960
 Default=False
 FileKey1=%Documents%\My Games\Path of Exile\Minimap|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Path of Exile\logs|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Grinding Gear Games\Path of Exile\Logs|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Grinding Gear Games\Path of Exile\Logs|*.*
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Path of Exile\logs|*.*
 FileKey4=%ProgramFiles%\Grinding Gear Games\Path of Exile\Logs|*.*
 FileKey5=%ProgramFiles%\Steam\steamapps\common\Path of Exile\logs|*.*
 
@@ -13618,12 +13489,12 @@ Default=False
 FileKey1=%AppData%\PC Tools Performance Toolkit\CleanReports|*.*
 FileKey2=%CommonAppData%\PC Tools\Performance Toolkit\Defrag\Logs|*.*
 FileKey3=%CommonAppData%\PC Tools\Performance Toolkit\Repair\Logs|*.*
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\PC Tools\*\Log|*.*
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\PC Tools\*\~tmp|*.*
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\PC Tools\*\~tmp|*.*
+FileKey5=%LocalAppData%\VirtualStore\Program Files*\PC Tools\*\Log|*.*
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\PC Tools\Performance Toolkit\Defrag\Logs|*.*
 FileKey7=%LocalAppData%\VirtualStore\ProgramData\PC Tools\Performance Toolkit\Repair\Logs|*.*
-FileKey8=%ProgramFiles%\PC Tools\*\Log|*.*
-FileKey9=%ProgramFiles%\PC Tools\*\~tmp|*.*
+FileKey8=%ProgramFiles%\PC Tools\*\~tmp|*.*
+FileKey9=%ProgramFiles%\PC Tools\*\Log|*.*
 
 [PC Tools sMonitor*]
 LangSecRef=3024
@@ -13685,19 +13556,13 @@ Detect=HKCU\Software\Woozle\PE Module Explorer
 Default=False
 RegKey1=HKCU\Software\Woozle\PE Module Explorer\Recent Files
 
-[Peerblock Failed Lists*]
-LangSecRef=3024
-DetectFile=%ProgramFiles%\Peerblock
-Default=False
-Warning=This will delete all lists that failed to load into your peerblock
-FileKey1=%ProgramFiles%\Peerblock\lists|*.list.failed*
-
 [Peerblock*]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Peerblock
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Peerblock|*.log;History.db;*.bak;cache.p2b
 FileKey2=%ProgramFiles%\Peerblock|*.log;History.db;*.bak;cache.p2b
+FileKey3=%ProgramFiles%\Peerblock\lists|*.list.failed*
 
 [PeerNetworking*]
 LangSecRef=3025
@@ -13767,12 +13632,10 @@ FileKey2=%SystemDrive%\PerfLogs\System\Performance|*.*|RECURSE
 LangSecRef=3024
 DetectFile=%ProgramFiles%\PC Starters\Performance Maintainer
 Default=False
-FileKey1=%ProgramFiles%\PC Starters\Performance Maintainer\log|*.*|RECURSE
-FileKey2=%ProgramFiles%\PC Starters\Performance Maintainer\Backups|*.*|RECURSE
-FileKey3=%ProgramFiles%\PC Starters\Performance Maintainer\Logs|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\PC Starters\Performance Maintainer\log|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\PC Starters\Performance Maintainer\Backups|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\PC Starters\Performance Maintainer\Logs|*.*|RECURSE
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\PC Starters\Performance Maintainer\Backups|*.*|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\PC Starters\Performance Maintainer\log*|*.*|RECURSE
+FileKey3=%ProgramFiles%\PC Starters\Performance Maintainer\Backups|*.*|RECURSE
+FileKey4=%ProgramFiles%\PC Starters\Performance Maintainer\log*|*.*|RECURSE
 
 [Pet Pals Animal Doctor*]
 Section=Games
@@ -13787,17 +13650,12 @@ FileKey6=%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor\temp|*.*|REMOV
 ExcludeKey1=PATH|%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor\jre\bin\|*.*
 ExcludeKey2=PATH|%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor\jre\lib\|*.*
 
-[phase-6 logs*]
-LangSecRef=3021
-DetectFile=%UserProfile%\.phase-6
-Default=False
-FileKey1=%UserProfile%\.phase-6\logs|phase-6.log|REMOVESELF
-
 [phase-6*]
 LangSecRef=3021
 DetectFile=%UserProfile%\.phase-6
 Default=False
 FileKey1=%UserProfile%\.phase-6|window-position.txt|REMOVESELF
+FileKey2=%UserProfile%\.phase-6\logs|phase-6.log|REMOVESELF
 
 [Phone*]
 DetectOS=10.0|
@@ -13879,8 +13737,8 @@ RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 LangSecRef=3021
 Detect=HKCU\Software\Teorex\PhotoScissors
 Default=False
-RegKey1=HKCU\Software\Teorex\PhotoScissors\RecentFileList
-RegKey2=HKCU\Software\Teorex\PhotoScissors\Recent File List
+RegKey1=HKCU\Software\Teorex\PhotoScissors\Recent File List
+RegKey2=HKCU\Software\Teorex\PhotoScissors\RecentFileList
 
 [Photoshop CS Filebrowser*]
 LangSecRef=3021
@@ -14009,15 +13867,15 @@ FileKey1=%AppData%\PlayFirst|logfile.txt|RECURSE
 LangSecRef=3023
 Detect=HKCU\Software\Plex, Inc.\Plex Media Server
 Default=False
-FileKey1=%LocalAppData%\Plex Media Server\Crash Reports|*.*|RECURSE
-FileKey2=%LocalAppData%\Plex Media Server\Logs|*.*|RECURSE
-FileKey3=%LocalAppData%\Plex Media Server\Updates|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Plex\Plex Media Server|*.txt;*.log|RECURSE
+FileKey1=%LocalAppData%\Plex Media Server\Cache\PhotoTranscoder|*.*|RECURSE
+FileKey2=%LocalAppData%\Plex Media Server\Crash Reports|*.*|RECURSE
+FileKey3=%LocalAppData%\Plex Media Server\Logs|*.*|RECURSE
+FileKey4=%LocalAppData%\Plex Media Server\Updates|*.*|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\Program Files*\Plex Media Server\Cache\PhotoTranscoder|*.*|RECURSE
 FileKey6=%LocalAppData%\VirtualStore\Program Files*\Plex Media Server\Crash Reports|*.*|RECURSE
 FileKey7=%LocalAppData%\VirtualStore\Program Files*\Plex Media Server\Logs|*.*|RECURSE
 FileKey8=%LocalAppData%\VirtualStore\Program Files*\Plex Media Server\Updates|*.*|RECURSE
-FileKey9=%LocalAppData%\Plex Media Server\Cache\PhotoTranscoder|*.*|RECURSE
+FileKey9=%LocalAppData%\VirtualStore\Program Files*\Plex\Plex Media Server|*.txt;*.log|RECURSE
 FileKey10=%ProgramFiles%\Plex\Plex Media Server|*.txt;*.log|RECURSE
 
 [Pogo Games Cache*]
@@ -14044,8 +13902,8 @@ FileKey1=%AppData%\Pok3d|*.log;*.dmp
 Section=Games
 DetectFile=%LocalAppData%\PokerStars
 Default=False
-FileKey1=%LocalAppData%\PokeStars|*.log.*
-FileKey2=%LocalAppData%\PokerStars\ImgCache|*.*
+FileKey1=%LocalAppData%\PokerStars\ImgCache|*.*
+FileKey2=%LocalAppData%\PokeStars|*.log.*
 
 [Pokki Backups*]
 LangSecRef=3022
@@ -14205,8 +14063,8 @@ FileKey1=%AppData%\PriceGong\tmp|*.*|RECURSE
 Section=Games
 DetectFile=%ProgramFiles%\Ubisoft\Prince of Persia T2T
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Prince of Persia T2T|*.log
-FileKey2=%LocalAppData%\Ubisoft\Prince of Persia T2T|*.log
+FileKey1=%LocalAppData%\Ubisoft\Prince of Persia T2T|*.log
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Prince of Persia T2T|*.log
 FileKey3=%ProgramFiles%\Ubisoft\Prince of Persia T2T|*.log
 
 [Print Queue*]
@@ -14220,8 +14078,8 @@ FileKey1=%WinDir%\System32\Spool\Printers|*.*
 LangSecRef=3025
 Detect=HKLM\System\CurrentControlSet\Control\Print
 Default=False
-FileKey1=%WinDir%\system32\spool|spooler.xml
-FileKey2=%SystemDrive%\spoolerlogs|spooler.xml
+FileKey1=%SystemDrive%\spoolerlogs|spooler.xml
+FileKey2=%WinDir%\system32\spool|spooler.xml
 
 [Prison Architect*]
 Section=Games
@@ -14387,21 +14245,16 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Puran Defrag|PuranDefrag.html
 FileKey2=%ProgramFiles%\Puran Defrag|PuranDefrag.html
 
-[Pure Networks Dumps*]
-LangSecRef=3022
-Detect=HKCU\Software\Pure Networks
-Default=False
-FileKey1=%CommonAppData%\Pure Networks\Platform\minidumps|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Pure Networks\Platform\minidumps|*.*
-
 [Pure Networks*]
 LangSecRef=3022
 Detect=HKCU\Software\Pure Networks
 Default=False
 FileKey1=%CommonAppData%\Pure Networks\Log|*.*
 FileKey2=%CommonAppData%\Pure Networks\Platform|*.bak
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Pure Networks\Log|*.*
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Pure Networks\Platform|*.bak
+FileKey3=%CommonAppData%\Pure Networks\Platform\minidumps|*.*
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\Pure Networks\Log|*.*
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\Pure Networks\Platform|*.bak
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Pure Networks\Platform\minidumps|*.*
 
 [PureRa Log*]
 LangSecRef=3024
@@ -14501,24 +14354,24 @@ LangSecRef=3024
 Detect=HKCU\Software\Quizo\QTTabBar
 Default=False
 FileKey1=%AppData%\QTTabBar|*.log
-RegKey1=HKCU\Software\Quizo\QTTabBar\Cache|
-RegKey2=HKCU\Software\Quizo\QTTabBar\RecentlyClosed|
-RegKey3=HKCU\Software\Quizo\QTTabBar|TabsOnLastClosedWindow
+RegKey1=HKCU\Software\Quizo\QTTabBar|TabsOnLastClosedWindow
+RegKey2=HKCU\Software\Quizo\QTTabBar\Cache|
+RegKey3=HKCU\Software\Quizo\QTTabBar\RecentlyClosed|
 
 [QuickBooks*]
 LangSecRef=3021
 Detect=HKLM\Software\Intuit\QuickBooks
 Default=False
 FileKey1=%CommonAppData%\Common Files\Intuit\Quickbooks\qbupdate\log|*.*
-FileKey2=%CommonAppData%\Intuit\Quickbooks|*.log;qbsdklog.txt
-FileKey3=%CommonAppData%\Intuit\QBWebConnector\log|*.*
+FileKey2=%CommonAppData%\Intuit\QBWebConnector\log|*.*
+FileKey3=%CommonAppData%\Intuit\Quickbooks|*.log;qbsdklog.txt
 FileKey4=%CommonAppData%\Intuit\QuickBooks DB Server Manager|*.log;*.old
 FileKey5=%CommonProgramFiles%\Intuit\Quickbooks\QBUpdate\Log|*.*
 FileKey6=%LocalAppData%\Intuit\QuickBooks\Log|*.*|RECURSE
 FileKey7=%LocalAppData%\VirtualStore\Program Files*\Intuit\Quickbooks\QBUpdate\Log|*.*
 FileKey8=%LocalAppData%\VirtualStore\ProgramData\Common Files\Intuit\Quickbooks\qbupdate\log|*.*
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Intuit\Quickbooks|*.log;qbsdklog.txt
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Intuit\QBWebConnector\log|*.*
+FileKey9=%LocalAppData%\VirtualStore\ProgramData\Intuit\QBWebConnector\log|*.*
+FileKey10=%LocalAppData%\VirtualStore\ProgramData\Intuit\Quickbooks|*.log;qbsdklog.txt
 FileKey11=%LocalAppData%\VirtualStore\ProgramData\Intuit\QuickBooks DB Server Manager|*.log;*.old
 
 [QuickDic History*]
@@ -14535,16 +14388,16 @@ Default=False
 FileKey1=%AppData%\Intuit\Quicken\Log|*.txt;*.log
 FileKey2=%AppData%\Quicken\Log|*.txt;*.log
 FileKey3=%CommonAppData%\Intuit\Quicken\Log|*.log
-FileKey4=%CommonAppData%\Quicken\Log|*.log
-FileKey5=%CommonAppData%\Intuit\Quicken\Log\installer|*.*|REMOVESELF
-FileKey6=%CommonAppData%\Quicken\Log\installer|*.*|REMOVESELF
-FileKey7=%CommonAppData%\Intuit\SendError|*.log
+FileKey4=%CommonAppData%\Intuit\Quicken\Log\installer|*.*|REMOVESELF
+FileKey5=%CommonAppData%\Intuit\SendError|*.log
+FileKey6=%CommonAppData%\Quicken\Log|*.log
+FileKey7=%CommonAppData%\Quicken\Log\installer|*.*|REMOVESELF
 FileKey8=%CommonAppData%\Quicken\SendError|*.log
 FileKey9=%LocalAppData%\Intuit\Common\Authorization\V1\Logs|*.txt
 FileKey10=%LocalAppData%\Quicken\Common\Authorization\V1\Logs|*.txt
 FileKey11=%LocalAppData%\VirtualStore\ProgramData\Intuit\Quicken\Log|*.log
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\Quicken\Log|*.log
-FileKey13=%LocalAppData%\VirtualStore\ProgramData\Intuit\SendError|*.log
+FileKey12=%LocalAppData%\VirtualStore\ProgramData\Intuit\SendError|*.log
+FileKey13=%LocalAppData%\VirtualStore\ProgramData\Quicken\Log|*.log
 FileKey14=%LocalAppData%\VirtualStore\ProgramData\Quicken\SendError|*.log
 FileKey15=%ProgramFiles%\Quicken\PDFDrv|install.log;InstallPDFConverter.log
 
@@ -14677,9 +14530,9 @@ FileKey1=%AppData%\RadeonPro\Temp|*.*|RECURSE
 LangSecRef=3021
 Detect=HKCU\Software\Radialix
 Default=False
-FileKey1=%ProgramFiles%\Radialix 2|*diz;*.txt;*.url
-FileKey2=%ProgramFiles%\Radialix 2\Tools\UPX|COPYING;LICENSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Radialix 2|*diz;*.txt;*.url
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Radialix 2|*diz;*.txt;*.url
+FileKey2=%ProgramFiles%\Radialix 2|*diz;*.txt;*.url
+FileKey3=%ProgramFiles%\Radialix 2\Tools\UPX|COPYING;LICENSE
 
 [RadioSure Logs*]
 LangSecRef=3023
@@ -14726,22 +14579,22 @@ FileKey3=%LocalAppData%\VirtualStore\ProgramData\FreshGames\RanchRush\*|*.log;te
 FileKey4=%ProgramFiles%\Ranch Rush*|*.html;*.nfo
 FileKey5=%WinDir%\|Ranch Rush Setup Log.txt
 
-[Raptr Chat History*]
-Section=Games
-Detect=HKCU\Software\Raptr
-Default=False
-FileKey1=%AppData%\Raptr\Data\*|chat_history.db
-
 [Raptr*]
 LangSecRef=3021
 Detect=HKCU\Software\Raptr
 DetectFile=%ProgramFiles%\Raptr
 Default=False
 FileKey1=%AppData%\Raptr|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Raptr|*.log
-FileKey3=%ProgramFiles%\Raptr|*.log
-FileKey4=%AppData%\Raptr\Avatars|*.*|RECURSE
+FileKey2=%AppData%\Raptr\Avatars|*.*|RECURSE
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Raptr|*.log
+FileKey4=%ProgramFiles%\Raptr|*.log
 ExcludeKey1=FILE|%ProgramFiles%\Raptr\|install.log
+
+[Raptr Chat History*]
+Section=Games
+Detect=HKCU\Software\Raptr
+Default=False
+FileKey1=%AppData%\Raptr\Data\*|chat_history.db
 
 [Razer Game Booster*]
 LangSecRef=3024
@@ -14754,13 +14607,6 @@ FileKey4=%LocalAppData%\VirtualStore\ProgramData\Razer\Game Booster|DiagnoseRepo
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\Razer\Game Booster\Logs|*.*
 FileKey6=%ProgramFiles%\Razer\Razer Game Booster|*.log
 
-[Razer Synapse Downloads*]
-LangSecRef=3024
-DetectFile=%CommonAppData%\Razer\Synapse
-Default=False
-FileKey1=%CommonAppData%\Razer\Synapse\ProductUpdates\Downloads|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Razer\Synapse\ProductUpdates\Downloads|*.*
-
 [Razer Synapse*]
 LangSecRef=3024
 DetectFile=%CommonAppData%\Razer\Synapse
@@ -14769,8 +14615,15 @@ FileKey1=%CommonAppData%\Razer\InGameEngine\Logs|*.*
 FileKey2=%CommonAppData%\Razer\S*e\Logs|*.*
 FileKey3=%CommonAppData%\Razer\Synapse\Accounts\*\DataSync|SyncDate.txt
 FileKey4=%LocalAppData%\Razer\RzUninstallation\Logs|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Razer\Synapse\Logs|*.*
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Razer\Synapse\Accounts\*\DataSync|SyncDate.txt
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\Razer\Synapse\Accounts\*\DataSync|SyncDate.txt
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Razer\Synapse\Logs|*.*
+
+[Razer Synapse Downloads*]
+LangSecRef=3024
+DetectFile=%CommonAppData%\Razer\Synapse
+Default=False
+FileKey1=%CommonAppData%\Razer\Synapse\ProductUpdates\Downloads|*.*
+FileKey2=%LocalAppData%\VirtualStore\ProgramData\Razer\Synapse\ProductUpdates\Downloads|*.*
 
 [RazerComms*]
 LangSecRef=3022
@@ -14820,8 +14673,8 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Studios.RecklessRacingUltimate_8wekyb3d8bbwe
 DetectFile=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey2=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 
 [RecollX*]
 LangSecRef=3021
@@ -14843,8 +14696,8 @@ DetectFile=%LocalAppData%\Packages\*.RedditToGo_*
 Default=False
 FileKey1=%LocalAppData%\Packages\*.RedditToGo_*\AC\AppCache|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\*.RedditToGo_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\*.RedditToGo_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey4=%LocalAppData%\Packages\*.RedditToGo_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\*.RedditToGo_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\*.RedditToGo_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 FileKey5=%LocalAppData%\Packages\*.RedditToGo_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
 FileKey6=%LocalAppData%\Packages\*.RedditToGo_*\AC\Temp|*.*
 FileKey7=%LocalAppData%\Packages\*.RedditToGo_*\RoamingState|history.txt
@@ -14907,9 +14760,9 @@ RegKey3=HKCU\Software\ReGet Software\ReGetDx\Search\HistFind
 LangSecRef=3024
 Detect=HKCU\Software\Resplendence Sp\Registrar Registry Manager
 Default=False
-RegKey1=HKCU\Software\Resplendence Sp\Registrar Registry Manager\Settings|LastOpenedKey
-RegKey2=HKCU\Software\Resplendence Sp\Registrar Registry Manager\Settings|ExportForm.saveDialogExportFilename
-RegKey3=HKCU\Software\Resplendence Sp\Registrar Registry Manager\Settings|ExportForm.saveDialogExportInitialDir
+RegKey1=HKCU\Software\Resplendence Sp\Registrar Registry Manager\Settings|ExportForm.saveDialogExportFilename
+RegKey2=HKCU\Software\Resplendence Sp\Registrar Registry Manager\Settings|ExportForm.saveDialogExportInitialDir
+RegKey3=HKCU\Software\Resplendence Sp\Registrar Registry Manager\Settings|LastOpenedKey
 
 [Registry Clean Expert*]
 LangSecRef=3023
@@ -14922,14 +14775,14 @@ FileKey2=%ProgramFiles%\Registry Clean Expert|fixlog.ini
 LangSecRef=3024
 Detect1=HKCU\Software\KsL Software\RFA
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\RFA *|*.diz;*.url
-FileKey2=%LocalAppData%\Microsoft\Windows|NTUSER.tmp;UsrClass.tmp
+FileKey1=%LocalAppData%\Microsoft\Windows|NTUSER.tmp;UsrClass.tmp
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\RFA *|*.diz;*.url
 FileKey3=%ProgramFiles%\RFA *|*.diz;*.url
 FileKey4=%UserProfile%\|NTUSER.tmp;UsrClass.tmp
 FileKey5=%WinDir%\ServiceProfiles\*Service|*.tmp;*.tmp.LOG1;*.tmp.LOG2
-FileKey6=%WinDir%\System32\config\systemprofile|*.tmp;*.tmp.LOG1;*.tmp.LOG2
-FileKey7=%WinDir%\SysWOW64\config\systemprofile|*.tmp;*.tmp.LOG1;*.tmp.LOG2
-FileKey8=%WinDir%\System32\config|*.tmp;*.tmp.LOG1;*.tmp.LOG2
+FileKey6=%WinDir%\System32\config|*.tmp;*.tmp.LOG1;*.tmp.LOG2
+FileKey7=%WinDir%\System32\config\systemprofile|*.tmp;*.tmp.LOG1;*.tmp.LOG2
+FileKey8=%WinDir%\SysWOW64\config\systemprofile|*.tmp;*.tmp.LOG1;*.tmp.LOG2
 
 [Registry Mechanic*]
 LangSecRef=3024
@@ -14990,10 +14843,10 @@ FileKey1=%LocalAppData%\1C\Reign Conflict of Nations|PSPLog.log
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\Windows
 Default=False
-FileKey1=%CommonAppData%\Microsoft\RAC\StateData|*.log;*.jrs
-FileKey2=%CommonAppData%\Microsoft\RAC\PublishedData|*.log;*.jrs
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Microsoft\RAC\StateData|*.log;*.jrs
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Microsoft\RAC\PublishedData|*.log;*.jrs
+FileKey1=%CommonAppData%\Microsoft\RAC\PublishedData|*.log;*.jrs
+FileKey2=%CommonAppData%\Microsoft\RAC\StateData|*.log;*.jrs
+FileKey3=%LocalAppData%\VirtualStore\ProgramData\Microsoft\RAC\PublishedData|*.log;*.jrs
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\Microsoft\RAC\StateData|*.log;*.jrs
 
 [Relic Downloader*]
 Section=Games
@@ -15012,8 +14865,8 @@ FileKey1=%Documents%\|*.rdp
 LangSecRef=3024
 Detect=HKCU\Software\Vitaliy Levchenko\Renamus
 Default=False
-RegKey1=HKCU\Software\Vitaliy Levchenko\Renamus\Settings|LastFolder
-RegKey2=HKCU\Software\Vitaliy Levchenko\Renamus\Recent Projects
+RegKey1=HKCU\Software\Vitaliy Levchenko\Renamus\Recent Projects
+RegKey2=HKCU\Software\Vitaliy Levchenko\Renamus\Settings|LastFolder
 
 [Repair setup log*]
 LangSecRef=3025
@@ -15070,8 +14923,8 @@ FileKey3=%ProgramFiles%\Restore Point Creator|*.log;*.txt
 LangSecRef=3021
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{D2E80193-7318-4707-A9DE-49AF663ADA73}
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\ProgramData\Individual Software\ResumeMaker\R12|*.log
-FileKey2=%CommonAppData%\Individual Software\ResumeMaker\R12|*.log
+FileKey1=%CommonAppData%\Individual Software\ResumeMaker\R12|*.log
+FileKey2=%LocalAppData%\VirtualStore\ProgramData\Individual Software\ResumeMaker\R12|*.log
 
 [Reus*]
 Section=Games
@@ -15155,8 +15008,8 @@ LangSecRef=3024
 DetectFile1=%UserProfile%\Desktop\Rkill
 DetectFile2=%UserProfile%\Desktop\Rkill.txt
 Default=False
-FileKey1=%UserProfile%\Desktop\Rkill|*.*|REMOVESELF
-FileKey2=%UserProfile%\Desktop|*rkill*.*
+FileKey1=%UserProfile%\Desktop|*rkill*.*
+FileKey2=%UserProfile%\Desktop\Rkill|*.*|REMOVESELF
 
 [Roadkil's Unstoppable Copier*]
 LangSecRef=3024
@@ -15211,15 +15064,15 @@ FileKey1=%Documents%\My Games\Rocket League\TAGame\Logs|*.*
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Shield
 Default=False
-FileKey1=%ProgramFiles%\Shield|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Shield|*.log
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Shield|*.log
+FileKey2=%ProgramFiles%\Shield|*.log
 
 [Roxio Creator 2012 Pro*]
 LangSecRef=3021
 Detect=HKCU\Software\Roxio\EMC13
 Default=False
-RegKey1=HKLM\Software\Roxio\EMC13\Common SDK\Users
-RegKey2=HKCU\Software\Roxio\EMC13\VideoUI\RecentFiles\Catalogs
+RegKey1=HKCU\Software\Roxio\EMC13\VideoUI\RecentFiles\Catalogs
+RegKey2=HKLM\Software\Roxio\EMC13\Common SDK\Users
 RegKey3=HKLM\Software\Wow6432Node\Roxio\EMC13\Common SDK\Users
 
 [Roxio Creator NXT Pro*]
@@ -15227,20 +15080,20 @@ LangSecRef=3021
 Detect=HKCU\Software\Roxio\EMC14
 Default=False
 FileKey1=%Documents%\Roxio\Music Disc Creator|*.*
-RegKey1=HKLM\Software\Roxio\EMC14\Common SDK\Users
-RegKey2=HKCU\Software\Roxio\EMC14\Label Creator\Recent File List
-RegKey3=HKCU\Software\Roxio\EMC14\MusicDiscCreator\Directories
-RegKey4=HKCU\Software\Roxio\EMC14\MusicDiscCreator\MediaSelector
+RegKey1=HKCU\Software\Roxio\EMC14\Label Creator\Recent File List
+RegKey2=HKCU\Software\Roxio\EMC14\MusicDiscCreator\Directories
+RegKey3=HKCU\Software\Roxio\EMC14\MusicDiscCreator\MediaSelector
+RegKey4=HKCU\Software\Roxio\EMC14\PhotoSuite\RoxioPhotoSuite\MRUFiles
 RegKey5=HKCU\Software\Roxio\EMC14\SoundEdit\Directories
 RegKey6=HKCU\Software\Roxio\EMC14\SoundEdit\MediaSelector
 RegKey7=HKCU\Software\Roxio\EMC14\SoundEdit\WaveCache
-RegKey8=HKCU\Software\Roxio\EMC14\PhotoSuite\RoxioPhotoSuite\MRUFiles
-RegKey9=HKCU\Software\Roxio\EMC14\VideoConvert\Directories
-RegKey10=HKCU\Software\Roxio\EMC14\VideoConvert\MediaSelector
-RegKey11=HKCU\Software\Roxio\EMC14\VideoUI\RecentFiles\Albums
-RegKey12=HKCU\Software\Roxio\EMC14\VideoUI\RecentFiles\Catalogs
-RegKey13=HKCU\Software\Roxio\EMC14\VideoUI\RecentFiles\DVD Projects
-RegKey14=HKCU\Software\Roxio\EMC14\VideoUI\RecentFiles\Productions
+RegKey8=HKCU\Software\Roxio\EMC14\VideoConvert\Directories
+RegKey9=HKCU\Software\Roxio\EMC14\VideoConvert\MediaSelector
+RegKey10=HKCU\Software\Roxio\EMC14\VideoUI\RecentFiles\Albums
+RegKey11=HKCU\Software\Roxio\EMC14\VideoUI\RecentFiles\Catalogs
+RegKey12=HKCU\Software\Roxio\EMC14\VideoUI\RecentFiles\DVD Projects
+RegKey13=HKCU\Software\Roxio\EMC14\VideoUI\RecentFiles\Productions
+RegKey14=HKLM\Software\Roxio\EMC14\Common SDK\Users
 RegKey15=HKLM\Software\Wow6432Node\Roxio\EMC14\Common SDK\Users
 
 [Roxio Log Files*]
@@ -15258,8 +15111,8 @@ FileKey6=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\Roxio Log Files|
 LangSecRef=3021
 Detect=HKCU\Software\Roxio
 Default=False
-FileKey1=%AppData%\Roxio\Dragon\3.x\DiscInfoCache|*.tmp
-FileKey2=%AppData%\Roxio Burn\Temp|*.*|RECURSE
+FileKey1=%AppData%\Roxio Burn\Temp|*.*|RECURSE
+FileKey2=%AppData%\Roxio\Dragon\3.x\DiscInfoCache|*.tmp
 FileKey3=%LocalAppData%\|rx_audio.Cache;rx_image32.Cache
 
 [RssBandit*]
@@ -15281,18 +15134,18 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Rust|debug_steamclient.txt
 FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Rust|debug_steamclient.txt
 
-[SABnzbd Backup*]
-LangSecRef=3022
-Detect=HKCU\Software\SABnzbd
-Default=False
-FileKey1=%LocalAppData%\SABnzbd|*.bak
-
 [SABnzbd*]
 LangSecRef=3021
 DetectFile=%LocalAppData%\sabnzbd
 Default=False
 FileKey1=%LocalAppData%\sabnzbd\admin|history1.db;totals9.sab
 FileKey2=%LocalAppData%\sabnzbd\logs|*.*
+
+[SABnzbd Backup*]
+LangSecRef=3022
+Detect=HKCU\Software\SABnzbd
+Default=False
+FileKey1=%LocalAppData%\SABnzbd|*.bak
 
 [Sage ACT!*]
 LangSecRef=3021
@@ -15370,6 +15223,14 @@ Detect=HKCU\Software\Valve\Steam\Apps\91600
 Default=False
 FileKey1=%Documents%\My Games\Sanctum\SanctumGame\Logs|*.*
 
+[Santa Ride! 2*]
+Section=Games
+Detect=HKLM\Software\Invictus-Games\Santa Ride 2
+DetectFile=%ProgramFiles%\Invictus Games\Santa Ride! 2\SR2.exe
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Invictus Games\Santa Ride! 2|*.log
+FileKey2=%ProgramFiles%\Invictus Games\Santa Ride! 2|*.log
+
 [Santa's Rampage*]
 Section=Games
 DetectFile=%ProgramFiles%\*Santa* Rampage
@@ -15382,20 +15243,12 @@ ExcludeKey2=PATH|%ProgramFiles%\*Santa* Rampage\UDKGame\Script\|*.*
 ExcludeKey3=PATH|%ProgramFiles%\*Santa* Rampage\Binaries\Win32\|*.*
 ExcludeKey4=PATH|%ProgramFiles%\*Santa* Rampage\Binaries\Win64\|*.*
 
-[Santa Ride! 2*]
-Section=Games
-Detect=HKLM\Software\Invictus-Games\Santa Ride 2
-DetectFile=%ProgramFiles%\Invictus Games\Santa Ride! 2\SR2.exe
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Invictus Games\Santa Ride! 2|*.log
-FileKey2=%ProgramFiles%\Invictus Games\Santa Ride! 2|*.log
-
 [Sauerbraten*]
 Section=Games
 DetectFile=%ProgramFiles%\Sauerbraten\bin\sauerbraten.exe
 Default=False
-FileKey1=%Documents%\My Games\Sauerbraten|log.txt
-FileKey2=%Documents%\My Games\Crash|*.log
+FileKey1=%Documents%\My Games\Crash|*.log
+FileKey2=%Documents%\My Games\Sauerbraten|log.txt
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\Sauerbraten\packages\base|*.bak|RECURSE
 FileKey4=%ProgramFiles%\Sauerbraten\packages\base|*.bak|RECURSE
 
@@ -15444,8 +15297,8 @@ FileKey2=%SystemDrive%\ScanDefrag\logs|*.txt
 LangSecRef=3024
 DetectFile=%AppData%\Learnpulse\Screenpresso
 Default=False
-FileKey1=%Pictures%\Screenpresso\Thumbnails|*.*|RECURSE
-FileKey2=%AppData%\Learnpulse\Screenpresso|settings.copy.xml
+FileKey1=%AppData%\Learnpulse\Screenpresso|settings.copy.xml
+FileKey2=%Pictures%\Screenpresso\Thumbnails|*.*|RECURSE
 
 [ScreenShot Index*]
 DetectOS=6.2|
@@ -15455,18 +15308,18 @@ Default=False
 Warning=This Resets Screenshot Naming Back To "Screenshot (1).png"
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer|ScreenshotIndex
 
+[Scribe*]
+LangSecRef=3021
+Detect=HKCU\Software\NCH Software\Scribe
+Default=False
+FileKey1=%AppData%\NCH Software\Scribe\Logs|*.*
+
 [Scribe Finished Jobs*]
 LangSecRef=3021
 Detect=HKCU\Software\NCH Software\Scribe
 Default=False
 Warning=This will delete copies of files related you have run through Scribe.
 FileKey1=%AppData%\NCH Software\Scribe\Done|*.*
-
-[Scribe*]
-LangSecRef=3021
-Detect=HKCU\Software\NCH Software\Scribe
-Default=False
-FileKey1=%AppData%\NCH Software\Scribe\Logs|*.*
 
 [Scribus*]
 LangSecRef=3023
@@ -15507,15 +15360,15 @@ FileKey4=%AppData%\Mozilla\SeaMonkey\Profiles\*\adblock*|patterns-backup*.ini;*.
 FileKey5=%AppData%\Mozilla\SeaMonkey\Profiles\*\bookmarkbackups|*.json*
 FileKey6=%AppData%\Mozilla\SeaMonkey\Profiles\*\chatzilla|inputHistory.txt
 FileKey7=%AppData%\Mozilla\SeaMonkey\Profiles\*\datareporting\archived|*.jsonlz4|REMOVESELF
-FileKey8=%AppData%\Mozilla\SeaMonkey\Profiles\*\saved-telemetry-pings|*.*
-FileKey9=%AppData%\Mozilla\SeaMonkey\Profiles\*\sessions\Deleted Sessions|*.session
-FileKey10=%AppData%\Mozilla\SeaMonkey\Profiles\*\storage|*.*|REMOVESELF
-FileKey11=%AppData%\Mozilla\SeaMonkey\Profiles\*\minidumps|*.*
+FileKey8=%AppData%\Mozilla\SeaMonkey\Profiles\*\minidumps|*.*
+FileKey9=%AppData%\Mozilla\SeaMonkey\Profiles\*\saved-telemetry-pings|*.*
+FileKey10=%AppData%\Mozilla\SeaMonkey\Profiles\*\sessions\Deleted Sessions|*.session
+FileKey11=%AppData%\Mozilla\SeaMonkey\Profiles\*\storage|*.*|REMOVESELF
 FileKey12=%AppData%\Mozilla\SeaMonkey\Profiles\*\weave\logs|*.*
 FileKey13=%LocalAppData%\Mozilla\SeaMonkey\*\updates|*.*|RECURSE
-FileKey14=%LocalAppData%\Mozilla\SeaMonkey\Profiles\*\shortcutCache|*.*
-FileKey15=%LocalAppData%\Mozilla\SeaMonkey\Profiles\*\startupCache|*.*
-FileKey16=%LocalAppData%\Mozilla\SeaMonkey\Profiles\*|urlclassifier3.sqlite
+FileKey14=%LocalAppData%\Mozilla\SeaMonkey\Profiles\*|urlclassifier3.sqlite
+FileKey15=%LocalAppData%\Mozilla\SeaMonkey\Profiles\*\shortcutCache|*.*
+FileKey16=%LocalAppData%\Mozilla\SeaMonkey\Profiles\*\startupCache|*.*
 ExcludeKey1=PATH|%AppData%\Mozilla\SeaMonkey\Profiles\*\storage\default\moz-extension*\|*.*
 
 [Search History*]
@@ -15526,6 +15379,12 @@ Default=False
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\SearchHistory
 RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Search\RecentApps
 
+[Second Copy*]
+LangSecRef=3024
+DetectFile=%LocalAppData%\Centered Systems\Second Copy
+Default=False
+FileKey1=%LocalAppData%\Centered Systems\Second Copy|log*.*
+
 [Second Copy 2000*]
 LangSecRef=3021
 Detect=HKCU\Software\Centered Systems\Second Copy 2000
@@ -15534,26 +15393,15 @@ FileKey1=%LocalAppData%\VirtualStore\Program Files*\SecCopy|log.rtf;log-old.rtf
 FileKey2=%ProgramFiles%\SecCopy|log.rtf;log-old.rtf
 RegKey1=HKCU\Software\Centered Systems\Second Copy 2000\MRU
 
-[Second Copy*]
-LangSecRef=3024
-DetectFile=%LocalAppData%\Centered Systems\Second Copy
-Default=False
-FileKey1=%LocalAppData%\Centered Systems\Second Copy|log*.*
-
-[SecondLife Cache*]
+[SecondLife*]
 LangSecRef=3021
 DetectFile=%AppData%\SecondLife
 Default=False
-FileKey1=%AppData%\SecondLife\*\Browser_Profile\Cache|*.*|RECURSE
-FileKey2=%AppData%\SecondLife\*\cache|*.*|RECURSE
-FileKey3=%AppData%\SecondLife\cache|*.*|RECURSE
-
-[SecondLife Logs*]
-LangSecRef=3021
-DetectFile=%AppData%\SecondLife
-Default=False
-FileKey1=%AppData%\SecondLife\Logs|*.*
-FileKey2=%AppData%\SecondLife\*|*.txt|RECURSE
+FileKey1=%AppData%\SecondLife\*|*.txt|RECURSE
+FileKey2=%AppData%\SecondLife\*\Browser_Profile\Cache|*.*|RECURSE
+FileKey3=%AppData%\SecondLife\*\cache|*.*|RECURSE
+FileKey4=%AppData%\SecondLife\cache|*.*|RECURSE
+FileKey5=%AppData%\SecondLife\Logs|*.*
 
 [Secunia PSI*]
 LangSecRef=3021
@@ -15711,8 +15559,8 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\GAMELOFTSA.SharkDashByGameloft_0pp20fcewvvtj
 DetectFile=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_0pp20fcewvvtj
 Default=False
-FileKey1=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey2=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 
 [Shatter*]
 Section=Games
@@ -15768,8 +15616,8 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ShuffleParty_8wekyb3d8bbwe
 DetectFile=%LocalAppData%\Packages\Microsoft.ShuffleParty_8wekyb3d8bbwe
 Default=False
-FileKey1=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey2=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 
 [Sidebar Cache*]
 LangSecRef=3025
@@ -15907,16 +15755,15 @@ DetectFile=%ProgramFiles%\Skype For Salesforce
 Default=False
 FileKey1=%AppData%\Skype|*.tmp;*.db-journal;*.lck;*.lock;cookies.dat|RECURSE
 FileKey2=%AppData%\Skype\*\*cache|*.*|RECURSE
-FileKey3=%AppData%\Skype\DbTemp|*.*|RECURSE
-FileKey4=%AppData%\Skype\DataRv|*.*
-FileKey5=%AppData%\Skype\*\*cache|*.*
-FileKey6=%AppData%\Skype\*\httpfe|*.*
-FileKey7=%AppData%\Skype\*\logs|*.*
-FileKey8=%AppData%\Skype\*\media_messaging\media_cache*|*.*
-FileKey9=%AppData%\Skype\*\media_messaging\*\asyncdb\tmp|*.*
-FileKey10=%AppData%\Skype\*\qikdb\tmp|*.*
-FileKey11=%AppData%\SkypePM|*.ezlog
-FileKey12=%UserProfile%\Tracing\WPPMedia|*.*|RECURSE
+FileKey3=%AppData%\Skype\*\httpfe|*.*
+FileKey4=%AppData%\Skype\*\logs|*.*
+FileKey5=%AppData%\Skype\*\media_messaging\*\asyncdb\tmp|*.*
+FileKey6=%AppData%\Skype\*\media_messaging\media_cache*|*.*
+FileKey7=%AppData%\Skype\*\qikdb\tmp|*.*
+FileKey8=%AppData%\Skype\DataRv|*.*
+FileKey9=%AppData%\Skype\DbTemp|*.*|RECURSE
+FileKey10=%AppData%\SkypePM|*.ezlog
+FileKey11=%UserProfile%\Tracing\WPPMedia|*.*|RECURSE
 
 [SkypeAlyzer*]
 LangSecRef=3024
@@ -16089,17 +15936,17 @@ FileKey1=%LocalAppData%\SMPlayer2\File_settings|*.*|RECURSE
 LangSecRef=3023
 DetectFile=%LocalAppData%\SMPlayer2
 Default=False
-FileKey1=%Pictures%\smplayer2_screenshots|*.*|RECURSE
-FileKey2=%LocalAppData%\SMPlayer2\screenshots|*.*|RECURSE
+FileKey1=%LocalAppData%\SMPlayer2\screenshots|*.*|RECURSE
+FileKey2=%Pictures%\smplayer2_screenshots|*.*|RECURSE
 
 [Snagit 13/18*]
 LangSecRef=3024
 Detect1=HKCU\Software\TechSmith\Snagit\13
 Detect2=HKCU\Software\TechSmith\Snagit\18
 Default=False
-FileKey1=%LocalAppData%\TechSmith\Snagit\DataStore\*Icons|*.ico
-FileKey2=%LocalAppData%\TechSmith\Snagit\Thumbnails|*.*
-FileKey3=%LocalAppData%\TechSmith\Snagit|Tray.bin
+FileKey1=%LocalAppData%\TechSmith\Snagit|Tray.bin
+FileKey2=%LocalAppData%\TechSmith\Snagit\DataStore\*Icons|*.ico
+FileKey3=%LocalAppData%\TechSmith\Snagit\Thumbnails|*.*
 RegKey1=HKCU\Software\TechSmith\Snagit\13\Recent Captures
 RegKey2=HKCU\Software\TechSmith\Snagit\13\SnagitEditor\Recent File List
 RegKey3=HKCU\Software\TechSmith\Snagit\18\Recent Captures
@@ -16164,17 +16011,12 @@ DetectFile=%AppData%\sobees Ltd\Sobees
 Default=False
 FileKey1=%AppData%\sobees Ltd\Sobees\tmp\imagecache|*.*|RECURSE
 
-[SocialFolders Cache*]
+[SocialFolders*]
 LangSecRef=3022
 DetectFile=%LocalAppData%\ftopia\SocialFolders
 Default=False
 FileKey1=%LocalAppData%\ftopia\SocialFolders\Cache|*.*|RECURSE
-
-[SocialFolders Dumps*]
-LangSecRef=3022
-DetectFile=%LocalAppData%\ftopia\SocialFolders
-Default=False
-FileKey1=%LocalAppData%\ftopia\SocialFolders\Dumps|*.*|RECURSE
+FileKey2=%LocalAppData%\ftopia\SocialFolders\Dumps|*.*|RECURSE
 
 [SoftCafe MenuPRo*]
 LangSecRef=3021
@@ -16188,16 +16030,16 @@ Detect=HKCU\Software\SoftEther Project\SoftEther VPN
 Default=False
 Warning=Exclude installer.cache if you're using SoftEther VPN Client Web Installer
 FileKey1=%ProgramFiles%\SoftEther VPN Client|installer.cache
-FileKey2=%ProgramFiles%\SoftEther VPN Client\vpn_debug|*.*
-FileKey3=%ProgramFiles%\SoftEther VPN Client\backup.vpn_client.config|*.config
-FileKey4=%ProgramFiles%\SoftEther VPN Client\client_log|*.*
+FileKey2=%ProgramFiles%\SoftEther VPN Client\backup.vpn_client.config|*.config
+FileKey3=%ProgramFiles%\SoftEther VPN Client\client_log|*.*
+FileKey4=%ProgramFiles%\SoftEther VPN Client\vpn_debug|*.*
 
 [SoftGrid Client*]
 LangSecRef=3022
 DetectFile=%AppData%\SoftGrid Client
 Default=False
-FileKey1=%AppData%\SoftGrid Client\Icon Cache|*.*
-FileKey2=%AppData%\SoftGrid client|*.tmp|RECURSE
+FileKey1=%AppData%\SoftGrid Client|*.tmp|RECURSE
+FileKey2=%AppData%\SoftGrid Client\Icon Cache|*.*
 FileKey3=%CommonAppData%\Microsoft\Application Virtualization Client\SoftGrid Client|*.tmp|RECURSE
 FileKey4=%LocalAppData%\SoftGrid Client|*.tmp|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Application Virtualization Client\SoftGrid Client|*.tmp|RECURSE
@@ -16229,16 +16071,20 @@ FileKey2=%CommonAppData%\Microsoft\Windows\Sqm\Sessions|*.psqm;*.sqm
 FileKey3=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\Sqm\Manifest|*.bin
 FileKey4=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\Sqm\Sessions|*.psqm;*.sqm
 
-[Soluto Cache*]
+[Soluto*]
 LangSecRef=3024
 Detect=HKLM\Software\Soluto
 Default=False
 FileKey1=%CommonAppData%\Devices|*.*
 FileKey2=%CommonAppData%\Soluto\IconCaching|*.*
-FileKey3=%CommonAppData%\Soluto\rdcache|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Devices|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Soluto\IconCaching|*.*
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Soluto\rdcache|*.*|RECURSE
+FileKey3=%CommonAppData%\Soluto\logs|*.log;*.txt|RECURSE
+FileKey4=%CommonAppData%\Soluto\rdcache|*.*|RECURSE
+FileKey5=%CommonAppData%\Soluto\Temp|*.*|RECURSE
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Devices|*.*
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\Soluto\IconCaching|*.*
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\Soluto\logs|*.log;*.txt|RECURSE
+FileKey9=%LocalAppData%\VirtualStore\ProgramData\Soluto\rdcache|*.*|RECURSE
+FileKey10=%LocalAppData%\VirtualStore\ProgramData\Soluto\Temp|*.*|RECURSE
 
 [Soluto Dumps*]
 LangSecRef=3024
@@ -16250,13 +16096,6 @@ FileKey2=%CommonAppData%\Soluto\Logs\KMCustomDumpFolder|*.*|RECURSE
 FileKey3=%LocalAppData%\VirtualStore\ProgramData\Soluto\Dumps|*.*|RECURSE
 FileKey4=%LocalAppData%\VirtualStore\ProgramData\Soluto\Logs\KMCustomDumpFolder|*.*|RECURSE
 
-[Soluto Logs*]
-LangSecRef=3024
-Detect=HKLM\Software\Soluto
-Default=False
-FileKey1=%CommonAppData%\Soluto\logs|*.log;*.txt|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Soluto\logs|*.log;*.txt|RECURSE
-
 [Soluto Reports*]
 LangSecRef=3024
 Detect=HKLM\Software\Soluto
@@ -16264,24 +16103,18 @@ Default=False
 FileKey1=%CommonAppData%\Soluto\SysInfo|*.*
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Soluto\SysInfo|*.*
 
-[Soluto Temp*]
-LangSecRef=3024
-Detect=HKLM\Software\Soluto
-Default=False
-FileKey1=%CommonAppData%\Soluto\Temp|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Soluto\Temp|*.*|RECURSE
-
 [SongKong Logs*]
 LangSecRef=3023
 DetectFile=%AppData%\SongKong
 Default=False
 FileKey1=%AppData%\SongKong\Logs|*.*|RECURSE
 
-[Sonic Visualiser RecentFiles*]
+[Sonic Visualiser*]
 LangSecRef=3023
 Detect=HKCU\Software\sonic-visualiser
 DetectFile=%UserProfile%\.Sonic Visualiser
 Default=False
+FileKey1=%UserProfile%\.Sonic Visualiser\cache|*.*
 RegKey1=HKCU\Software\sonic-visualiser\Sonic Visualiser\RecentFiles|recent-0
 RegKey2=HKCU\Software\sonic-visualiser\Sonic Visualiser\RecentFiles|recent-1
 RegKey3=HKCU\Software\sonic-visualiser\Sonic Visualiser\RecentFiles|recent-2
@@ -16302,13 +16135,6 @@ RegKey17=HKCU\Software\sonic-visualiser\Sonic Visualiser\RecentFiles|recent-16
 RegKey18=HKCU\Software\sonic-visualiser\Sonic Visualiser\RecentFiles|recent-17
 RegKey19=HKCU\Software\sonic-visualiser\Sonic Visualiser\RecentFiles|recent-18
 RegKey20=HKCU\Software\sonic-visualiser\Sonic Visualiser\RecentFiles|recent-19
-
-[Sonic Visualiser*]
-LangSecRef=3023
-Detect=HKCU\Software\sonic-visualiser
-DetectFile=%UserProfile%\.Sonic Visualiser
-Default=False
-FileKey1=%UserProfile%\.Sonic Visualiser\cache|*.*
 
 [Sonique*]
 LangSecRef=3023
@@ -16368,6 +16194,13 @@ Detect=HKCU\Software\Valve\Steam\Apps\105430
 Default=False
 FileKey1=%LocalAppData%\inkle\Sorcery|*.log
 
+[Soulseek*]
+LangSecRef=3022
+DetectFile=%ProgramFiles%\Soulseek\slsk.exe
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Soulseek*|search.cfg
+FileKey2=%ProgramFiles%\Soulseek*|search.cfg
+
 [Soulseek NS*]
 LangSecRef=3022
 Detect=HKCU\Software\Soulseek2
@@ -16375,13 +16208,6 @@ Default=False
 Warning=This will delete your chat history.
 FileKey1=%Documents%\Soulseek Chat Logs\Private|*.txt
 RegKey1=HKCU\Software\Soulseek2\config|search
-
-[Soulseek*]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\Soulseek\slsk.exe
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Soulseek*|search.cfg
-FileKey2=%ProgramFiles%\Soulseek*|search.cfg
 
 [SoulseekQt*]
 LangSecRef=3022
@@ -16447,8 +16273,8 @@ FileKey1=%AppData%\SpeedyComputer\Log|*.*|RECURSE
 LangSecRef=3024
 DetectFile=%AppData%\SpiderOak
 Default=False
-FileKey1=%AppData%\SpiderOak\download_cache|*.*
-FileKey2=%AppData%\SpiderOak|*.log|RECURSE
+FileKey1=%AppData%\SpiderOak|*.log|RECURSE
+FileKey2=%AppData%\SpiderOak\download_cache|*.*
 
 [Spiral Knights*]
 Section=Games
@@ -16499,8 +16325,8 @@ FileKey1=%AppData%\.spotflux|*.log
 LangSecRef=3023
 DetectFile=%LocalAppData%\Spotify
 Default=False
-FileKey1=%LocalAppData%\Spotify\Storage|*.*|RECURSE
-FileKey2=%LocalAppData%\Spotify\Browser|*.*|RECURSE
+FileKey1=%LocalAppData%\Spotify\Browser|*.*|RECURSE
+FileKey2=%LocalAppData%\Spotify\Storage|*.*|RECURSE
 
 [Spoutcraft*]
 Section=Games
@@ -16548,10 +16374,10 @@ LangSecRef=3024
 Detect1=HKCU\Software\Safer Networking Limited\Spybot - Search & Destroy 2
 Detect2=HKLM\Software\Safer Networking Limited\SpybotSnD
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Spybot - Search & Destroy\Updates|*.zip
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Spybot - Search & Destroy 2\Updates|*.*|RECURSE
-FileKey3=%ProgramFiles%\Spybot - Search & Destroy\Updates|*.zip
-FileKey4=%ProgramFiles%\Spybot - Search & Destroy 2\Updates|*.*|RECURSE
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Spybot - Search & Destroy 2\Updates|*.*|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Spybot - Search & Destroy\Updates|*.zip
+FileKey3=%ProgramFiles%\Spybot - Search & Destroy 2\Updates|*.*|RECURSE
+FileKey4=%ProgramFiles%\Spybot - Search & Destroy\Updates|*.zip
 ExcludeKey1=FILE|%ProgramFiles%\Spybot - Search & Destroy 2\Updates\Downloads\|updates.uid
 
 [SpyDefense*]
@@ -16686,12 +16512,6 @@ FileKey12=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\__Installer|I
 FileKey13=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\logs|*.*
 FileKey14=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
 
-[StarCraft II Editor Recent Files*]
-Section=Games
-Detect=HKLM\SOFTWARE\Blizzard Entertainment\StarCraft II Editor
-Default=False
-RegKey1=HKCU\Software\Blizzard Entertainment\StarCraft II Editor\Recent Files
-
 [StarCraft II*]
 Section=Games
 Detect=HKLM\SOFTWARE\Blizzard Entertainment\StarCraft II
@@ -16703,6 +16523,12 @@ FileKey4=%Documents%\StarCraft II\UserLogs|*.*|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\Program Files*\Starcraft II\Logs|*.*
 FileKey6=%LocalAppData%\VirtualStore\ProgramData\Blizzard Entertainment\Starcraft II\Maps\Cache|*.*|RECURSE
 FileKey7=%ProgramFiles%\Starcraft II\Logs|*.*
+
+[StarCraft II Editor Recent Files*]
+Section=Games
+Detect=HKLM\SOFTWARE\Blizzard Entertainment\StarCraft II Editor
+Default=False
+RegKey1=HKCU\Software\Blizzard Entertainment\StarCraft II Editor\Recent Files
 
 [StarCraft II More*]
 Section=Games
@@ -16832,11 +16658,11 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam
 Default=False
 FileKey1=%ProgramFiles%\Steam\steamapps|*.mdmp;*.tmp;*.dmp;*.icns;.DS_Store;logfile.*;*.log;text.txt;output_log.txt;*log.txt;log*.txt|RECURSE
-FileKey2=%ProgramFiles%\Steam\steamapps\common\*\Cache|*.*|RECURSE
-FileKey3=%ProgramFiles%\Steam\steamapps\common\*\config\html|*.*|RECURSE
-FileKey4=%ProgramFiles%\Steam\steamapps\common\*\DebugData|*.*|RECURSE
-FileKey5=%ProgramFiles%\Steam\steamapps\common\*\docs|*.*|RECURSE
-FileKey6=%ProgramFiles%\Steam\steamapps\common\*\*\downloads|*.*|RECURSE
+FileKey2=%ProgramFiles%\Steam\steamapps\common\*\*\downloads|*.*|RECURSE
+FileKey3=%ProgramFiles%\Steam\steamapps\common\*\Cache|*.*|RECURSE
+FileKey4=%ProgramFiles%\Steam\steamapps\common\*\config\html|*.*|RECURSE
+FileKey5=%ProgramFiles%\Steam\steamapps\common\*\DebugData|*.*|RECURSE
+FileKey6=%ProgramFiles%\Steam\steamapps\common\*\docs|*.*|RECURSE
 FileKey7=%ProgramFiles%\Steam\steamapps\common\*\EULA|*.*|RECURSE
 FileKey8=%ProgramFiles%\Steam\steamapps\common\*\Manual|*.*|RECURSE
 FileKey9=%ProgramFiles%\Steam\Steamapps\temp|*.*|RECURSE
@@ -16856,10 +16682,10 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam
 Default=False
 FileKey1=%AppData%\SteamVR\Logs|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Steam|*.log;*log.last;connection_log_*.txt;*_log.txt;remote_connections.txt;vr*_*.txt|RECURSE
-FileKey3=%ProgramFiles%\Steam\logs|*.*
-FileKey4=%ProgramFiles%\Steam\vr\runtime\logs|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Steam|*.log;*log.last;connection_log_*.txt;*_log.txt;remote_connections.txt;vr*_*.txt|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam|*.log;*log.last;connection_log_*.txt;*_log.txt;remote_connections.txt;vr*_*.txt|RECURSE
+FileKey3=%ProgramFiles%\Steam|*.log;*log.last;connection_log_*.txt;*_log.txt;remote_connections.txt;vr*_*.txt|RECURSE
+FileKey4=%ProgramFiles%\Steam\logs|*.*
+FileKey5=%ProgramFiles%\Steam\vr\runtime\logs|*.*|RECURSE
 
 [Steam Old Files*]
 Section=Games
@@ -16945,9 +16771,9 @@ FileKey7=%LocalAppData%\Packages\*Win*Store_*\AC\Microsoft\Windows Store\Data|hi
 FileKey8=%LocalAppData%\Packages\*Win*Store_*\AC\PRICache|*.*|RECURSE
 FileKey9=%LocalAppData%\Packages\*Win*Store_*\AC\Temp|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\*Win*Store_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\WinStore_*\LocalState\LiveTile|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\*Win*Store_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.WindowsStore_*\LocalCache\*|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\*Win*Store_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.WindowsStore_*\LocalCache\*|*.*|RECURSE
+FileKey13=%LocalAppData%\Packages\WinStore_*\LocalState\LiveTile|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\WinStore_cw5n1h2txyewy\SearchHistory
 
 [Stored Media Player Paths*]
@@ -16972,8 +16798,8 @@ RegKey1=HKCU\Software\Trolltech\OrganizationDefaults
 Section=Games
 DetectFile=%LocalAppData%\Midway\Stranglehold
 Default=False
-FileKey1=%LocalAppData%\Midway\Stranglehold\Cache|*.*|REMOVESELF
-FileKey2=%LocalAppData%\Midway\Stranglehold|*.log|RECURSE
+FileKey1=%LocalAppData%\Midway\Stranglehold|*.log|RECURSE
+FileKey2=%LocalAppData%\Midway\Stranglehold\Cache|*.*|REMOVESELF
 
 [Stream-Cloner*]
 LangSecRef=3023
@@ -17012,9 +16838,9 @@ FileKey1=%AppData%\Style Jukebox Settings|*.bmp|RECURSE
 LangSecRef=3024
 DetectFile1=%AppData%\Sublime Text*
 Default=False
-FileKey1=%AppData%\Sublime Text\Options|*.*
-FileKey2=%AppData%\Sublime Text 2\Settings|*.sublime_session
-FileKey3=%AppData%\Sublime Text 3\Local|Session.sublime_session
+FileKey1=%AppData%\Sublime Text 2\Settings|*.sublime_session
+FileKey2=%AppData%\Sublime Text 3\Local|Session.sublime_session
+FileKey3=%AppData%\Sublime Text\Options|*.*
 
 [Success Story*]
 Section=Games
@@ -17028,17 +16854,17 @@ DetectFile=%AppData%\SumatraPDF
 Default=False
 FileKey1=%AppData%\SumatraPDF\sumatrapdfcache|*.*
 
-[SUMo Database*]
-LangSecRef=3024
-Detect=HKCU\Software\KC Softwares\SUMo
-Default=False
-FileKey1=%AppData%\KC Softwares\SUMo|db.sumo
-
 [SUMo*]
 LangSecRef=3024
 Detect=HKCU\Software\KC Softwares\SUMo
 Default=False
 FileKey1=%AppData%\KC Softwares\SUMo|db.bak;SUMo.cache;*.log;errlst.txt
+
+[SUMo Database*]
+LangSecRef=3024
+Detect=HKCU\Software\KC Softwares\SUMo
+Default=False
+FileKey1=%AppData%\KC Softwares\SUMo|db.sumo
 
 [SUPERAntiSpyware More*]
 LangSecRef=3024
@@ -17068,8 +16894,8 @@ FileKey1=%LocalAppData%\SuperBird\Application\*\Installer|*.7z
 LangSecRef=3029
 Detect=HKCU\Software\SuperBird
 Default=False
-FileKey1=%LocalAppData%\SuperBird\User Data\*\Cache|*.*|RECURSE
-FileKey2=%LocalAppData%\SuperBird\User Data\*|Favicons*
+FileKey1=%LocalAppData%\SuperBird\User Data\*|Favicons*
+FileKey2=%LocalAppData%\SuperBird\User Data\*\Cache|*.*|RECURSE
 
 [SuperBird - Internet History*]
 LangSecRef=3029
@@ -17220,13 +17046,6 @@ DetectFile=%ProgramFiles%\System Explorer\SystemExplorer.exe
 Default=False
 FileKey1=%CommonAppData%\SystemExplorer\snapshots|*.ses
 
-[System Mechanic Snapshots*]
-LangSecRef=3024
-Detect=HKCU\Software\iolo\System Mechanic
-Default=False
-Warning=This will delete System Mechanic System Snapshots Data.
-FileKey1=%AppData%\iolo\System Snapshots Data|*.*
-
 [System Mechanic*]
 LangSecRef=3024
 Detect=HKCU\Software\iolo\System Mechanic
@@ -17245,6 +17064,13 @@ FileKey11=%LocalAppData%\VirtualStore\ProgramData\iolo\TempResources|*.*|REMOVES
 FileKey12=%ProgramFiles%\iolo\System Mechanic|*.txt;*.xml
 FileKey13=%SystemDrive%\Documents and Settings\LocalService\*\iolo|*.*|REMOVESELF
 FileKey14=%WinDir%\System32\config|iolo App.evt
+
+[System Mechanic Snapshots*]
+LangSecRef=3024
+Detect=HKCU\Software\iolo\System Mechanic
+Default=False
+Warning=This will delete System Mechanic System Snapshots Data.
+FileKey1=%AppData%\iolo\System Snapshots Data|*.*
 
 [SysTracer*]
 LangSecRef=3024
@@ -17353,6 +17179,15 @@ RegKey2=HKCU\Software\TeamViewer\Version5.1|Last_Machine_Connections
 RegKey3=HKCU\Software\TeamViewer\Version6|Last_Machine_Connections
 RegKey4=HKCU\Software\TeamViewer\Version7|Last_Machine_Connections
 
+[Technic Launcher*]
+Section=Games
+DetectFile=%AppData%\.technic*
+Default=False
+FileKey1=%AppData%\.technic*|*.old;*.log;*.tmp|RECURSE
+FileKey2=%AppData%\.technic*\*\logs|*.*|RECURSE
+FileKey3=%AppData%\.technic*\cache|*.*
+FileKey4=%AppData%\.technic*\temp|*.*|RECURSE
+
 [Technic Launcher Backups*]
 Section=Games
 DetectFile=%AppData%\.technic*
@@ -17364,15 +17199,6 @@ Section=Games
 DetectFile1=%AppData%\.technic*
 Default=False
 FileKey1=%AppData%\.technic*\*\Screenshots|*.*
-
-[Technic Launcher*]
-Section=Games
-DetectFile=%AppData%\.technic*
-Default=False
-FileKey1=%AppData%\.technic*|*.old;*.log;*.tmp|RECURSE
-FileKey2=%AppData%\.technic*\*\logs|*.*|RECURSE
-FileKey3=%AppData%\.technic*\temp|*.*|RECURSE
-FileKey4=%AppData%\.technic*\cache|*.*
 
 [TechSmith DubIt*]
 LangSecRef=3023
@@ -17534,10 +17360,10 @@ FileKey1=%UserProfile%\.gimp-2.2|documents
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\239220
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\Log|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\CrashReport|*.*
-FileKey3=%ProgramFiles%\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\Log|*.*
-FileKey4=%ProgramFiles%\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\CrashReport|*.*
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\CrashReport|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\Log|*.*
+FileKey3=%ProgramFiles%\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\CrashReport|*.*
+FileKey4=%ProgramFiles%\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\Log|*.*
 
 [The Mystery of the Mary Celeste*]
 Section=Games
@@ -17565,6 +17391,12 @@ Default=False
 FileKey1=%CommonAppData%\Terminal Studio\The Rise of Atlantis|log.html
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Terminal Studio\The Rise of Atlantis|log.html
 
+[The Sims 3*]
+Section=Games
+Detect=HKCU\Software\Electronic Arts\Sims 3
+Default=False
+FileKey1=%Documents%\Electronic Arts\The Sims 3|*.log;*.mdmp;xcpt*.txt|RECURSE
+
 [The Sims 3 Cache Files*]
 Section=Games
 Detect=HKCU\Software\Electronic Arts\Sims 3
@@ -17580,12 +17412,6 @@ Default=False
 Warning=This may make premium content buggy if deleted.
 FileKey1=%Documents%\Electronic arts\The sims 3\DCBackup|*.package
 ExcludeKey1=FILE|%Documents%\electronic arts\The sims 3\DCBackup\|ccmerged.package
-
-[The Sims 3*]
-Section=Games
-Detect=HKCU\Software\Electronic Arts\Sims 3
-Default=False
-FileKey1=%Documents%\Electronic Arts\The Sims 3|*.log;*.mdmp;xcpt*.txt|RECURSE
 
 [The Sims Medieval Logs*]
 Section=Games
@@ -17718,8 +17544,8 @@ Detect1=HKCU\Software\Tipard Studio\Tipard Total Media Converter
 Detect2=HKCU\Software\Tipard Studio\Tipard Total Media Converter Platinum
 Default=False
 FileKey1=%LocalAppData%\Tipard Studio\Tipard Total Media*|*.txt
-RegKey1=HKCU\Software\Tipard Studio\Tipard Total Media Converter\Edit|LastVideoFilePath
-RegKey2=HKCU\Software\Tipard Studio\Tipard Total Media Converter Platinum\Edit|LastVideoFilePath
+RegKey1=HKCU\Software\Tipard Studio\Tipard Total Media Converter Platinum\Edit|LastVideoFilePath
+RegKey2=HKCU\Software\Tipard Studio\Tipard Total Media Converter\Edit|LastVideoFilePath
 
 [Tipard Video Converter Ultimate*]
 LangSecRef=3023
@@ -17764,18 +17590,18 @@ FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Tom Clancy's Rainbow
 FileKey3=%ProgramFiles%\Steam\SteamApps\Common\Tom Clancy's Rainbow Six Vegas 2|CrashReport*.*;*.log|RECURSE
 FileKey4=%ProgramFiles%\Ubisoft\Tom Clancy's Rainbow Six Vegas 2|CrashReport*.*;*.log|RECURSE
 
-[Tomahawk PDF+*]
-LangSecRef=3021
-Detect=HKCU\Software\NativeWinds\Tomahawk
-Default=False
-RegKey1=HKCU\Software\NativeWinds\Tomahawk\MRU
-
 [Tomahawk*]
 LangSecRef=3023
 Detect=HKCU\Software\Tomahawk
 Default=False
 FileKey1=%LocalAppData%\Tomahawk|*.log
 FileKey2=%LocalAppData%\Tomahawk\Tomahawk\Cache|*.*|RECURSE
+
+[Tomahawk PDF+*]
+LangSecRef=3021
+Detect=HKCU\Software\NativeWinds\Tomahawk
+Default=False
+RegKey1=HKCU\Software\NativeWinds\Tomahawk\MRU
 
 [Tomb Raider*]
 Section=Games
@@ -17799,13 +17625,6 @@ FileKey1=%AppData%\TomTom\HOME\Profiles\*|Log.txt
 FileKey2=%LocalAppData%\TomTom\HOME3|Log.txt
 FileKey3=%LocalAppData%\TomTom\HOME3\cache|*.*|RECURSE
 
-[ToonTown Rewritten*]
-Section=Games
-DetectFile=%ProgramFiles%\ToonTown Rewritten
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ToonTown ReWritten\logs|*.*
-FileKey2=%ProgramFiles%\ToonTown ReWritten\logs|*.*
-
 [ToonTown*]
 Section=Games
 DetectFile=%LocalLowAppData%\Panda3D
@@ -17813,6 +17632,13 @@ Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Disney\Disney Online\ToontownOnline|*.log
 FileKey2=%LocalLowAppData%\Panda3D\Log|*.*
 FileKey3=%ProgramFiles%\Disney\Disney Online\ToontownOnline|*.log
+
+[ToonTown Rewritten*]
+Section=Games
+DetectFile=%ProgramFiles%\ToonTown Rewritten
+Default=False
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\ToonTown ReWritten\logs|*.*
+FileKey2=%ProgramFiles%\ToonTown ReWritten\logs|*.*
 
 [TopStyle 5*]
 LangSecRef=3021
@@ -17837,8 +17663,8 @@ FileKey1=%LocalAppData%\Torch\Application\*\Installer|*.7z
 LangSecRef=3029
 Detect=HKCU\Software\Torch
 Default=False
-FileKey1=%LocalAppData%\Torch\User Data\*\Cache|*.*|RECURSE
-FileKey2=%LocalAppData%\Torch\User Data\*|Favicons*
+FileKey1=%LocalAppData%\Torch\User Data\*|Favicons*
+FileKey2=%LocalAppData%\Torch\User Data\*\Cache|*.*|RECURSE
 
 [Torch - Internet History*]
 LangSecRef=3029
@@ -17867,20 +17693,20 @@ Detect=HKCU\Software\Torch
 Default=False
 FileKey1=%LocalAppData%\Torch\User Data\*|Current Tabs;Current session;Last Tabs;Last Session
 
-[Torchlight 2*]
-Section=Games
-Detect1=HKCU\Software\Valve\Steam\Apps\200710
-Detect2=HKLM\Software\Runic Games\Torchlight II
-Default=False
-FileKey1=%Documents%\My Games\Runic Games\Torchlight 2\logs|*.*
-FileKey2=%Documents%\My Games\runic games\torchlight 2|ogre.log
-
 [Torchlight*]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\41500
 DetectFile=%AppData%\Runic Games\Torchlight
 Default=False
 FileKey1=%AppData%\Runic Games\Torchlight|*.log
+
+[Torchlight 2*]
+Section=Games
+Detect1=HKCU\Software\Valve\Steam\Apps\200710
+Detect2=HKLM\Software\Runic Games\Torchlight II
+Default=False
+FileKey1=%Documents%\My Games\runic games\torchlight 2|ogre.log
+FileKey2=%Documents%\My Games\Runic Games\Torchlight 2\logs|*.*
 
 [Torrent Search Log*]
 LangSecRef=3022
@@ -17895,19 +17721,19 @@ Detect=HKCU\Software\tortoisemerge
 Default=False
 FileKey1=%AppData%\TortoiseHg|*.log;*.old
 
-[TortoiseSVN History*]
-LangSecRef=3024
-Detect=HKCU\Software\TortoiseSVN
-Default=False
-Warning=This will remove your repo paths and last checkout location
-RegKey1=HKCU\Software\TortoiseSVN\History
-
 [TortoiseSVN*]
 LangSecRef=3024
 Detect=HKCU\Software\TortoiseSVN
 Default=False
 FileKey1=%AppData%\TortoiseSVN|*.*
 FileKey2=%LocalAppData%\TSVNCache|*.*
+
+[TortoiseSVN History*]
+LangSecRef=3024
+Detect=HKCU\Software\TortoiseSVN
+Default=False
+Warning=This will remove your repo paths and last checkout location
+RegKey1=HKCU\Software\TortoiseSVN\History
 
 [Toshiba BluetoothStack*]
 LangSecRef=3024
@@ -17942,6 +17768,17 @@ RegKey7=HKCU\Software\HighCriteria\TotalRecorder\Recent File list|File7
 RegKey8=HKCU\Software\HighCriteria\TotalRecorder\Recent File list|File8
 RegKey9=HKCU\Software\HighCriteria\TotalRecorder\Recent File list|File9
 
+[Total Uninstall*]
+LangSecRef=3024
+Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 5_is1
+Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 6_is1
+Default=False
+FileKey1=%CommonAppData%\Martau\Total Uninstall*|*.Folders;*.cache|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Total Uninstall|Log.txt;*.GID
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Total Uninstall*|*.rtf;*.txt|RECURSE
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*|*.Folders;*.cache|RECURSE
+FileKey5=%ProgramFiles%\Total Uninstall*|*.rtf;*.txt;*.GID|RECURSE
+
 [Total Uninstall Backups*]
 LangSecRef=3024
 Detect1=HKCU\Software\MartS\Total Uninstall
@@ -17949,25 +17786,14 @@ Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall
 Detect3=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 6_is1
 Default=False
 Warning=This will delete analyzed programs and backups.
-FileKey1=%CommonAppData%\Martau\Total Uninstall*\Analyzed Programs|*.*
-FileKey2=%CommonAppData%\Martau\Total Uninstall*\Backup|*.zip
-FileKey3=%CommonAppData%\Martau\Total Uninstall*\System Snapshots|*.zsns
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*\Analyzed Programs|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*\Backup|*.zip
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*\System Snapshots|*.zsns
-FileKey7=%CommonAppData%\Martau\Total Uninstall*|*.tlg;*.zsns;*.zip|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*|*.tlg;*.zsns;*.zip|RECURSE
-
-[Total Uninstall*]
-LangSecRef=3024
-Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 5_is1
-Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 6_is1
-Default=False
-FileKey1=%CommonAppData%\Martau\Total Uninstall*|*.Folders;*.cache|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Total Uninstall*|*.rtf;*.txt|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*|*.Folders;*.cache|RECURSE
-FileKey4=%ProgramFiles%\Total Uninstall*|*.rtf;*.txt;*.GID|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Total Uninstall|Log.txt;*.GID
+FileKey1=%CommonAppData%\Martau\Total Uninstall*|*.tlg;*.zsns;*.zip|RECURSE
+FileKey2=%CommonAppData%\Martau\Total Uninstall*\Analyzed Programs|*.*
+FileKey3=%CommonAppData%\Martau\Total Uninstall*\Backup|*.zip
+FileKey4=%CommonAppData%\Martau\Total Uninstall*\System Snapshots|*.zsns
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*|*.tlg;*.zsns;*.zip|RECURSE
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*\Analyzed Programs|*.*
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*\Backup|*.zip
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*\System Snapshots|*.zsns
 
 [Towns*]
 Section=Games
@@ -18064,16 +17890,10 @@ FileKey2=%ProgramFiles%\Trend Micro\RUBotted\DebugLogs|*.*|REMOVESELF
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\17080
 Default=False
-FileKey1=%Documents%\My Games\Tribes Ascend\TribesGame\Logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\tribes\Binaries\Logs|*.*
-FileKey3=%ProgramFiles%\Steam\steamapps\common\tribes\Binaries\Logs|*.*
-FileKey4=%CommonAppData%\Hi-Rez Studios\BrowserCacheTribes\Default\Cache|*.*|RECURSE
-
-[Trillian Logs*]
-LangSecRef=3022
-Detect=HKLM\Software\Clients\IM\Trillian
-Default=False
-FileKey1=%AppData%\Trillian\users\*\logs|*.*|RECURSE
+FileKey1=%CommonAppData%\Hi-Rez Studios\BrowserCacheTribes\Default\Cache|*.*|RECURSE
+FileKey2=%Documents%\My Games\Tribes Ascend\TribesGame\Logs|*.*
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\tribes\Binaries\Logs|*.*
+FileKey4=%ProgramFiles%\Steam\steamapps\common\tribes\Binaries\Logs|*.*
 
 [Trillian*]
 LangSecRef=3022
@@ -18091,15 +17911,21 @@ FileKey9=%ProgramFiles%\Trillian\Crash Files|*.*|RECURSE
 FileKey10=%ProgramFiles%\Trillian\Users\Default\buddyicons|*.*|RECURSE
 FileKey11=%ProgramFiles%\Trillian\Users\Default\instantlookup|*.*
 
+[Trillian Logs*]
+LangSecRef=3022
+Detect=HKLM\Software\Clients\IM\Trillian
+Default=False
+FileKey1=%AppData%\Trillian\users\*\logs|*.*|RECURSE
+
 [Trine*]
 Section=Games
 Detect1=HKCU\Software\Valve\Steam\Apps\35700
 Detect2=HKCU\Software\Valve\Steam\Apps\35720
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\Trine\_enchanted_edition_\log|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Trine*\log*|*.*
-FileKey3=%ProgramFiles%\Steam\SteamApps\common\Trine\_enchanted_edition_\log|*.*
-FileKey4=%ProgramFiles%\Steam\SteamApps\Common\Trine*\log*|*.*
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Trine*\log*|*.*
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\Trine\_enchanted_edition_\log|*.*
+FileKey3=%ProgramFiles%\Steam\SteamApps\Common\Trine*\log*|*.*
+FileKey4=%ProgramFiles%\Steam\SteamApps\common\Trine\_enchanted_edition_\log|*.*
 
 [TrojanHunter Debug Logs*]
 LangSecRef=3024
@@ -18135,9 +17961,9 @@ FileKey1=%LocalAppData%\Diagnostics|*.*|RECURSE
 LangSecRef=3022
 Detect=HKCU\Software\Trusteer\Rapport
 Default=False
-FileKey1=%Windir%\System32\config\systemprofile\AppData\Local\Trusteer\Rapport\user\logs|*.*
+FileKey1=%CommonAppData%\Trusteer\Rapport\logs|*.*
 FileKey2=%LocalAppData%\Trusteer\Rapport\user\logs|*.*
-FileKey3=%CommonAppData%\Trusteer\Rapport\logs|*.*
+FileKey3=%Windir%\System32\config\systemprofile\AppData\Local\Trusteer\Rapport\user\logs|*.*
 
 [Tubebox!*]
 LangSecRef=3023
@@ -18183,14 +18009,14 @@ FileKey2=%LocalLowAppData%\TV_Net\Logs|*.*|RECURSE
 LangSecRef=3023
 Detect=HKLM\Software\TVersity\Media Server
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\TVersity\Media Server\logs|*.log;*.txt;*.xml;*.zip|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\TVersity Codec Pack|*.exe;*.url
-FileKey3=%ProgramFiles%\TVersity\Media Server|*.rtf;*.url;*TVersityCodecPackSetup*
-FileKey4=%ProgramFiles%\TVersity\Media Server\logs|*.log;*.txt;*.xml;*.zip|RECURSE
-FileKey5=%ProgramFiles%\TVersity Codec Pack|*.exe;*.url
-FileKey6=%WinDir%\System32\config\systemprofile\AppData\Local\Temp\TVersity Media Server|*.*|REMOVESELF
-FileKey7=%WinDir%\System32\config\systemprofile\Local Settings\Application Data\Temp\TVersity Media Server|*.*|REMOVESELF
-FileKey8=%WinDir%\System32|tversity.cookies;TVersityMediaServer.log;*.1;*.2;*.3
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\TVersity Codec Pack|*.exe;*.url
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\TVersity\Media Server\logs|*.log;*.txt;*.xml;*.zip|RECURSE
+FileKey3=%ProgramFiles%\TVersity Codec Pack|*.exe;*.url
+FileKey4=%ProgramFiles%\TVersity\Media Server|*.rtf;*.url;*TVersityCodecPackSetup*
+FileKey5=%ProgramFiles%\TVersity\Media Server\logs|*.log;*.txt;*.xml;*.zip|RECURSE
+FileKey6=%WinDir%\System32|tversity.cookies;TVersityMediaServer.log;*.1;*.2;*.3
+FileKey7=%WinDir%\System32\config\systemprofile\AppData\Local\Temp\TVersity Media Server|*.*|REMOVESELF
+FileKey8=%WinDir%\System32\config\systemprofile\Local Settings\Application Data\Temp\TVersity Media Server|*.*|REMOVESELF
 ExcludeKey1=PATH|%ProgramFiles%\TVersity\Media Server\|*version.txt;*HOWTO Share Media.txt
 ExcludeKey2=FILE|%ProgramFiles%\TVersity Codec Pack\|uninst.exe
 
@@ -18254,8 +18080,8 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\27761LazywormApplications.135450F141EEE_5tydn77rr51qw
 Default=False
 FileKey1=%LocalAppData%\Packages\*LazywormApplications.135450F141EEE_*\AC\Microsoft\*|*.LOG|RECURSE
-FileKey2=%LocalAppData%\Packages\*LazywormApplications.135450F141EEE_*\AC\Microsoft\*\Native Images\Temp|*.*
-FileKey3=%LocalAppData%\Packages\*LazywormApplications.135450F141EEE_*\AC\Microsoft\*\Native Images\Assembly\Temp|*.*
+FileKey2=%LocalAppData%\Packages\*LazywormApplications.135450F141EEE_*\AC\Microsoft\*\Native Images\Assembly\Temp|*.*
+FileKey3=%LocalAppData%\Packages\*LazywormApplications.135450F141EEE_*\AC\Microsoft\*\Native Images\Temp|*.*
 FileKey4=%LocalAppData%\Packages\*LazywormApplications.135450F141EEE_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\*LazywormApplications.135450F141EEE_*\AC\PRICache|*.*
 FileKey6=%LocalAppData%\Packages\*LazywormApplications.135450F141EEE_*\AC\Temp|*.*
@@ -18279,13 +18105,6 @@ Detect=HKCU\Software\Valve\Steam\Apps\1930
 Default=False
 FileKey1=%Documents%\TwoWorlds Files\FontsCache|*.tmp
 
-[Ubisoft Game Launcher Installers*]
-Section=Games
-DetectFile=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher
-Default=False
-Warning=Make sure to launch all of your installed UPlay games at least once before running this, or they may not launch properly.
-FileKey1=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\Installers|*.*|REMOVESELF
-
 [Ubisoft Game Launcher*]
 Section=Games
 DetectFile=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher
@@ -18298,6 +18117,13 @@ FileKey5=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher|*.log
 FileKey6=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\assets|*.*
 FileKey7=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\http*|*.*|RECURSE
 FileKey8=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Logs|*.*
+
+[Ubisoft Game Launcher Installers*]
+Section=Games
+DetectFile=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher
+Default=False
+Warning=Make sure to launch all of your installed UPlay games at least once before running this, or they may not launch properly.
+FileKey1=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\Installers|*.*|REMOVESELF
 
 [Ulead GIF Animator 5.05*]
 LangSecRef=3024
@@ -18423,8 +18249,8 @@ Detect1=HKLM\Software\UnlockrootPro
 Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\unlockroot.exe
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Unlockroot|*.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Unlockroot\tools|*.zip
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Unlockroot Pro|*.txt
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Unlockroot Pro|*.txt
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Unlockroot\tools|*.zip
 FileKey4=%ProgramFiles%\Unlockroot*|*.txt
 FileKey5=%ProgramFiles%\Unlockroot*\tools|*.zip
 
@@ -18452,12 +18278,12 @@ Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVe
 DetectFile=%LocalAppData%\Packages\USATODAY.USATODAY_wy7mw3214mat8
 Default=False
 FileKey1=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\PRICache|*.*
-FileKey5=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Temp|*.*
-FileKey6=%LocalAppData%\Packages\USATODAY.USATODAY_*\TempState|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\CLR_v4.0|*.log
+FileKey2=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\CLR_v4.0|*.log
+FileKey3=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\PRICache|*.*
+FileKey6=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Temp|*.*
+FileKey7=%LocalAppData%\Packages\USATODAY.USATODAY_*\TempState|*.*|RECURSE
 
 [USB Disk Security*]
 LangSecRef=3024
@@ -18516,8 +18342,8 @@ Default=False
 FileKey1=%AppData%\utorrent|*.log;*.dmp;*.bad;*.older;*.benc
 FileKey2=%AppData%\utorrent\updates|*.exe
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\uTorrent|*.tmp;*.old
-FileKey4=%ProgramFiles%\uTorrent|*.tmp;*.old
-FileKey5=%LocalLowAppData%\uTorrentBar\Logs|*.*
+FileKey4=%LocalLowAppData%\uTorrentBar\Logs|*.*
+FileKey5=%ProgramFiles%\uTorrent|*.tmp;*.old
 
 [V&V Messenger Chat History*]
 LangSecRef=3022
@@ -18683,14 +18509,14 @@ FileKey2=%CommonAppData%\VMware\Installer|*.*|REMOVESELF
 FileKey3=%CommonAppData%\VMware\logs|*.log|RECURSE
 FileKey4=%CommonAppData%\VMware\VMware vCenter Converter Standalone|*.log;*.gz;*.zip|RECURSE
 FileKey5=%Documents%\My Virtual Machines|*.log|RECURSE
-FileKey6=%LocalAppData%\VMware\VMware vCenter Converter Standalone Client\Logs|*.log;*.gz
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\VMware\VMware vCenter Converter Standalone|*.rtf;*.zip|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\VMware\VMware VIX|*.txt;*.rtf
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\VMware\hostd|*.log;*.gz|RECURSE
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\VMware\Installer|*.*|REMOVESELF
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\VMware\VMware vCenter Converter Standalone|*.log;*.gz;*.zip|RECURSE
-FileKey12=%ProgramFiles%\VMware\VMware VIX|*.txt;*.rtf
-FileKey13=%ProgramFiles%\VMware\VMware vCenter Converter Standalone|*.rtf;*.zip|RECURSE
+FileKey6=%LocalAppData%\VirtualStore\Program Files*\VMware\VMware vCenter Converter Standalone|*.rtf;*.zip|RECURSE
+FileKey7=%LocalAppData%\VirtualStore\Program Files*\VMware\VMware VIX|*.txt;*.rtf
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\VMware\hostd|*.log;*.gz|RECURSE
+FileKey9=%LocalAppData%\VirtualStore\ProgramData\VMware\Installer|*.*|REMOVESELF
+FileKey10=%LocalAppData%\VirtualStore\ProgramData\VMware\VMware vCenter Converter Standalone|*.log;*.gz;*.zip|RECURSE
+FileKey11=%LocalAppData%\VMware\VMware vCenter Converter Standalone Client\Logs|*.log;*.gz
+FileKey12=%ProgramFiles%\VMware\VMware vCenter Converter Standalone|*.rtf;*.zip|RECURSE
+FileKey13=%ProgramFiles%\VMware\VMware VIX|*.txt;*.rtf
 ExcludeKey1=PATH|%ProgramFiles%\VMware\VMware vCenter Converter Standalone\Help\|*.txt
 ExcludeKey2=FILE|%ProgramFiles%\VMware\VMware VIX\|vixwrapper-config.txt
 ExcludeKey3=FILE|%ProgramFiles%\VMware\VMware Workstation\|vixwrapper-product-config.txt
@@ -18756,9 +18582,9 @@ FileKey1=%ProgramFiles%\Golden Bow\Vopt 9|Vopt.log
 LangSecRef=3021
 DetectFile=%AppData%\Code
 Default=False
-FileKey1=%AppData%\Code\GPUCache|*.*
-FileKey2=%AppData%\Code\Local Storage|*.*
-FileKey3=%AppData%\Code|cookies;cookies-journal
+FileKey1=%AppData%\Code|cookies;cookies-journal
+FileKey2=%AppData%\Code\GPUCache|*.*
+FileKey3=%AppData%\Code\Local Storage|*.*
 FileKey4=%LocalAppData%\SquirrelTemp|*.log
 
 [VSO Batcher*]
@@ -18777,14 +18603,14 @@ FileKey2=%CommonAppData%\VSO|*.cache
 FileKey3=%CommonAppData%\VSO\Blu-ray Converter Ultimate\*\Log|*.log;*.crashlist|REMOVESELF
 FileKey4=%CommonAppData%\VSO\vsothumbs|*.*|REMOVESELF
 FileKey5=%Documents%\PcSetup|*.log|REMOVESELF
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\VSO|*.cache
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\VSO\Blu-ray Converter Ultimate\*|*.txt
+FileKey6=%LocalAppData%\VirtualStore\Program Files*\VSO\Blu-ray Converter Ultimate\*|*.txt
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\VSO|*.cache
 FileKey8=%LocalAppData%\VirtualStore\ProgramData\VSO\Blu-ray Converter Ultimate\*\Log|*.log;*.crashlist|REMOVESELF
 FileKey9=%LocalAppData%\VirtualStore\ProgramData\VSO\vsothumbs|*.*|REMOVESELF
 FileKey10=%ProgramFiles%\VSO\Blu-ray Converter Ultimate\*|*.txt
-RegKey1=HKCU\Software\VSO\Blu-ray Converter Ultimate\2|MediaLabel
+RegKey1=HKCU\Software\VSO\Blu-ray Converter Ultimate\2|BDMVInputFolders
 RegKey2=HKCU\Software\VSO\Blu-ray Converter Ultimate\2|ISOInputFolders
-RegKey3=HKCU\Software\VSO\Blu-ray Converter Ultimate\2|BDMVInputFolders
+RegKey3=HKCU\Software\VSO\Blu-ray Converter Ultimate\2|MediaLabel
 RegKey4=HKCU\Software\VSO\Blu-ray Converter Ultimate\3|input_MRUfiles_audio
 RegKey5=HKCU\Software\VSO\Blu-ray Converter Ultimate\3|input_MRUfiles_bluray
 RegKey6=HKCU\Software\VSO\Blu-ray Converter Ultimate\3|input_MRUfiles_dvd
@@ -18823,14 +18649,14 @@ FileKey2=%CommonAppData%\VSO|*.cache
 FileKey3=%CommonAppData%\VSO\DVD Converter Ultimate\*\Log|*.log;*.crashlist|REMOVESELF
 FileKey4=%CommonAppData%\VSO\vsothumbs|*.*|REMOVESELF
 FileKey5=%Documents%\PcSetup|*.log|REMOVESELF
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\VSO|*.cache
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\VSO\DVD Converter Ultimate\*|*.txt
+FileKey6=%LocalAppData%\VirtualStore\Program Files*\VSO\DVD Converter Ultimate\*|*.txt
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\VSO|*.cache
 FileKey8=%LocalAppData%\VirtualStore\ProgramData\VSO\DVD Converter Ultimate\*\Log|*.log;*.crashlist|REMOVESELF
 FileKey9=%LocalAppData%\VirtualStore\ProgramData\VSO\vsothumbs|*.*|REMOVESELF
 FileKey10=%ProgramFiles%\VSO\DVD Converter Ultimate\*|*.txt
-RegKey1=HKCU\Software\VSO\DVD Converter Ultimate\2|MediaLabel
+RegKey1=HKCU\Software\VSO\DVD Converter Ultimate\2|BDMVInputFolders
 RegKey2=HKCU\Software\VSO\DVD Converter Ultimate\2|ISOInputFolders
-RegKey3=HKCU\Software\VSO\DVD Converter Ultimate\2|BDMVInputFolders
+RegKey3=HKCU\Software\VSO\DVD Converter Ultimate\2|MediaLabel
 RegKey4=HKCU\Software\VSO\DVD Converter Ultimate\3|input_MRUfiles_audio
 RegKey5=HKCU\Software\VSO\DVD Converter Ultimate\3|input_MRUfiles_bluray
 RegKey6=HKCU\Software\VSO\DVD Converter Ultimate\3|input_MRUfiles_dvd
@@ -18860,8 +18686,8 @@ FileKey2=%CommonAppData%\VSO|*.cache
 FileKey3=%CommonAppData%\VSO\VSO Video Converter\*\Log|*.log;*.crashlist|REMOVESELF
 FileKey4=%CommonAppData%\VSO\vsothumbs|*.*|REMOVESELF
 FileKey5=%Documents%\PcSetup|*.log|REMOVESELF
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\VSO|*.cache
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\VSO\VSO Video Converter\*|*.txt
+FileKey6=%LocalAppData%\VirtualStore\Program Files*\VSO\VSO Video Converter\*|*.txt
+FileKey7=%LocalAppData%\VirtualStore\ProgramData\VSO|*.cache
 FileKey8=%LocalAppData%\VirtualStore\ProgramData\VSO\VSO Video Converter\*\Log|*.log;*.crashlist|REMOVESELF
 FileKey9=%LocalAppData%\VirtualStore\ProgramData\VSO\vsothumbs|*.*|REMOVESELF
 FileKey10=%ProgramFiles%\VSO\VSO Video Converter\*|*.txt
@@ -18936,22 +18762,14 @@ Section=Games
 Detect1=HKCU\Software\Gaijin\WarThunder
 Detect2=HKCU\Software\Valve\Steam\Apps\236390
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\War Thunder\.launcher_log|*.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\War Thunder\_debuginfo|*.clog
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\War Thunder\.launcher_log|*.txt
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\War Thunder\_debuginfo|*.clog
-FileKey5=%ProgramFiles%\War Thunder\.launcher_log|*.txt
-FileKey6=%ProgramFiles%\War Thunder\_debuginfo|*.clog
-FileKey7=%ProgramFiles%\Steam\SteamApps\common\War Thunder\.launcher_log|*.txt
-FileKey8=%ProgramFiles%\Steam\SteamApps\common\War Thunder\_debuginfo|*.clog
-
-[Warcraft III Backup Files*]
-Section=Games
-Detect=HKLM\Software\Blizzard Entertainment\Warcraft III
-Default=False
-Warning=This will delete all your Warcraft III backup files. You won't be able to restore from them if something goes wrong.
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Warcraft III|*.bak;*.old|RECURSE
-FileKey2=%ProgramFiles%\Warcraft III|*.bak;*.old|RECURSE
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\War Thunder\.launcher_log|*.txt
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\War Thunder\_debuginfo|*.clog
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\War Thunder\.launcher_log|*.txt
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\War Thunder\_debuginfo|*.clog
+FileKey5=%ProgramFiles%\Steam\SteamApps\common\War Thunder\.launcher_log|*.txt
+FileKey6=%ProgramFiles%\Steam\SteamApps\common\War Thunder\_debuginfo|*.clog
+FileKey7=%ProgramFiles%\War Thunder\.launcher_log|*.txt
+FileKey8=%ProgramFiles%\War Thunder\_debuginfo|*.clog
 
 [Warcraft III*]
 Section=Games
@@ -18963,6 +18781,14 @@ FileKey2=%LocalAppData%\VirtualStore\Program Files*\Warcraft III\Errors|*.dmp;*.
 FileKey3=%ProgramFiles%\Warcraft III|*.log;*.html
 FileKey4=%ProgramFiles%\Warcraft III\Errors|*.dmp;*.txt
 ExcludeKey1=PATH|%ProgramFiles%\Warcraft III\|*CustomKeyInfo.txt;*CustomKeysSample.txt
+
+[Warcraft III Backup Files*]
+Section=Games
+Detect=HKLM\Software\Blizzard Entertainment\Warcraft III
+Default=False
+Warning=This will delete all your Warcraft III backup files. You won't be able to restore from them if something goes wrong.
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Warcraft III|*.bak;*.old|RECURSE
+FileKey2=%ProgramFiles%\Warcraft III|*.bak;*.old|RECURSE
 
 [Warframe*]
 Section=Games
@@ -19141,12 +18967,12 @@ LangSecRef=3024
 DetectFile=%CommonAppData%\Western Digital
 Default=False
 FileKey1=%AppData%\Western Digital\WD SmartWare\Logs|*.*
-FileKey2=%CommonAppData%\Western Digital\WD SmartWare|*.log
-FileKey3=%CommonAppData%\Western Digital\WDFME|*.*
-FileKey4=%CommonAppData%\Western Digital\Logs\WD *\*|*.log
-FileKey5=%LocalAppData%\Western Digital\WD SmartWare|*log.txt
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Western Digital\WD SmartWare|*.log
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Western Digital\WDFME|*.*
+FileKey2=%CommonAppData%\Western Digital\Logs\WD *\*|*.log
+FileKey3=%CommonAppData%\Western Digital\WD SmartWare|*.log
+FileKey4=%CommonAppData%\Western Digital\WDFME|*.*
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\Western Digital\WD SmartWare|*.log
+FileKey6=%LocalAppData%\VirtualStore\ProgramData\Western Digital\WDFME|*.*
+FileKey7=%LocalAppData%\Western Digital\WD SmartWare|*log.txt
 
 [WhatPulse Backups*]
 LangSecRef=3021
@@ -19224,8 +19050,8 @@ FileKey6=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\Micros
 FileKey7=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
 FileKey8=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\PRICache|*.*|RECURSE
 FileKey9=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\AC\Temp|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\TempState|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\LocalState\LiveComm\*\*\DBStore\LogFiles|edbtmp.log
+FileKey10=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\LocalState\LiveComm\*\*\DBStore\LogFiles|edbtmp.log
+FileKey11=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.windowscommunicationsapps_8wekyb3d8bbwe\SearchHistory
 
 [Windows Connected Devices Platform*]
@@ -19251,10 +19077,10 @@ FileKey8=%CommonAppData%\Microsoft\Windows Defender\Support|*.*|RECURSE
 LangSecRef=3023
 Detect=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings
 Default=False
-RegKey1=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\Browse 128
-RegKey2=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\Browse 2
-RegKey3=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\Browse 5
-RegKey4=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\Browse 7
+RegKey1=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\Browse 2
+RegKey2=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\Browse 5
+RegKey3=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\Browse 7
+RegKey4=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\Browse 128
 RegKey5=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\MRU0
 RegKey6=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\MRU1
 RegKey7=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\MRU2
@@ -19272,10 +19098,10 @@ FileKey5=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\CrashDumps|*.dmp
 FileKey6=%WinDir%\SysWOW64\config\systemprofile\Local Settings\Application Data\CrashDumps|*.dmp
 RegKey1=HKCU\Software\Microsoft\Windows\Windows Error Reporting\Debug|StoreLocation
 RegKey2=HKLM\Software\Microsoft\Windows\Windows Error Reporting\Debug|StoreLocation
-RegKey3=HKLM\Software\Microsoft\Windows\Windows Error Reporting\LocalDumps
-RegKey4=HKLM\Software\Microsoft\Windows\Windows Error Reporting\FullLiveKernelReports|LastFullLiveReport
-RegKey5=HKLM\Software\Microsoft\Windows\Windows Error Reporting\FullLiveKernelReports\win32k.sys
-RegKey6=HKLM\Software\Microsoft\Windows\Windows Error Reporting\LiveKernelReports\win32k.sys
+RegKey3=HKLM\Software\Microsoft\Windows\Windows Error Reporting\FullLiveKernelReports|LastFullLiveReport
+RegKey4=HKLM\Software\Microsoft\Windows\Windows Error Reporting\FullLiveKernelReports\win32k.sys
+RegKey5=HKLM\Software\Microsoft\Windows\Windows Error Reporting\LiveKernelReports\win32k.sys
+RegKey6=HKLM\Software\Microsoft\Windows\Windows Error Reporting\LocalDumps
 RegKey7=HKU\.DEFAULT\Software\Microsoft\Windows\Windows Error Reporting\Debug|StoreLocation
 
 [Windows ESENT Process MRU*]
@@ -19319,9 +19145,9 @@ RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\WIA
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Installer
 Default=False
-FileKey1=%WinDir%\Installer\MSI*.tmp-|*.*|REMOVESELF
-FileKey2=%WinDir%\Installer|*.tmp|RECURSE
-FileKey3=%WinDir%\Installer|SourceHash{*};wix{*}.SchedServiceConfig.rmi
+FileKey1=%WinDir%\Installer|*.tmp|RECURSE
+FileKey2=%WinDir%\Installer|SourceHash{*};wix{*}.SchedServiceConfig.rmi
+FileKey3=%WinDir%\Installer\MSI*.tmp-|*.*|REMOVESELF
 
 [Windows Live Mail*]
 LangSecRef=3025
@@ -19329,10 +19155,10 @@ Detect=HKCU\Software\Microsoft\Windows Live Mail
 Default=False
 Warning=This will reset the read counts, which will be recalculated when WLMail is started.
 FileKey1=%LocalAppData%\Microsoft\Windows*Mail|*.log;*.jrs;*.chk;*.rss;*.tmp|RECURSE
-FileKey2=%LocalAppData%\Microsoft\Windows*Mail\Backup|*.*|REMOVESELF
-FileKey3=%LocalAppData%\Microsoft\Windows*Mail\*\Backup|*.*|REMOVESELF
-FileKey4=%LocalAppData%\Microsoft\Windows*Mail\*.tmp|*.*|RECURSE
-FileKey5=%LocalAppData%\Microsoft\Windows*Mail\*|*.MSMessageStore|RECURSE
+FileKey2=%LocalAppData%\Microsoft\Windows*Mail\*|*.MSMessageStore|RECURSE
+FileKey3=%LocalAppData%\Microsoft\Windows*Mail\*.tmp|*.*|RECURSE
+FileKey4=%LocalAppData%\Microsoft\Windows*Mail\*\Backup|*.*|REMOVESELF
+FileKey5=%LocalAppData%\Microsoft\Windows*Mail\Backup|*.*|REMOVESELF
 RegKey1=HKCU\Software\Microsoft\Windows Live Mail|SearchFolderVersion
 
 [Windows Live Messenger Chat History*]
@@ -19351,8 +19177,8 @@ FileKey2=%LocalAppData%\Microsoft\Messenger|*.uccapilog;*.bak;*.txt|RECURSE
 FileKey3=%LocalAppData%\Microsoft\Windows Live|*.log;*.jrs;*.sqm|RECURSE
 FileKey4=%LocalAppData%\Microsoft\Windows Live Contacts|*.log;*.jrs|RECURSE
 FileKey5=%LocalAppData%\Microsoft\Windows Live Contacts\*\*\*\Backup|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Windows Live\Messenger|*.bak|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Common Files\Windows Live\.cache|*.*|RECURSE
+FileKey6=%LocalAppData%\VirtualStore\Program Files*\Common Files\Windows Live\.cache|*.*|RECURSE
+FileKey7=%LocalAppData%\VirtualStore\Program Files*\Windows Live\Messenger|*.bak|RECURSE
 FileKey8=%ProgramFiles%\Windows Live\Messenger|*.bak|RECURSE
 FileKey9=%WinDir%\System32\config\systemprofile\Documents|wlidsvctrace*.txt
 FileKey10=%WinDir%\SysWOW64\config\systemprofile\Documents|wlidsvctrace*.txt
@@ -19381,9 +19207,9 @@ LangSecRef=3023
 Detect=HKCU\Software\Microsoft\Windows Live\Photo Gallery
 Default=False
 FileKey1=%LocalAppData%\Microsoft\Windows Live Photo Gallery|*.*|RECURSE
-RegKey1=HKCU\Software\Microsoft\Windows Live\Photo Gallery|galleryscopedfolders
-RegKey2=HKCU\Software\Microsoft\Windows Live\Photo Aquisition\Camera|FinenameTemplate
-RegKey3=HKCU\Software\Microsoft\Windows Live\Photo Aquisition\Camera|RootDirectory
+RegKey1=HKCU\Software\Microsoft\Windows Live\Photo Aquisition\Camera|FinenameTemplate
+RegKey2=HKCU\Software\Microsoft\Windows Live\Photo Aquisition\Camera|RootDirectory
+RegKey3=HKCU\Software\Microsoft\Windows Live\Photo Gallery|galleryscopedfolders
 
 [Windows Live Setup Logs*]
 LangSecRef=3022
@@ -19477,14 +19303,14 @@ RegKey3=HKCU\Software\Microsoft\Windows\ShellNoRoam\MUICache
 LangSecRef=3023
 Detect=HKCU\Software\Microsoft\Windows Photo Gallery
 Default=False
-RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\Camera|FilenameTemplate
-RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\Camera|RootDirectory
-RegKey3=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\DestinationMru
-RegKey4=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\OpticalMedia|FilenameTemplate
-RegKey5=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\OpticalMedia|RootDirectory
-RegKey6=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\Scanner|FilenameTemplate
-RegKey7=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\Scanner|RootDirectory
-RegKey8=HKCU\Software\Microsoft\Windows Photo Gallery\Library\PreviewAssignment\MRU
+RegKey1=HKCU\Software\Microsoft\Windows Photo Gallery\Library\PreviewAssignment\MRU
+RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\Camera|FilenameTemplate
+RegKey3=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\Camera|RootDirectory
+RegKey4=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\DestinationMru
+RegKey5=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\OpticalMedia|FilenameTemplate
+RegKey6=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\OpticalMedia|RootDirectory
+RegKey7=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\Scanner|FilenameTemplate
+RegKey8=HKCU\Software\Microsoft\Windows\CurrentVersion\Photo Aquisition\Scanner|RootDirectory
 
 [Windows Photo Viewer*]
 LangSecRef=3025
@@ -19505,8 +19331,8 @@ FileKey5=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\Cryptnet
 FileKey6=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
 FileKey7=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\PRICache|*.*
 FileKey8=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Temp|*.*
-FileKey9=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState\bici|*.sqm
-FileKey10=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState|*.log;*.jpg
+FileKey9=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState|*.log;*.jpg
+FileKey10=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState\bici|*.sqm
 FileKey11=%LocalAppData%\Packages\microsoft.windowsphotos_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.windowsphotos_8wekyb3d8bbwe\SearchHisto
 
@@ -19551,8 +19377,8 @@ FileKey1=%WinDir%\Logs\WindowsUpdate|*.*|RECURSE
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Explorer\WindowsUpdate
 Default=False
-FileKey1=%WinDir%\SoftwareDistribution\DataStore\Logs|*.*
-FileKey2=%WinDir%\SoftwareDistribution|*.log
+FileKey1=%WinDir%\SoftwareDistribution|*.log
+FileKey2=%WinDir%\SoftwareDistribution\DataStore\Logs|*.*
 
 [Windows Update Notification Manager Logs*]
 DetectOS=10.0|
@@ -19586,14 +19412,10 @@ LangSecRef=3021
 Detect=HKCU\Software\Qbik Software\GateKeeper
 DetectFile=%ProgramFiles%\WinGate\WinGate.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\WinGate|*Log.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\WinGate\Drivers\Vista|*.log
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\WinGate\Logs\Global|*.log;*.idx
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\WinGate\Logs\WinGate Update Installer|*.log
-FileKey5=%ProgramFiles%\WinGate|*Log.txt
-FileKey6=%ProgramFiles%\WinGate\Drivers\Vista|*.log
-FileKey7=%ProgramFiles%\WinGate\Logs\Global|*.log;*.idx
-FileKey8=%ProgramFiles%\WinGate\Logs\WinGate Update Installer|*.log
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\WinGate|*Log.txt;*.log|RECURSE
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\WinGate\Logs\Global|*.idx
+FileKey3=%ProgramFiles%\WinGate|*Log.txt;*.log|RECURSE
+FileKey4=%ProgramFiles%\WinGate\Logs\Global|*.idx
 
 [WinHasher*]
 LangSecRef=3024
@@ -19667,9 +19489,9 @@ Detect=HKCU\Software\WinRAR
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\WinRAR|*.tmp|RECURSE
 FileKey2=%ProgramFiles%\WinRAR|*.tmp|RECURSE
-RegKey1=HKCU\Software\WinRAR\DialogEditHistory
-RegKey2=HKCU\Software\WinRAR\General\Info|CommentFile
-RegKey3=HKCU\Software\WinRAR SFX
+RegKey1=HKCU\Software\WinRAR SFX
+RegKey2=HKCU\Software\WinRAR\DialogEditHistory
+RegKey3=HKCU\Software\WinRAR\General\Info|CommentFile
 
 [WinRemote*]
 LangSecRef=3021
@@ -19798,12 +19620,12 @@ LangSecRef=3022
 Detect=HKLM\SOFTWARE\Wondershare\Wondershare AllMyTube
 Default=False
 FileKey1=%AppData%\Wondershare AllMyTube|*.*|RECURSE
-FileKey2=%CommonAppData%\Wondershare\AllMyTube|*.bak;*.xml
-FileKey3=%CommonAppData%\Wondershare AllMyTube\ConvertedLibPic|*.*|RECURSE
-FileKey4=%CommonAppData%\Wondershare Application Common Data\Download|*.bak;*.xml
-FileKey5=%CommonAppData%\Wondershare Application Common Data\Download\MediaLibPic|*.*|RECURSE
-FileKey6=%CommonAppData%\Wondershare Application Common Data\Download\SiteLogo|*.*|RECURSE
-FileKey7=%CommonAppData%\Wondershare Application Common Data\Download\TempThumbDir|*.*|RECURSE
+FileKey2=%CommonAppData%\Wondershare AllMyTube\ConvertedLibPic|*.*|RECURSE
+FileKey3=%CommonAppData%\Wondershare Application Common Data\Download|*.bak;*.xml
+FileKey4=%CommonAppData%\Wondershare Application Common Data\Download\MediaLibPic|*.*|RECURSE
+FileKey5=%CommonAppData%\Wondershare Application Common Data\Download\SiteLogo|*.*|RECURSE
+FileKey6=%CommonAppData%\Wondershare Application Common Data\Download\TempThumbDir|*.*|RECURSE
+FileKey7=%CommonAppData%\Wondershare\AllMyTube|*.bak;*.xml
 FileKey8=%ProgramFiles%\Wondershare\AllMyTube\Log|*.*|RECURSE
 
 [Wondershare dr.fone toolkit for Android*]
@@ -19846,10 +19668,10 @@ Detect=HKCU\SOFTWARE\Wondershare\MobileGo
 DetectFile=%AppData%\Wondershare\MobileGo for iOS
 Default=False
 FileKey1=%AppData%\se_tmp|*.*|REMOVESELF
-FileKey2=%AppData%\Wondershare\DataEraser|*.log
-FileKey3=%AppData%\Wondershare\Dr.FoneTool\log|*.log
-FileKey4=%AppData%\Wondershare\DrFoneAndroidTool\log|*.log
-FileKey5=%AppData%\Wondershare\*Go*|*.log
+FileKey2=%AppData%\Wondershare\*Go*|*.log
+FileKey3=%AppData%\Wondershare\DataEraser|*.log
+FileKey4=%AppData%\Wondershare\Dr.FoneTool\log|*.log
+FileKey5=%AppData%\Wondershare\DrFoneAndroidTool\log|*.log
 FileKey6=%AppData%\Wondershare\MirrorGo\ImageCache\ADImage|*.*|RECURSE
 FileKey7=%AppData%\Wondershare\MobileGo\DeviceImageCache|*.*|RECURSE
 FileKey8=%AppData%\Wondershare\MobileGo\iOSTemp|*.*|REMOVESELF
@@ -19876,8 +19698,8 @@ FileKey2=%AppData%\HYXDevPsnList|*.*|REMOVESELF
 FileKey3=%AppData%\se_tmp|*.*|REMOVESELF
 FileKey4=%AppData%\se_tmp_win|*.*|REMOVESELF
 FileKey5=%AppData%\Wondershare\SafeEraser|*.log
-FileKey6=%AppData%\Wondershare\SafeEraser\Logs\iOSTemp|*.*|RECURSE
-FileKey7=%AppData%\Wondershare\SafeEraser\Logs\DeviceConnection|*.*|RECURSE
+FileKey6=%AppData%\Wondershare\SafeEraser\Logs\DeviceConnection|*.*|RECURSE
+FileKey7=%AppData%\Wondershare\SafeEraser\Logs\iOSTemp|*.*|RECURSE
 FileKey8=%ProgramFiles%\Wondershare\SafeEraser\se_tmp_win|*.*|REMOVESELF
 FileKey9=%SystemDrive%\se_tmp|*.*|REMOVESELF
 
@@ -20290,12 +20112,12 @@ FileKey1=%LocalAppData%\Zemana\Zemana AntiMalware\reports|*.txt
 LangSecRef=3021
 Detect=HKCU\Software\Zend\ZendStudio
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0|*.html
+FileKey1=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0|*.html
+FileKey2=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0|*.log|RECURSE
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0\docs|*.txt|REMOVESELF
 FileKey4=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0\features|*.html|RECURSE
-FileKey5=%ProgramFiles%\Zend\Zend Studio 10.0.0|*.log|RECURSE
-FileKey6=%ProgramFiles%\Zend\Zend Studio 10.0.0|*.html
+FileKey5=%ProgramFiles%\Zend\Zend Studio 10.0.0|*.html
+FileKey6=%ProgramFiles%\Zend\Zend Studio 10.0.0|*.log|RECURSE
 FileKey7=%ProgramFiles%\Zend\Zend Studio 10.0.0\docs|*.txt|REMOVESELF
 FileKey8=%ProgramFiles%\Zend\Zend Studio 10.0.0\features|*.html|RECURSE
 
@@ -20309,8 +20131,8 @@ FileKey1=%AppData%\KC Softwares\Zer0|*.log
 LangSecRef=3022
 Detect=HKCU\Software\Zimbra
 Default=False
-FileKey1=%LocalAppData%\Zimbra\Zimbra Desktop\data\tmp\diskcache|*.*|RECURSE
-FileKey2=%LocalAppData%\Zimbra\Zimbra Desktop\data\*log|*.*
+FileKey1=%LocalAppData%\Zimbra\Zimbra Desktop\data\*log|*.*
+FileKey2=%LocalAppData%\Zimbra\Zimbra Desktop\data\tmp\diskcache|*.*|RECURSE
 
 [ZipGenius*]
 LangSecRef=3024
@@ -20332,14 +20154,6 @@ DetectFile=%ProgramFiles%\Gasanov.net\ZoneIDTrimmer\ZoneIDTrimmer.Tool.exe
 Default=False
 FileKey1=%AppData%\ZoneIDTrimmer\Logs|ZoneIDTrimmer.log
 
-[Zoner Photo Studio AutoSave*]
-LangSecRef=3023
-Detect1=HKCU\Software\ZONER\Zoner Photo Studio 15
-Detect2=HKCU\Software\ZONER\Zoner Photo Studio 16
-Detect3=HKCU\Software\ZONER\Zoner Photo Studio 18
-Default=False
-FileKey1=%LocalAppData%\Zoner\OriginalsRepository|*.JPG.info;*.JPG.original|RECURSE
-
 [Zoner Photo Studio*]
 LangSecRef=3022
 DetectFile=%LocalAppData%\Zoner\ZPS 14
@@ -20351,6 +20165,14 @@ FileKey1=%LocalAppData%\Zoner\ZPS *\Cache|*.*|RECURSE
 FileKey2=%LocalAppData%\Zoner\ZPS *\CEF|*.log
 FileKey3=%LocalAppData%\Zoner\ZPS *\ZPSCache.dat|*.*
 FileKey4=%Pictures%|*.uid-zps
+
+[Zoner Photo Studio AutoSave*]
+LangSecRef=3023
+Detect1=HKCU\Software\ZONER\Zoner Photo Studio 15
+Detect2=HKCU\Software\ZONER\Zoner Photo Studio 16
+Detect3=HKCU\Software\ZONER\Zoner Photo Studio 18
+Default=False
+FileKey1=%LocalAppData%\Zoner\OriginalsRepository|*.JPG.info;*.JPG.original|RECURSE
 
 [Zune Music*]
 LangSecRef=3031
@@ -20392,10 +20214,10 @@ FileKey6=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\PRICache|*.*|RECURSE
 FileKey7=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Temp|*.*|RECURSE
 FileKey8=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\TokenBroker\Cache|*.*|RECURSE
 FileKey9=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\*Cache*|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\PlayReady|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\TempState|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\Database\anonymous|*.log
+FileKey10=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\Database\anonymous|*.log
+FileKey11=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\PlayReady|*.*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneVideo_8wekyb3d8bbwe\SearchHistory
 
 [Zuse Logs*]


### PR DESCRIPTION
Here I've started a refactor. Some comments:

Implemented broad use of nested wildcards and wildcards in detectfile paths

I merged together many entries. Many of these were situations like separate logs/cache cleaning, or situations were multiple similar entries are related. My rationale behind this is that it's a little exhausting having Skype installed and to be greeted with 5 extra checkboxes for components of Skype that otherwise come with no explanation. Things that a user might generally not want to clean alongside "junk" files (such as history, chat logs, etc) I did not merge

It's a pretty broad, sweeping change to a lot of parts of the file, so feel free to cherrypick/debate the usefulness of any changes. 

There are some pull requests pending that might not merge well with this also. 