### PR TITLE
Fix Detect/DetectFile entries

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -268,7 +268,7 @@ FileKey10=%LocalAppData%\Vivaldi\User Data\*\File System|*.*|REMOVESELF
 [Installer *]
 LangSecRef=3029
 SpecialDetect=DET_CHROME
-Detect1=HKCU\Software\Vivaldi
+Detect=HKCU\Software\Vivaldi
 Default=False
 FileKey1=%LocalAppData%\Google\Chrome*\Application\*\Installer|*.*|RECURSE
 FileKey2=%LocalAppData%\Google\Update\*\*\Installer|*.*|RECURSE
@@ -470,7 +470,7 @@ RegKey1=HKCU\software\Local AppWizard-Generated Applications
 [SetupMetrics *]
 LangSecRef=3029
 SpecialDetect=DET_CHROME
-Detect1=HKCU\Software\Vivaldi
+Detect=HKCU\Software\Vivaldi
 Default=False
 FileKey1=%LocalAppData%\Vivaldi\Application\SetupMetrics|*.*|RECURSE
 FileKey2=%ProgramFiles%\Google\Chrome\Application\SetupMetrics|*.*|RECURSE
@@ -2758,7 +2758,7 @@ FileKey1=%CommonAppData%\Avira\VPN|*.log
 [Avira System Speedup *]
 LangSecRef=3024
 Detect1=HKLM\Software\Avira\Speedup
-Detect2g=HKLM\Software\AviraSpeedup
+Detect2=HKLM\Software\AviraSpeedup
 Default=False
 FileKey1=%CommonAppData%\Avira\Launcher\Logfiles|*.log
 FileKey2=%CommonAppData%\Avira\SystemSpeedup\Errors|*.*
@@ -3306,7 +3306,7 @@ FileKey1=%AppData%\Blender Foundation\Blender\*\config|recent-files.txt
 
 [Blimb Entertainment AIRSTRIKE3D *]
 Section=Games
-DetectFile1=%ProgramFiles%\Blimb Entertainment\AIRSTRIKE3D
+DetectFile=%ProgramFiles%\Blimb Entertainment\AIRSTRIKE3D
 Default=False
 FileKey1=%ProgramFiles%\Blimb Entertainment\AIRSTRIKE3D|*.log
 
@@ -3745,8 +3745,8 @@ RegKey6=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Studio\9.0|RecentRe
 
 [Canon Digital Photo Professional 4 *]
 LangSecRef=3021
-Detect1=HKLM\Software\Canon_Inc_IC\DPP4
-DetectFile1=%ProgramFiles%\Canon\Digital Photo Professional 4
+Detect=HKLM\Software\Canon_Inc_IC\DPP4
+DetectFile=%ProgramFiles%\Canon\Digital Photo Professional 4
 Default=False
 FileKey1=%AppData%\Canon_Inc_IC\DPP4\DppMWare\Cache|*.*|RECURSE
 
@@ -4659,7 +4659,7 @@ FileKey1=%ProgramFiles%\Core Temp|*.csv
 
 [Corel AfterShot Pro *]
 LangSecRef=3023
-Detect1=HKCU\Software\Corel\AfterShot Pro V3
+Detect=HKCU\Software\Corel\AfterShot Pro V3
 Default=False
 FileKey1=%LocalAppData%\Corel\AfterShot Pro *|*.log
 FileKey2=%LocalAppData%\Corel\AfterShot Pro *\Cache|*.*|RECURSE
@@ -6676,7 +6676,7 @@ FileKey1=%AppData%\FEZ|Debug Log.txt
 
 [FFsplit *]
 LangSecRef=3023
-DetectFile1=%ProgramFiles%\FFsplit
+DetectFile=%ProgramFiles%\FFsplit
 Default=False
 FileKey1=%AppData%\FFsplit|FFsourceLog.txt
 FileKey2=%AppData%\FFsplit\logs|*.*
@@ -9736,7 +9736,7 @@ FileKey1=%LocalAppData%\Lupinho.Net|*.log|RECURSE
 
 [Lynx Web Browser *]
 LangSecRef=3022
-DetectFile1=%ProgramFiles%\Lynx - web browser
+DetectFile=%ProgramFiles%\Lynx - web browser
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Lynx - web browser\tmp|*.*
 FileKey2=%ProgramFiles%\Lynx - web browser\tmp|*.*
@@ -10855,14 +10855,14 @@ FileKey1=%LocalAppData%\Microsoft\UserScanProfiles|*.*
 
 [MS Visual Basic 2010 Express MRU *]
 LangSecRef=3021
-Detect1=HKCU\Software\Microsoft\VBExpress\10.0
+Detect=HKCU\Software\Microsoft\VBExpress\10.0
 Default=False
 RegKey1=HKCU\Software\Microsoft\VBExpress\10.0\FileMRUList
 RegKey2=HKCU\Software\Microsoft\VBExpress\10.0\ProjectMRUList
 
 [MS Visual Basic 2010 Express Search History *]
 LangSecRef=3021
-Detect1=HKCU\Software\Microsoft\VBExpress\10.0
+Detect=HKCU\Software\Microsoft\VBExpress\10.0
 Default=False
 RegKey1=HKCU\Software\Microsoft\VBExpress\10.0\Find|Find
 RegKey2=HKCU\Software\Microsoft\VBExpress\10.0\Find|Find 0
@@ -10909,14 +10909,14 @@ RegKey42=HKCU\Software\Microsoft\VBExpress\10.0\Find|Replace 19
 
 [MS Visual C# 2010 Express MRU *]
 LangSecRef=3021
-Detect1=HKCU\Software\Microsoft\VCSExpress\10.0
+Detect=HKCU\Software\Microsoft\VCSExpress\10.0
 Default=False
 RegKey1=HKCU\Software\Microsoft\VCSExpress\10.0\FileMRUList
 RegKey2=HKCU\Software\Microsoft\VCSExpress\10.0\ProjectMRUList
 
 [MS Visual C# 2010 Express Search History *]
 LangSecRef=3021
-Detect1=HKCU\Software\Microsoft\VCSExpress\10.0
+Detect=HKCU\Software\Microsoft\VCSExpress\10.0
 Default=False
 RegKey1=HKCU\Software\Microsoft\VCSExpress\10.0\Find|Find
 RegKey2=HKCU\Software\Microsoft\VCSExpress\10.0\Find|Find 0
@@ -10963,14 +10963,14 @@ RegKey42=HKCU\Software\Microsoft\VCSExpress\10.0\Find|Replace 19
 
 [MS Visual C++ 2010 Express MRU *]
 LangSecRef=3021
-Detect1=HKCU\Software\Microsoft\VCExpress\10.0
+Detect=HKCU\Software\Microsoft\VCExpress\10.0
 Default=False
 RegKey1=HKCU\Software\Microsoft\VCExpress\10.0\FileMRUList
 RegKey2=HKCU\Software\Microsoft\VCExpress\10.0\ProjectMRUList
 
 [MS Visual C++ 2010 Express Search History *]
 LangSecRef=3021
-Detect1=HKCU\Software\Microsoft\VCExpress\10.0
+Detect=HKCU\Software\Microsoft\VCExpress\10.0
 Default=False
 RegKey1=HKCU\Software\Microsoft\VCExpress\10.0\Find|Find
 RegKey2=HKCU\Software\Microsoft\VCExpress\10.0\Find|Find 0
@@ -11060,7 +11060,7 @@ FileKey11=%UserProfile%\.nuget|*.*|RECURSE
 
 [MS Visual Studio MRU *]
 LangSecRef=3021
-Detect1=HKCU\Software\Microsoft\VisualStudio
+Detect=HKCU\Software\Microsoft\VisualStudio
 Default=False
 RegKey1=HKCU\Software\Microsoft\VisualStudio\9.0\FileMRUList
 RegKey2=HKCU\Software\Microsoft\VisualStudio\9.0\LastLoadedSolution
@@ -11080,7 +11080,7 @@ RegKey15=HKCU\Software\Microsoft\VisualStudio\14.0\ProjectMRUList
 
 [MS Visual Studio Search History *]
 LangSecRef=3021
-Detect1=HKCU\Software\Microsoft\VisualStudio
+Detect=HKCU\Software\Microsoft\VisualStudio
 Default=False
 RegKey1=HKCU\Software\Microsoft\VisualStudio\9.0\Find|Find 0
 RegKey2=HKCU\Software\Microsoft\VisualStudio\9.0\Find|Find 1
@@ -11714,7 +11714,7 @@ RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 
 [NETGEAR Genie *]
 LangSecRef=3024
-Detect1=HKLM\Software\NETGEAR Genie
+Detect=HKLM\Software\NETGEAR Genie
 Default=False
 FileKey1=%LocalAppData%\NETGEARGenie|*.txt
 FileKey2=%LocalAppData%\NETGEARGenie\log|*.log
@@ -13947,7 +13947,7 @@ FileKey2=%ProgramFiles%\Registry Clean Expert|fixlog.ini
 
 [Registry First Aid *]
 LangSecRef=3024
-Detect1=HKCU\Software\KsL Software\RFA
+Detect=HKCU\Software\KsL Software\RFA
 Default=False
 FileKey1=%LocalAppData%\Microsoft\Windows|NTUSER.tmp;UsrClass.tmp
 FileKey2=%UserProfile%|NTUSER.tmp;UsrClass.tmp
@@ -14312,7 +14312,7 @@ FileKey1=%LocalAppData%|SageThumbs.*
 
 [SAM Broadcaster *]
 LangSecRef=3023
-Detect1=HKCU\Software\SAMBC
+Detect=HKCU\Software\SAMBC
 Default=False
 FileKey1=%LocalAppData%\SpacialAudio\SAMBC|*.log|RECURSE
 FileKey2=%LocalAppData%\SpacialAudio\SAMBC\backup|*.*|RECURSE
@@ -15342,7 +15342,7 @@ FileKey2=%ProgramFiles%\SpongeBob Diner Dash|logfile.*
 
 [Spooky Mall *]
 Section=Games
-Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Spooky Mall1.0
+Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Spooky Mall1.0
 Default=False
 FileKey1=%CommonAppData%\SpookyMall|*.xml_log
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Foxy Games\Spooky Mall|*.log
@@ -15513,7 +15513,7 @@ FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Star Wars BattleFront II|update*.
 
 [Star Wars The Force Unleashed *]
 Section=Games
-DetectFile1=%LocalAppData%\LucasArts\Star Wars The Force Unleashed*
+DetectFile=%LocalAppData%\LucasArts\Star Wars The Force Unleashed*
 Default=False
 FileKey1=%LocalAppData%\LucasArts\Star Wars The Force Unleashed*|*.*
 
@@ -15819,7 +15819,7 @@ FileKey1=%AppData%\Style Jukebox Settings|*.bmp|RECURSE
 
 [Sublime Text Session *]
 LangSecRef=3024
-DetectFile1=%AppData%\Sublime Text*
+DetectFile=%AppData%\Sublime Text*
 Default=False
 FileKey1=%AppData%\Sublime Text 2\Settings|*.sublime_session
 FileKey2=%AppData%\Sublime Text 3\Local|Session.sublime_session
@@ -16111,7 +16111,7 @@ FileKey1=%AppData%\.technic*\*\Backups|*.*|RECURSE
 
 [Technic Launcher Screenshots *]
 Section=Games
-DetectFile1=%AppData%\.technic*
+DetectFile=%AppData%\.technic*
 Default=False
 FileKey1=%AppData%\.technic*\*\Screenshots|*.*
 
@@ -17183,7 +17183,7 @@ FileKey1=%LocalAppData%\V Cast Media Manager|*.log;backuplog.txt;logfile.txt;*.t
 
 [VCRedist Temp Setup Files *]
 LangSecRef=3021
-DetectFile1=%SystemDrive%\VC_RED.*
+DetectFile=%SystemDrive%\VC_RED.*
 Default=False
 FileKey1=%SystemDrive%|eula.1028.txt;eula.1031.txt;eula.1033.txt;eula.1036.txt;eula.1040.txt;eula.1041.txt;eula.1042.txt;eula.2052.txt;eula.3082.txt;globdata.ini;install.exe;install.ini;install.res.1028.dll;install.res.1031.dll;install.res.1033.dll;install.res.1036.dll;install.res.1040.dll;install.res.1041.dll;install.res.1042.dll;install.res.2052.dll;install.res.3082.dll;VC_RED.cab;VC_RED.MSI;vcredist.bmp
 


### PR DESCRIPTION
Rename `Detect1=` or `DetectFile1=` entries that do not have a corresponding `Detect2=` or `DetectFile2=` entry, respectively