### PR TITLE
Updates from the community

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -3986,7 +3986,7 @@ FileKey8=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\AppData|*.
 FileKey9=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\Cache|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Camera_8wekyb3d8bbwe\SearchHistory
-ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\INetCache\|container.dat
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft*Camera_*\AC\INetCache\|container.dat
 
 [Cameyo *]
 LangSecRef=3021

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1121,6 +1121,7 @@ FileKey2=%LocalAppData%\Packages\Microsoft.3DBuilder_*\AC\Temp|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.3DBuilder_*\LocalCache|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.3DBuilder_*\LocalState\Cache|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.3DBuilder_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.3DBuilder_*\AC\INetCache\|container.dat
 
 [3DMark *]
 Section=Games
@@ -1319,10 +1320,10 @@ FileKey1=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\AppCache|*.*|REC
 FileKey2=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\INet*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.AccountsControl_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.AccountsControl_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.AccountsControl_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.AccountsControl_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.AccountsControl_*\LocalState\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.AccountsControl_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\INetCache\|container.dat
 
 [AccurateRip *]
 LangSecRef=3023
@@ -1342,6 +1343,7 @@ FileKey2=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\AC\Microso
 FileKey3=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\AC\Temp|*.*
 FileKey4=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\LocalState|*.tmp
 FileKey5=%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\TempState\Bing.Maps\Cache|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\AccuWeather.AccuWeatherforWindows8_*\AC\INetCache\|container.dat
 
 [ACDSee Pro *]
 LangSecRef=3023
@@ -2279,6 +2281,7 @@ DetectFile=%LocalAppData%\Packages\1ED5AEA5.AngryBirdsSpace_p2gbknwb5d8r2
 Default=False
 FileKey1=%LocalAppData%\Packages\*.AngryBirdsSpace_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\*.AngryBirdsSpace_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+ExcludeKey1=FILE|%LocalAppData%\Packages\*.AngryBirdsSpace_*\AC\INetCache\|container.dat
 
 [Angry Birds Star Wars *]
 LangSecRef=3031
@@ -2287,6 +2290,7 @@ DetectFile=%LocalAppData%\Packages\1ED5AEA5.AngryBirdsBlack_p2gbknwb5d8r2
 Default=False
 FileKey1=%LocalAppData%\Packages\*.AngryBirdsBlack_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\*.AngryBirdsBlack_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+ExcludeKey1=FILE|%LocalAppData%\Packages\*.AngryBirdsBlack_*\AC\INetCache\|container.dat
 
 [Anim8or *]
 LangSecRef=3021
@@ -2830,6 +2834,7 @@ FileKey7=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Temp|*.*
 FileKey8=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\Cache|*.*|RECURSE
 FileKey9=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\navigationHistory|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\INetCache\|container.dat
 
 [Auto BCC For MS Outlook *]
 LangSecRef=3021
@@ -2992,6 +2997,7 @@ FileKey4=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0*\N
 FileKey5=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Temp|*.*
 FileKey6=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\LocalState|*.*|RECURSE
 FileKey7=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\INetCache\|container.dat
 
 [Avidemux *]
 LangSecRef=3023
@@ -3354,8 +3360,7 @@ FileKey1=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\AppCache|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\PRICache|*.*
 FileKey4=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.BingFinance_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.BingFinance_*\TempState|*.*|RECURSE
 
 [Bing Food and Drink *]
 LangSecRef=3031
@@ -3393,8 +3398,7 @@ Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\PRICache|*.*
 FileKey3=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.BingNews_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.BingNews_*\LocalState\navigationHistory|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingNews_8wekyb3d8bbwe\SearchHistory
 
 [Bing Search *]
@@ -3414,9 +3418,8 @@ FileKey1=%LocalAppData%\Packages\Microsoft.BingSports_*\AC\AppCache|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.BingSports_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.BingSports_*\AC\PRICache|*.*
 FileKey4=%LocalAppData%\Packages\Microsoft.BingSports_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.BingSports_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.BingSports_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.BingSports_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.BingSports_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.BingSports_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingSports_8wekyb3d8bbwe\SearchHistory
 
 [Bing Travel *]
@@ -3442,12 +3445,12 @@ FileKey4=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\CryptnetUr
 FileKey5=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
 FileKey6=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\PRICache|*.*|RECURSE
 FileKey7=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState|*.tmp
-FileKey10=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.BingWeather_*\TempState|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState|*.tmp
+FileKey9=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\Cache|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.BingWeather_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingWeather_8wekyb3d8bbwe\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\INetCache\|container.dat
 
 [BioShock Infinite *]
 Section=Games
@@ -3733,6 +3736,7 @@ FileKey5=%LocalAppData%\Packages\*Box_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 FileKey6=%LocalAppData%\Packages\*Box_*\AC\PRICache|*.*
 FileKey7=%LocalAppData%\Packages\*Box_*\AC\Temp|*.*
 FileKey8=%LocalAppData%\Packages\*Box_*\LocalState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\*Box_*\AC\INetCache\|container.dat
 
 [Brawlhalla Replays *]
 Section=Games
@@ -3977,12 +3981,12 @@ FileKey3=%LocalAppData%\Packages\Microsoft*Camera_*\AC\Microsoft\CLR_v4.0\UsageL
 FileKey4=%LocalAppData%\Packages\Microsoft*Camera_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 FileKey5=%LocalAppData%\Packages\Microsoft*Camera_*\AC\PRICache|*.*
 FileKey6=%LocalAppData%\Packages\Microsoft*Camera_*\AC\Temp|*.*
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalCache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\AppData|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\TempState|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalCache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\AppData|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\Cache|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Camera_8wekyb3d8bbwe\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\INetCache\|container.dat
 
 [Cameyo *]
 LangSecRef=3021
@@ -4495,6 +4499,7 @@ FileKey3=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\Microsoft\CLR_v4
 FileKey4=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\PRICache|*.*
 FileKey5=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\Temp|*.*
 FileKey6=%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\588E6FFA.CNNAppforWindows_*\AC\INetCache\|container.dat
 
 [CodeGear RAD Studio 2009 *]
 LangSecRef=3024
@@ -4573,10 +4578,10 @@ FileKey1=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\AppCache|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\INet*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.CommsPhone_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.CommsPhone_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.CommsPhone_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.CommsPhone_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.CommsPhone_*\LocalState\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.CommsPhone_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.CommsPhone_*\AC\INetCache\|container.dat
 
 [Comodo *]
 LangSecRef=3024
@@ -4672,10 +4677,10 @@ FileKey1=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\AppCache|*.*|R
 FileKey2=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\INet*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\LocalState\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\AC\INetCache\|container.dat
 
 [Conquer Online *]
 Section=Games
@@ -4697,10 +4702,10 @@ FileKey5=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*
 FileKey6=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey7=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
 FileKey8=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Temp|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalCache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalState\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Windows.ContactSupport_*\TempState|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalCache|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalState\Cache|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Windows.ContactSupport_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Windows.ContactSupport_*\AC\INetCache\|container.dat
 
 [Content Delivery Manager *]
 DetectOS=10.0|
@@ -4712,13 +4717,12 @@ FileKey2=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\B
 FileKey3=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\INet*|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\Favicons|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\MobilityExperience\ImageCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\OneSettingsResponseCache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\TargetedContentCache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\TempState|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\Favicons|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\MobilityExperience\ImageCache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\OneSettingsResponseCache|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\LocalState\TargetedContentCache|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\TempState|*.*|RECURSE
 ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.Windows.ContentDeliveryManager_*\AC\INetCache\|container.dat
 
 [ConTEXT *]
@@ -4766,7 +4770,6 @@ Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Cook'n
 Default=False
 FileKey1=%Documents%\Cook'n*|*.log|RECURSE
 FileKey2=%LocalAppData%\DVO\Cook'n*App|*.log|RECURSE
-
 
 [Copernic DesktopSearch4 *]
 LangSecRef=3024
@@ -4937,6 +4940,7 @@ FileKey6=%LocalAppData%\Packages\Microsoft*Cortana_*\TempState|*.*|RECURSE
 FileKey7=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\LocalCache|*.*|RECURSE
 FileKey8=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\LocalState\*Cache|*.*|RECURSE
 FileKey9=%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.Windows.Cortana_*\AC\INetCache\|container.dat
 
 [CounterSpy *]
 LangSecRef=3024
@@ -6538,6 +6542,7 @@ FileKey6=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\PRIC
 FileKey7=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\Temp|*.*
 FileKey8=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\LocalState|*.*|RECURSE
 FileKey9=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma\AC\INetCache\|container.dat
 
 [ESPN FC *]
 LangSecRef=3031
@@ -6550,6 +6555,7 @@ FileKey3=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\PRICache|*
 FileKey4=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\Temp|*.*
 FileKey5=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\LocalState|*.*|RECURSE
 FileKey6=%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma\AC\INetCache\|container.dat
 
 [ESPN Motion *]
 LangSecRef=3023
@@ -6828,7 +6834,7 @@ FileKey1=%CommonAppData%\MiserWare\FatBatt\logs|*.log
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\MiserWare\FatBatt\logs|*.log
 
 [Feedback Hub *]
-DetectOS=10.0
+DetectOS=10.0|
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsFeedbackHub_8wekyb3d8bbwe
 Default=False
@@ -6933,6 +6939,7 @@ FileKey2=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\Microsof
 FileKey3=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 FileKey4=%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\FilmOnLiveTVFree.FilmOnLiveTVFree_zx03kxexxb716\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\FilmOnLiveTVFree.FilmOnLiveTVFree_*\AC\INetCache\|container.dat
 
 [Firebird Project *]
 LangSecRef=3023
@@ -7363,6 +7370,7 @@ FileKey2=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Micro
 FileKey3=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\PRICache|*.*
 FileKey4=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Temp|*.*
 FileKey5=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\INetCache\|container.dat
 
 [gBurner *]
 LangSecRef=3021
@@ -7444,10 +7452,10 @@ Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalCache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalState\AppData\Local\Office\16.0\WebServiceCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalState\Cache|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalCache|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalState\AppData\Local\Office\16.0\WebServiceCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalState\Cache|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\INetCache\|container.dat
 
 [Get Started *]
 DetectOS=10.0|
@@ -7459,6 +7467,7 @@ FileKey2=%LocalAppData%\Packages\Microsoft.Getstarted_*\AC\Temp|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.Getstarted_*\LocalCache|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.Getstarted_*\LocalState\Cache|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.Getstarted_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.Getstarted_*\AC\INetCache\|container.dat
 
 [GetDiz Recent Files List *]
 LangSecRef=3021
@@ -7736,6 +7745,7 @@ DetectFile=%LocalAppData%\Packages\MiniclipSA.GravityGuy_gpanv85qtf6rc
 Default=False
 FileKey1=%LocalAppData%\Packages\MiniclipSA.GravityGuy_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\MiniclipSA.GravityGuy_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+ExcludeKey1=FILE|%LocalAppData%\Packages\MiniclipSA.GravityGuy_*\AC\INetCache\|container.dat
 
 [Green Ranch *]
 Section=Games
@@ -7788,13 +7798,13 @@ FileKey4=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\CryptnetUrlC
 FileKey5=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
 FileKey6=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\PRICache|*.*|RECURSE
 FileKey7=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\*Cache*|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\Database\*|*.log
-FileKey11=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\PlayReady|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\TempState|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\*Cache*|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\Database\*|*.log
+FileKey10=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\PlayReady|*.*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneMusic_8wekyb3d8bbwe\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\INetCache\|container.dat
 
 [GroupWise Messenger *]
 LangSecRef=3021
@@ -7861,6 +7871,7 @@ DetectFile=%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_*\AC\INetCache\|container.dat
 
 [HandBrake *]
 LangSecRef=3024
@@ -8218,6 +8229,7 @@ FileKey4=%LocalAppData%\Packages\*HPPrinterControl_*\AC\Microsoft\CryptnetUrlCac
 FileKey5=%LocalAppData%\Packages\*HPPrinterControl_*\AC\PRICache|*.*
 FileKey6=%LocalAppData%\Packages\*HPPrinterControl_*\AC\Temp|*.*
 FileKey7=%LocalAppData%\Packages\*HPPrinterControl_*\LocalState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\*HPPrinterControl_*\AC\INetCache\|container.dat
 
 [HP Scan and Capture *]
 LangSecRef=3031
@@ -8231,6 +8243,7 @@ FileKey4=%LocalAppData%\Packages\*HPScanandCapture_*\AC\Microsoft\CryptnetUrlCac
 FileKey5=%LocalAppData%\Packages\*HPScanandCapture_*\AC\PRICache|*.*
 FileKey6=%LocalAppData%\Packages\*HPScanandCapture_*\AC\Temp|*.*
 FileKey7=%LocalAppData%\Packages\*HPScanandCapture_*\LocalState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\*HPScanandCapture_*\AC\INetCache\|container.dat
 
 [HP Update *]
 LangSecRef=3021
@@ -8314,6 +8327,7 @@ FileKey3=%LocalAppData%\Packages\*.HyperforYouTube_*\AC\Microsoft\CryptnetUrlCac
 FileKey4=%LocalAppData%\Packages\*.HyperforYouTube_*\LocalState|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\*.HyperforYouTube_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\19120CensoredUser.HyperforYouTube_c0tqyanwsgfn6\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\*.HyperforYouTube_*\AC\INetCache\|container.dat
 
 [HyperSnap 7 *]
 LangSecRef=3021
@@ -8464,6 +8478,7 @@ FileKey8=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\Cach
 FileKey9=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\navigationHistory|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\windows.immersivecontrolpanel_cw5n1h2txyewy\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\INetCache\|container.dat
 
 [Immunet *]
 LangSecRef=3021
@@ -8841,6 +8856,7 @@ RegKey3=HKCU\Software\Microsoft\Internet Explorer\LowRegistry\DOMStorage
 RegKey4=HKCU\Software\Microsoft\Internet Explorer\Main\FeatureControl
 RegKey5=HKCU\Software\Microsoft\Internet Explorer\Recovery\PendingDelete
 RegKey6=HKCU\Software\Microsoft\Windows\CurrentVersion\Ext\Stats
+ExcludeKey1=FILE|%LocalAppData%\Packages\windows_ie_ac_*\AC\INetCache\|container.dat
 
 [Internet Explorer Vault *]
 DetectOS=6.2|
@@ -9369,6 +9385,7 @@ FileKey2=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Microsoft\CLR_v4
 FileKey3=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Microsoft\CLR_v4.0_32\UsageLogs|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\Temp|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\LocalCache|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\KasperskyLab.KasperskyNow_*\AC\INetCache\|container.dat
 
 [Kate's Video Toolkit *]
 LangSecRef=3023
@@ -9654,6 +9671,7 @@ FileKey1=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\INet*|*.*|RECUR
 FileKey2=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\PRICache|*.*
 FileKey3=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\Temp|*.*
 FileKey4=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\INetCache\|container.dat
 
 [LightScribe *]
 LangSecRef=3023
@@ -9749,10 +9767,10 @@ FileKey1=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\AppCache|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\INet*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.LockApp_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.LockApp_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.LockApp_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.LockApp_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.LockApp_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.LockApp_*\LocalState\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.LockApp_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.LockApp_*\AC\INetCache\|container.dat
 
 [LockHunter *]
 LangSecRef=3024
@@ -10040,10 +10058,10 @@ FileKey1=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\AppCache|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\INet*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\LocalState\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\INetCache\|container.dat
 
 [Marine Sharpshooter 3 *]
 Section=Games
@@ -10212,6 +10230,7 @@ FileKey7=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Temp|*.*
 FileKey8=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\Cache|*.*|RECURSE
 FileKey9=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\navigationHistory|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\INetCache\|container.dat
 
 [Media Player Classic *]
 LangSecRef=3023
@@ -10301,10 +10320,10 @@ Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Messaging_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Messaging_*\LocalCache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Messaging_*\LocalState\Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Messaging_*\TempState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Messaging_*\LocalCache|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.Messaging_*\LocalState\Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Messaging_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.Messaging_*\AC\INetCache\|container.dat
 
 [Messenger Plus! Live *]
 LangSecRef=3022
@@ -10451,6 +10470,7 @@ FileKey6=%LocalAppData%\Packages\Microsoft.Reader_*\AC\Temp|*.*
 FileKey7=%LocalAppData%\Packages\Microsoft.Reader_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Reader_8wekyb3d8bbwe\PersistedStorageItemTable\ManagedByApp
 RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Reader_8wekyb3d8bbwe\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.Reader_*\AC\INetCache\|container.dat
 
 [Microsoft Security Essentials *]
 LangSecRef=3021
@@ -10499,6 +10519,7 @@ FileKey7=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Temp|*.*
 FileKey8=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\LocalState\Cache|*.*|RECURSE
 FileKey9=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\LocalState\navigationHistory|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\INetCache\|container.dat
 
 [Midori *]
 LangSecRef=3022
@@ -10705,14 +10726,14 @@ FileKey4=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CryptnetUrlC
 FileKey5=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
 FileKey6=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\PRICache|*.*|RECURSE
 FileKey7=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalCache\PlayReady\Cache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\*Cache*|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\Database\anonymous|*.log
-FileKey12=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\PlayReady|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\TempState|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalCache\PlayReady\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\*Cache*|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\Database\anonymous|*.log
+FileKey11=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\navigationHistory|*.*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\PlayReady|*.*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneVideo_8wekyb3d8bbwe\SearchHistory\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\INetCache\|container.dat
 
 [MP3Gain *]
 LangSecRef=3023
@@ -11687,6 +11708,7 @@ FileKey3=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Microsof
 FileKey4=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\PRICache|*.*
 FileKey5=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\Temp|*.*
 FileKey6=%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\msnbc.comDigitalNetwork.msnbc.com_*\AC\INetCache\|container.dat
 
 [Neostar CMS Station Client *]
 LangSecRef=3024
@@ -11843,6 +11865,7 @@ FileKey7=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState|*.tmp|RECURSE
 FileKey8=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState\LiveTile|*.*
 FileKey9=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\4DF9E0F8.Netflix_mcm4njqhnhss8\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\INetCache\|container.dat
 
 [NETGEAR Genie *]
 LangSecRef=3024
@@ -11862,6 +11885,7 @@ FileKey2=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CLR_v
 FileKey3=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\PRICache|*.*
 FileKey4=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Temp|*.*
 FileKey5=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\INetCache\|container.dat
 
 [NetworkService *]
 LangSecRef=3025
@@ -12317,14 +12341,14 @@ Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local|msodata*.dat
-FileKey6=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\Office\16.0\WebServiceCache\AllUsers\office*client.microsoft.com|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\Office\OTele|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0|*.onecache
-FileKey9=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0\OneNote*Cache_Files|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\TempState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local|msodata*.dat
+FileKey5=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\Office\16.0\WebServiceCache\AllUsers\office*client.microsoft.com|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\Office\OTele|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0|*.onecache
+FileKey8=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\LocalState\AppData\Local\OneNote\16.0\OneNote*Cache_Files|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.Office.OneNote_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Office.OneNote_8wekyb3d8bbwe\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.Office.OneNote_*\AC\INetCache\|container.dat
 
 [OneTeam *]
 LangSecRef=3022
@@ -12359,6 +12383,7 @@ FileKey3=%LocalAppData%\Packages\Ookla.SpeedtestbyOokla_*\AC\Temp|*.*
 FileKey4=%LocalAppData%\Packages\Ookla.SpeedtestbyOokla_*\LocalState|*.tmp|RECURSE
 FileKey5=%LocalAppData%\Packages\Ookla.SpeedtestbyOokla_*\LocalState\Unity\Local.*\Analytics\ArchivedEvents\*|*.*|REMOVESELF
 FileKey6=%LocalAppData%\Packages\Ookla.SpeedtestbyOokla_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Ookla.SpeedtestbyOokla_*\AC\INetCache\|container.dat
 
 [ooVoo Chat History *]
 LangSecRef=3022
@@ -12954,10 +12979,10 @@ FileKey1=%LocalAppData%\Packages\Microsoft.People_*\AC\AppCache|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.People_*\AC\INet*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.People_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.People_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.People_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.People_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.People_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.People_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.People_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.People_*\LocalState\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.People_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.People_*\AC\INetCache\|container.dat
 
 [Perfect Registry *]
 LangSecRef=3024
@@ -13019,10 +13044,10 @@ FileKey1=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\AppCache|*.*|RECURS
 FileKey2=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\INet*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\LocalState\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsPhone_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.WindowsPhone_*\AC\INetCache\|container.dat
 
 [Phorest *]
 LangSecRef=3024
@@ -13083,10 +13108,11 @@ FileKey3=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\AC\Temp|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\LocalCache|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\LocalState|*.sqlite;*.sqlite-shm;*.sqlite-wal;*.xml
 FileKey6=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\LocalState\PhotosAppTile|*.*|RECURSE
-FileKey7=%LocalAppData%\PackagesMicrosoft.Windows.Photos_*\TempState|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Windows.Photos_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Photos_8wekyb3d8bbwe\PersistedPickerData\Microsoft.Windows.Photos_8wekyb3d8bbwe!App\DefaultSaveFileSingle
 RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Photos_8wekyb3d8bbwe\PersistedStorageItemTable\ManagedByApp
 RegKey3=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Photos_8wekyb3d8bbwe\PersistedStorageItemTable\MostRecentlyUsed
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.Windows.Photos_*\AC\INetCache\|container.dat
 
 [PhotoScissors *]
 LangSecRef=3021
@@ -13676,10 +13702,10 @@ FileKey3=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Microsoft\CLR_v4.0*|*.log|RE
 FileKey4=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey6=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\QuizUp.QuizUp_*\LocalCache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\QuizUp.QuizUp_*\LocalState\Cache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\QuizUp.QuizUp_*\TempState|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\QuizUp.QuizUp_*\LocalCache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\QuizUp.QuizUp_*\LocalState\Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\QuizUp.QuizUp_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\QuizUp.QuizUp_*\AC\INetCache\|container.dat
 
 [QupZilla Portable Cookies *]
 Section=QupZilla Portable
@@ -13896,6 +13922,7 @@ DetectFile=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_8wek
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.Studios.RecklessRacingUltimate_*\AC\INetCache\|container.dat
 
 [RecollX *]
 LangSecRef=3021
@@ -13923,6 +13950,7 @@ FileKey5=%LocalAppData%\Packages\*.RedditToGo_*\AC\Microsoft\Internet Explorer\D
 FileKey6=%LocalAppData%\Packages\*.RedditToGo_*\AC\Temp|*.*
 FileKey7=%LocalAppData%\Packages\*.RedditToGo_*\RoamingState|history.txt
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\55382ross456.RedditToGo_02dxdbb1qg9kw\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\*.RedditToGo_*\AC\INetCache\|container.dat
 
 [Reflector *]
 LangSecRef=3021
@@ -14452,10 +14480,10 @@ FileKey1=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\AppCache|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\INet*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.WindowsScan_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsScan_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsScan_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsScan_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.WindowsScan_*\LocalState\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsScan_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\INetCache\|container.dat
 
 [ScanDefrag *]
 LangSecRef=3024
@@ -14671,6 +14699,7 @@ DetectFile=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_0pp20fcewvvtj
 Default=False
 FileKey1=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+ExcludeKey1=FILE|%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\INetCache\|container.dat
 
 [Shatter *]
 Section=Games
@@ -14696,10 +14725,10 @@ FileKey1=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\AppC
 FileKey2=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\INet*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalState\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\INetCache\|container.dat
 
 [Shipping Assistant *]
 LangSecRef=3021
@@ -14728,6 +14757,7 @@ DetectFile=%LocalAppData%\Packages\Microsoft.ShuffleParty_8wekyb3d8bbwe
 Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.ShuffleParty_*\AC\INetCache\|container.dat
 
 [Signature Verification *]
 DetectOS=|5.1
@@ -14826,6 +14856,7 @@ FileKey6=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Temp|*.*
 FileKey7=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.microsoftskydrive_8wekyb3d8bbwe\PersistedPickerData\microsoft.microsoftskydrive_8wekyb3d8bbwe!Microsoft.MicrosoftSkyDrive\DefaultOpenFileMultiple|LastLocation
 RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.microsoftskydrive_8wekyb3d8bbwe\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\INetCache\|container.dat
 
 [Skype *]
 LangSecRef=3022
@@ -14863,6 +14894,7 @@ FileKey2=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Microsoft\CryptnetUrlCa
 FileKey3=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\PRICache|*.*
 FileKey4=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.SkypeApp_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\INetCache\|container.dat
 
 [SkypeAlyzer *]
 LangSecRef=3024
@@ -15225,10 +15257,10 @@ FileKey1=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\AppCache|*.
 FileKey2=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\INet*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalState\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\INetCache\|container.dat
 
 [SoundMAX *]
 LangSecRef=3023
@@ -15717,7 +15749,7 @@ FileKey11=%LocalAppData%\Packages\*Win*Store_*\LocalState\navigationHistory|*.*|
 FileKey12=%LocalAppData%\Packages\Microsoft.WindowsStore_*\LocalCache\*|*.*|RECURSE
 FileKey13=%LocalAppData%\Packages\WinStore_*\LocalState\LiveTile|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\WinStore_cw5n1h2txyewy\SearchHistory
-ExcludeKey1=FILE|%LocalAppData%\Packages\appname_*\AC\INetCache\|container.dat
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.WindowsStore_*\AC\INetCache\|container.dat
 
 [Stored Media Player Paths *]
 LangSecRef=3025
@@ -15857,10 +15889,10 @@ FileKey1=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\AppCache|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\INet*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Office.Sway_*\TempState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalState\Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Office.Sway_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\INetCache\|container.dat
 
 [Swift *]
 LangSecRef=3022
@@ -16008,6 +16040,7 @@ FileKey3=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\Microsoft\Cryptnet
 FileKey4=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\PRICache|*.*
 FileKey5=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\Temp|*.*
 FileKey6=%LocalAppData%\Packages\Microsoft.TeamCrossword_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.TeamCrossword_*\AC\INetCache\|container.dat
 
 [Team Fortress 2 *]
 Section=Games
@@ -16218,6 +16251,7 @@ FileKey4=%LocalAppData%\Packages\*TheQuran_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 FileKey5=%LocalAppData%\Packages\*TheQuran_*\AC\PRICache|*.*
 FileKey6=%LocalAppData%\Packages\*TheQuran_*\AC\Temp|*.*
 FileKey7=%LocalAppData%\Packages\*TheQuran_*\LocalState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\*TheQuran_*\AC\INetCache\|container.dat
 
 [The Rise of Atlantis *]
 Section=Games
@@ -16289,6 +16323,7 @@ FileKey2=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\AC\Microsoft\CLR_v4
 FileKey3=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\AC\Temp|*.*
 FileKey4=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\LocalState|*.tmp
 FileKey5=%LocalAppData%\Packages\Weather.TheWeatherChannel_*\TempState\Bing.Maps\Cache|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Weather.TheWeatherChannel_*\AC\INetCache\|container.dat
 
 [The Witcher *]
 Section=Games
@@ -16877,6 +16912,7 @@ FileKey1=%LocalAppData%\Packages\*Twitter_*\AC\INetC*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\*Twitter_*\AC\Microsoft\*|*.LOG|RECURSE
 FileKey3=%LocalAppData%\Packages\*Twitter_*\AC\PRICache|*.*
 FileKey4=%LocalAppData%\Packages\*Twitter_*\LocalState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\*Twitter_*\AC\INetCache\|container.dat
 
 [Two Worlds Epic Edition *]
 Section=Games
@@ -17053,6 +17089,7 @@ FileKey4=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Microsoft\Internet Explo
 FileKey5=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\PRICache|*.*
 FileKey6=%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\Temp|*.*
 FileKey7=%LocalAppData%\Packages\USATODAY.USATODAY_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\USATODAY.USATODAY_*\AC\INetCache\|container.dat
 
 [USB Disk Security *]
 LangSecRef=3024
@@ -17820,10 +17857,10 @@ FileKey4=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4
 FileKey5=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
 FileKey6=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey7=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\TempState|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\LocalCache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\LocalState\Cache|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\INetCache\|container.dat
 
 [Windows Image Acquisition *]
 LangSecRef=3025
@@ -18024,6 +18061,7 @@ FileKey9=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState|*.log;*.jp
 FileKey10=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState\bici|*.sqm
 FileKey11=%LocalAppData%\Packages\microsoft.windowsphotos_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.windowsphotos_8wekyb3d8bbwe\SearchHisto
+ExcludeKey1=FILE|%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\INetCache\|container.dat
 
 [Windows Registry Recovery *]
 LangSecRef=3024
@@ -18183,6 +18221,7 @@ FileKey7=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Temp|*.*
 FileKey8=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\LocalState\*Cache|*.*|RECURSE
 FileKey9=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\LocalState\navigationHistory|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\INetCache\|container.dat
 
 [WinMerge *]
 LangSecRef=3024
@@ -18548,12 +18587,12 @@ Default=False
 FileKey1=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalCache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalState|*.log;*.log*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalState\*Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalState\SmartGlass|*.log
-FileKey9=%LocalAppData%\Packages\Microsoft.XboxApp_*\TempState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalCache|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalState|*.log;*.log*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalState\*Cache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.XboxApp_*\LocalState\SmartGlass|*.log
+FileKey8=%LocalAppData%\Packages\Microsoft.XboxApp_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.XboxApp_*\AC\INetCache\|container.dat
 
 [Xbox Identity Provider *]
 DetectOS=10.0|
@@ -18565,10 +18604,10 @@ FileKey2=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Microsoft\C
 FileKey3=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\LocalCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\LocalState\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\TempState|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\LocalState\Cache|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\TempState|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.XboxIdentityProvider_*\AC\INetCache\|container.dat
 
 [Xbox LIVE Games *]
 LangSecRef=3031
@@ -18587,6 +18626,7 @@ FileKey9=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\LocalState\navigation
 FileKey10=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\LocalState\PlayReady|*.*|RECURSE
 FileKey11=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxLIVEGames_8wekyb3d8bbwe\SearchHistory
+ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\AC\INetCache\|container.dat
 
 [Xenocode Sandbox *]
 LangSecRef=3021


### PR DESCRIPTION
**SMalik:**

This exclude key should be added into each Windows Store app entry.
ExcludeKey1=FILE|%LocalAppData%\\Packages\\appname_\*\\AC\\INetCache\\|container.dat

This location should be removed from every Windows Store app entry. Store apps that use login info store that info here. Not all Store apps have this location.
%LocalAppData%\\Packages\\appname_\*\\AC\TokenBroker\\Cache|\*.\*|RECURSE 