### PR TITLE
Update Winapp2.ini

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1003,13 +1003,7 @@ FileKey2=%AppData%\Thunderbird\Profiles\*|webappsstore.sqlite
 
 ; End of Thunderbird entries.
 
-[.NET Framework Isolated Storage *]
-LangSecRef=3025
-Detect=HKLM\Software\Microsoft\.NETFramework
-Default=False
-FileKey1=%LocalAppData%\IsolatedStorage|*.*|RECURSE
-
-[.NET Framework Temps *]
+[.NET Framework *]
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\.NETFramework
 Default=False
@@ -1020,6 +1014,12 @@ FileKey4=%WinDir%\Microsoft.NET\Framework*\*\Temporary ASP.NET Files|*.*|REMOVES
 FileKey5=%WinDir%\Microsoft.NET\Framework*\v4.0.30319\SetupCache|*.*|RECURSE
 FileKey6=%WinDir%\System32\URTTemp|*.*|RECURSE
 RegKey1=HKCU\Software\Microsoft\.NETFramework\SQM\Apps
+
+[.NET Framework Isolated Storage *]
+LangSecRef=3025
+Detect=HKLM\Software\Microsoft\.NETFramework
+Default=False
+FileKey1=%LocalAppData%\IsolatedStorage|*.*|RECURSE
 
 [.NET Reflector *]
 LangSecRef=3021
@@ -6757,12 +6757,11 @@ DetectFile=%AppData%\FastStone\FSC
 Default=False
 FileKey1=%AppData%\FastStone\FSC|*.bak;fsc.db
 FileKey2=%LocalAppData%\FastStone\FSC|fsc.db
-RegKey1=HKCU\Software\FastStone|_GrbId
-RegKey2=HKCU\Software\FastStone|_LastClipPlayed
-RegKey3=HKCU\Software\FastStone|_LastRecordingFileName
-RegKey4=HKCU\Software\FastStone\APP.FSRecorder\Global|_GrbId
-RegKey5=HKCU\Software\FastStone\APP.FSRecorder\Global|_LastClipPlayed
-RegKey6=HKCU\Software\FastStone\APP.FSRecorder\Global|_LastRecordingFileName
+RegKey1=HKCU\Software\FastStone|_LastClipPlayed
+RegKey2=HKCU\Software\FastStone|_LastRecordingFileName
+RegKey3=HKCU\Software\FastStone\APP.FSRecorder\Global|_GrbId
+RegKey4=HKCU\Software\FastStone\APP.FSRecorder\Global|_LastClipPlayed
+RegKey5=HKCU\Software\FastStone\APP.FSRecorder\Global|_LastRecordingFileName
 
 [FastStone Image Viewer *]
 LangSecRef=3021
@@ -18645,8 +18644,7 @@ Default=False
 FileKey1=%AppData%\XnView\cache|*.db
 FileKey2=%AppData%\XnViewMP|*.db;category.bak
 FileKey3=%LocalAppData%\VirtualStore\Program Files*\XnViewMP|category.bak;*.db
-FileKey4=%ProgramFiles%\XnView|category.bak
-FileKey5=%ProgramFiles%\XnViewMP|category.bak;*.db
+FileKey4=%ProgramFiles%\XnViewMP|category.bak;*.db
 
 [XPhone *]
 LangSecRef=3021


### PR DESCRIPTION
Minor fixes.

**[.NET Framework Temps \*]** 
Renamed back to [.NET Framework \*].

**[FastStone Capture \*]**
Removed RegKey1 because it's in CCleaner and "Removed entries.ini" already.

**[XnView \*]**
Removed FileKey4 because it's in CCleaner and "Removed entries.ini" already.