### PR TITLE
Update Removed entries.ini

### DIFF
--- a/Non-CCleaner/Removed entries.ini
+++ b/Non-CCleaner/Removed entries.ini
@@ -517,13 +517,13 @@ FileKey5=%ProgramFiles%\Wondershare Video Converter Ultimate\TempThumbDir|*.*|RE
 LangSecRef=3023
 Detect=HKLM\Software\Wondershare\Wondershare Video Converter Pro
 Default=False
-FileKey1=%AllUsersProfile%\Documents\Wondershare|*.*|REMOVESELF
-FileKey2=%CommonAppData%\Wondershare Video Converter*|*.dat.bak
-FileKey3=%CommonAppData%\Wondershare Video Converter*\Temp*Dir|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Wondershare\Video Converter*\Log|*.*|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Wondershare Video Converter*|*.dat.bak
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Wondershare Video Converter*\Temp*Dir|*.*|RECURSE
-FileKey7=%ProgramFiles%\Wondershare\Video Converter*\Log|*.*|REMOVESELF
+FileKey1=%CommonAppData%\Wondershare Video Converter*|*.dat.bak
+FileKey2=%CommonAppData%\Wondershare Video Converter*\Temp*Dir|*.*|RECURSE
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Wondershare\Video Converter*\Log|*.*|REMOVESELF
+FileKey4=%LocalAppData%\VirtualStore\ProgramData\Wondershare Video Converter*|*.dat.bak
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\Wondershare Video Converter*\Temp*Dir|*.*|RECURSE
+FileKey6=%ProgramFiles%\Wondershare\Video Converter*\Log|*.*|REMOVESELF
+FileKey7=%Public%\Documents\Wondershare|*.*|REMOVESELF
 
 [Xilisoft Video Converter Extras *]
 LangSecRef=3023

--- a/Non-CCleaner/Removed entries.ini
+++ b/Non-CCleaner/Removed entries.ini
@@ -9,12 +9,61 @@ Detect=HKCU\Software\4Sync
 Default=False
 FileKey1=%AppData%\4Sync|*.log
 
+[Adobe CC Extras *]
+LangSecRef=3023
+DetectFile=%LocalAppData%\Adobe\Creative Cloud Libraries
+Default=False
+FileKey1=%LocalAppData%\Adobe\Creative Cloud Libraries\Logs|*.*
+
+[Adobe CS Extras *]
+LangSecRef=3023
+DetectFile=%AppData%\Adobe\CS*ServiceManager
+Default=False
+FileKey1=%AppData%\Adobe\CS*ServiceManager\Cache|*.*|RECURSE
+FileKey2=%AppData%\Adobe\CS*ServiceManager\Logs|*.*|RECURSE
+FileKey3=%AppData%\com.adobe.downloadassistant.AdobeDownloadAssistant|*.log|RECURSE
+FileKey4=%Documents%\Adobe\Adobe Media Encoder\6.0.0|*.log
+FileKey5=%LocalAppData%\Akamai\Cache|*.*
+FileKey6=%LocalAppData%\Akamai\Logs|*.*|RECURSE
+
 [Adobe Dreamweaver Extras *]
 LangSecRef=3023
 Detect=HKCU\Software\Adobe\MediaBrowser\MRU\Dreamweaver
 Default=False
+FileKey1=%AppData%\Adobe\Dreamweaver CS*\*\Configuration\logs|*.*
 RegKey1=HKCU\Software\Adobe\Dreamweaver CS6\Recent File List
 RegKey2=HKCU\Software\Adobe\MediaBrowser\MRU\Dreamweaver\FileList
+
+[Adobe My Digital Editions Extras *]
+LangSecRef=3023
+DetectFile=%Documents%\My Digital Editions
+Default=False
+FileKey1=%Documents%\My Digital Editions|import.log
+
+[Adobe Photoshop Extras *]
+LangSecRef=3023
+Detect=HKCU\Software\Adobe\Photoshop
+Default=False
+FileKey1=%AppData%\Adobe\Adobe Photoshop*\Generator\logs|*.*
+FileKey2=%AppData%\Adobe\Bridge*\Cache\Thumbnails|*.*|RECURSE
+FileKey3=%AppData%\Adobe\CameraRaw\Cache|*.*|RECURSE
+FileKey4=%AppData%\Adobe\FileBrowser\PhotoshopCS|*.*
+FileKey5=%AppData%\Adobe\Photoshop Album\*.*|Logse*.txt
+FileKey6=%Pictures%|.BridgeSort|RECURSE
+RegKey1=HKCU\Software\Adobe\Photoshop\5.5\VisitedDirs
+RegKey2=HKCU\Software\Adobe\Photoshop\90.0\VisitedDirs
+
+[Adobe Premiere Pro Extras *]
+LangSecRef=3023
+Detect1=HKCU\Software\Adobe\Premiere Pro\2.0
+Detect2=HKCU\Software\Adobe\Premiere Pro\7.0
+Detect3=HKLM\Software\Adobe\Premiere Pro\7.0
+Default=False
+FileKey1=%Documents%\Adobe\Premiere Pro\2.0\Adobe Premiere Pro Preview Files|*.*|RECURSE
+FileKey2=%Documents%\Adobe\Premiere Pro\2.0\Encoded Files|*.*
+FileKey3=%Documents%\Adobe\Premiere Pro\2.0\Media Cache Files|*.*
+FileKey4=%LocalAppData%\VirtualStore\Program Files*\Adobe\Adobe Premiere Pro CC\cache|*-*-*.cache
+FileKey5=%LocalAppData%\VirtualStore\Program Files*\Adobe\Adobe Premiere Pro CC\Required\data\cache|*.pcache
 
 [AIM Extras *]
 LangSecRef=3022

--- a/Non-CCleaner/Removed entries.ini
+++ b/Non-CCleaner/Removed entries.ini
@@ -22,7 +22,7 @@ Default=False
 FileKey1=%AppData%\Adobe\CS*ServiceManager\Cache|*.*|RECURSE
 FileKey2=%AppData%\Adobe\CS*ServiceManager\Logs|*.*|RECURSE
 FileKey3=%AppData%\com.adobe.downloadassistant.AdobeDownloadAssistant|*.log|RECURSE
-FileKey4=%Documents%\Adobe\Adobe Media Encoder\6.0.0|*.log
+FileKey4=%Documents%\Adobe\Adobe Media Encoder\*|*.log
 FileKey5=%LocalAppData%\Akamai\Cache|*.*
 FileKey6=%LocalAppData%\Akamai\Logs|*.*|RECURSE
 
@@ -52,18 +52,6 @@ FileKey5=%AppData%\Adobe\Photoshop Album\*.*|Logse*.txt
 FileKey6=%Pictures%|.BridgeSort|RECURSE
 RegKey1=HKCU\Software\Adobe\Photoshop\5.5\VisitedDirs
 RegKey2=HKCU\Software\Adobe\Photoshop\90.0\VisitedDirs
-
-[Adobe Premiere Pro Extras *]
-LangSecRef=3023
-Detect1=HKCU\Software\Adobe\Premiere Pro\2.0
-Detect2=HKCU\Software\Adobe\Premiere Pro\7.0
-Detect3=HKLM\Software\Adobe\Premiere Pro\7.0
-Default=False
-FileKey1=%Documents%\Adobe\Premiere Pro\2.0\Adobe Premiere Pro Preview Files|*.*|RECURSE
-FileKey2=%Documents%\Adobe\Premiere Pro\2.0\Encoded Files|*.*
-FileKey3=%Documents%\Adobe\Premiere Pro\2.0\Media Cache Files|*.*
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Adobe\Adobe Premiere Pro CC\cache|*-*-*.cache
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Adobe\Adobe Premiere Pro CC\Required\data\cache|*.pcache
 
 [AIM Extras *]
 LangSecRef=3022


### PR DESCRIPTION
**Suggestion:**

Added removed Adobe entries: [Adobe CC \*], [Adobe CS \*], [Adobe Dreamweaver \*], [Adobe My Digital Editions \*], [Adobe Photoshop \*] and [Adobe Premiere Pro \*].

It seems that the entries are just outdated. Shouldn't we add them to the "Removed entries.ini" file?