### PR TITLE
Update Winapp2.ini

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -7481,7 +7481,7 @@ ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\INetCache\|con
 LangSecRef=3021
 Detect=HKCU\Software\Novell\Messenger
 Default=False
-FileKey1=%LocalAppData%\Novell\GroupWise Messenger\history\%username%|*.*
+FileKey1=%LocalAppData%\Novell\GroupWise Messenger\history\%UserName%|*.*
 
 [Growl *]
 LangSecRef=3024
@@ -7871,9 +7871,7 @@ FileKey7=%LocalAppData%\VirtualStore\Program Files*\HPQ\Shared\Sierra Wireless|*
 FileKey8=%LocalAppData%\VirtualStore\ProgramData|hpzinstall.log
 FileKey9=%LocalAppData%\VirtualStore\ProgramData\Hewlett-Packard\HP*\Logs|*.*|RECURSE
 FileKey10=%ProgramFiles%\HPQ\Shared\Sierra Wireless|*.log|RECURSE
-FileKey11=%SystemDrive%\Documents and Settings\All Users\Application Data|hpzinstall.log
-FileKey12=%SystemDrive%\hp\bin\logs|*.log
-FileKey13=%SystemDrive%\Users\All Users|hpzinstall.log
+FileKey11=%SystemDrive%\hp\bin\logs|*.log
 
 [HP MediaSmart Photo *]
 LangSecRef=3023

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -7841,8 +7841,7 @@ FileKey3=%LocalAppData%\VirtualStore\Program Files*\HP\Temp|*.*|RECURSE
 FileKey4=%LocalAppData%\VirtualStore\ProgramData\HP\Installer\Temp|*.*
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\HP\Temp|*.*
 FileKey6=%ProgramFiles%\HP\Temp|*.*|RECURSE
-FileKey7=%SystemDrive%\Users\All Users\HP\Installer\Temp|*.*
-FileKey8=%WinDir%|*.dat.temp
+FileKey7=%WinDir%|*.dat.temp
 
 [HP Installation Files *]
 LangSecRef=3024


### PR DESCRIPTION
Minor fixes.

[HP Install Temps \*] - Removed FileKey7 because it is covered by FileKey1 already.
[HP Logs \*] - Removed FileKeys11+13 because they are covered by FileKey3 already.

Windows XP: 
%CommonAppData% = "%SystemDrive%\Documents and Settings\All Users\Application Data"

Windows Vista, 7, 8, 10: 
"%SystemDrive%\Users\All Users" is just a junction to "%SystemDrive%\ProgramData".
%CommonAppData% = "%SystemDrive%\ProgramData"