### PR TITLE
Fix REMOVESELF used instead of RECURSE

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -3496,7 +3496,7 @@ Section=Games
 DetectFile=%UserProfile%\BrawlhallaReplays
 Default=False
 Warning=You will delete your saved replays!
-FileKey1=%UserProfile%\BrawlhallaReplays|*.replay|REMOVESELF
+FileKey1=%UserProfile%\BrawlhallaReplays|*.replay|RECURSE
 
 [Breevy Backups *]
 LangSecRef=3021
@@ -6510,8 +6510,8 @@ Section=Games
 Detect=HKLM\Software\SCS Software
 Default=False
 FileKey1=%Documents%\My Games\FarmingSimulator*|*.txt
-FileKey2=%Documents%\My Games\FarmingSimulator*\pdlc*|*.dlc|REMOVESELF
-FileKey3=%Documents%\My Games\FarmingSimulator*\shader_cache|*.shc;*.xml|REMOVESELF
+FileKey2=%Documents%\My Games\FarmingSimulator*\pdlc*|*.dlc|RECURSE
+FileKey3=%Documents%\My Games\FarmingSimulator*\shader_cache|*.shc;*.xml|RECURSE
 
 [Farming Simulator Old Autosaves *]
 Section=Games
@@ -8381,7 +8381,7 @@ LangSecRef=3024
 Detect1=HKCU\Software\Intel
 Detect2=HKLM\Software\Intel
 Default=False
-FileKey1=%CommonAppData%\intel|*.log|REMOVESELF
+FileKey1=%CommonAppData%\intel|*.log|RECURSE
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Intel\InfInst|*.*|REMOVESELF
 FileKey3=%ProgramFiles%\Intel\InfInst|*.*|REMOVESELF
 FileKey4=%SystemDrive%\Intel\Logs|*.log
@@ -17013,10 +17013,10 @@ LangSecRef=3021
 Detect=HKCU\Software\VSO\Blindwrite
 Default=False
 FileKey1=%AppData%|pcouffin.log;ezplay.log
-FileKey2=%AppData%\VSO|*.log|REMOVESELF
-FileKey3=%CommonAppData%\VSO\Blindwrite\*|*.log|REMOVESELF
-FileKey4=%Documents%\PcSetup|*.log|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\VSO\Blindwrite\*|*.log|REMOVESELF
+FileKey2=%AppData%\VSO|*.log|RECURSE
+FileKey3=%CommonAppData%\VSO\Blindwrite\*|*.log|RECURSE
+FileKey4=%Documents%\PcSetup|*.log|RECURSE
+FileKey5=%LocalAppData%\VirtualStore\ProgramData\VSO\Blindwrite\*|*.log|RECURSE
 FileKey6=%UserProfile%|timestamp.txt
 
 [VSO Converter *]
@@ -17027,12 +17027,12 @@ Detect3=HKCU\Software\VSO\VSO Video Converter
 Default=False
 FileKey1=%AppData%|pcouffin.log
 FileKey2=%CommonAppData%\VSO|*.cache
-FileKey3=%CommonAppData%\VSO\*Converter*\*\Log|*.log;*.crashlist|REMOVESELF
+FileKey3=%CommonAppData%\VSO\*Converter*\*\Log|*.log;*.crashlist|RECURSE
 FileKey4=%CommonAppData%\VSO\vsothumbs|*.*|REMOVESELF
-FileKey5=%Documents%\PcSetup|*.log|REMOVESELF
+FileKey5=%Documents%\PcSetup|*.log|RECURSE
 FileKey6=%LocalAppData%\VirtualStore\Program Files*\VSO\*Converter*\*|*.txt
 FileKey7=%LocalAppData%\VirtualStore\ProgramData\VSO|*.cache
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\VSO\*Converter*\*\Log|*.log;*.crashlist|REMOVESELF
+FileKey8=%LocalAppData%\VirtualStore\ProgramData\VSO\*Converter*\*\Log|*.log;*.crashlist|RECURSE
 FileKey9=%LocalAppData%\VirtualStore\ProgramData\VSO\vsothumbs|*.*|REMOVESELF
 FileKey10=%ProgramFiles%\VSO\*Converter*\*|*.txt
 RegKey1=HKCU\Software\VSO\Blu-ray Converter Ultimate\2|BDMVInputFolders
@@ -17075,9 +17075,9 @@ LangSecRef=3021
 Detect=HKCU\Software\VSO\CopyTo
 Default=False
 FileKey1=%AppData%|pcouffin.log;ezplay.log
-FileKey2=%AppData%\VSO|*.log|REMOVESELF
+FileKey2=%AppData%\VSO|*.log|RECURSE
 FileKey3=%CommonAppData%\VSO|*.cache;*.crashlist;*.log;*.vsothumb|RECURSE
-FileKey4=%Documents%\PcSetup|*.log|REMOVESELF
+FileKey4=%Documents%\PcSetup|*.log|RECURSE
 FileKey5=%LocalAppData%\VirtualStore\ProgramData\VSO|*.cache;*.crashlist;*.log;*.vsothumb|RECURSE
 FileKey6=%UserProfile%|timestamp.txt
 
@@ -18456,11 +18456,11 @@ Detect=HKCU\Software\Zend\ZendStudio
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0|*.html
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0|*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0\docs|*.txt|REMOVESELF
+FileKey3=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0\docs|*.txt|RECURSE
 FileKey4=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0\features|*.html|RECURSE
 FileKey5=%ProgramFiles%\Zend\Zend Studio 10.0.0|*.html
 FileKey6=%ProgramFiles%\Zend\Zend Studio 10.0.0|*.log|RECURSE
-FileKey7=%ProgramFiles%\Zend\Zend Studio 10.0.0\docs|*.txt|REMOVESELF
+FileKey7=%ProgramFiles%\Zend\Zend Studio 10.0.0\docs|*.txt|RECURSE
 FileKey8=%ProgramFiles%\Zend\Zend Studio 10.0.0\features|*.html|RECURSE
 
 [Zer0 *]


### PR DESCRIPTION
For all entries that match `*.[extension]|REMOVESELF`, we should be able to assume that it is supposed to have `RECURSE` instead, since names of directories should not contain an extension.