### PR TITLE
Update Winapp3.ini

### DIFF
--- a/Winapp3/Beta/Winapp3.ini
+++ b/Winapp3/Beta/Winapp3.ini
@@ -336,6 +336,7 @@ FileKey1=%ProgramFiles%\Mozilla*|*.chk|RECURSE
 Section=Dangerous
 Detect=HKLM\Software\Microsoft
 Default=False
+Warning=This will delete Solidity scripts also.
 FileKey1=%SystemDrive%|*.SOL|RECURSE
 ExcludeKey1=FILE|%SystemDrive%\*\|Fontmap.Sol
 
@@ -478,7 +479,7 @@ FileKey4=%ProgramFiles%\Nero\Nero*\AudioPluginMgr|COPYING.FLAC;COPYING.LGPL;COPY
 FileKey5=%ProgramFiles%\Nero\Nero*\SMC|COPYING.FLAC;COPYING.LGPL;COPYING.XIPH;README
 FileKey6=%ProgramFiles%\Nero\Update|*.txt|RECURSE
 
-[Nexus Mod Manager old configs *]
+[Nexus Mod Manager Old Configs *]
 Section=Dangerous
 DetectFile=%LocalAppData%\Black_Tree_Gaming\NexusClient.exe*
 Default=False
@@ -638,7 +639,7 @@ Section=Dangerous
 Detect1=HKCU\Software\Samsung\Kies2.0
 Detect2=HKCU\Software\Samsung\Kies3.0
 Default=False
-FileKey1=%Documents%\samsung\Kies\*PIMS|*.*|RECURSE
+FileKey1=%Documents%\samsung\Kies*\PIMS|*.*|RECURSE
 
 [Samsung Kies Podcast *]
 Section=Dangerous

--- a/Winapp3/Beta/Winapp3.ini
+++ b/Winapp3/Beta/Winapp3.ini
@@ -1,5 +1,5 @@
-; Version: 180416
-; # of entries: 101
+; Version: 180418
+; # of entries: 106
 ;
 ; Winapp3 is fully licensed under the CC-BY-SA-4.0 license agreement.
 ; If you plan on modifying and/or distrubuting the file in your own program, please ask first.
@@ -32,13 +32,24 @@ FileKey2=%ProgramFiles%\K-Lite Codec Pack\MPC-HC64\Lang|*.*|REMOVESELF
 
 [Malwarebytes Anti-Malware Languages *]
 Section=Language Files
-Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\mbam.exe
+Detect1=HKCU\Software\Malwarebytes
+Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\mbam.exe
 Default=False
 Warning=This will delete all languages excluding English.
 FileKey1=%ProgramFiles%\Malwarebytes' Anti-Malware\Languages|*.lng
 FileKey2=%ProgramFiles%\Malwarebytes Anti-Malware\Languages|*.qm
+FileKey3=%ProgramFiles%\Malwarebytes\Anti-Malware\Languages|*.qm
 ExcludeKey1=FILE|%ProgramFiles%\Malwarebytes' Anti-Malware\Languages\|english.lng
 ExcludeKey2=FILE|%ProgramFiles%\Malwarebytes Anti-Malware\Languages\|lang_en.qm
+ExcludeKey3=PATH|%ProgramFiles%\Malwarebytes\Anti-Malware\Languages\|lang_en_*.qm
+
+[Revo Uninstaller Pro Languages *]
+Section=Language Files
+Detect=HKCU\Software\VS Revo Group\Revo Uninstaller Pro
+Default=False
+Warning=This will delete all language files excluding English.
+FileKey1=%ProgramFiles%\VS Revo Group\Revo Uninstaller Pro\lang|*.ini
+ExcludeKey1=FILE|%ProgramFiles%\VS Revo Group\Revo Uninstaller Pro\lang\|english.ini
 
 [Speccy Languages *]
 Section=Language Files
@@ -77,15 +88,22 @@ Default=False
 Warning=This will prevent a repair installation. You have to download the installer for a reinstallation.
 FileKey1=%ProgramFiles%\Adobe\Acrobat*\Setup Files|*.*|REMOVESELF
 
+[Adobe Media Cache *]
+Section=Dangerous
+DetectFile=%AppData%\Adobe\Common\Media Cache
+Default=False
+FileKey1=%AppData%\Adobe\Common\* Cache*|*.*|RECURSE
+FileKey2=%AppData%\Adobe\Common\Peak Files|*.*|RECURSE
+
 [Adobe Reader Setup Files *]
 Section=Dangerous
 Detect=HKLM\SOFTWARE\Adobe\Acrobat Reader
 Default=False
 Warning=This will prevent a repair installation. You have to download the installer for a reinstallation.
-FileKey1=%CommonAppData%\Adobe\ARM\Reader*|*.*|RECURSE
-FileKey2=%CommonAppData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AA1000000001}|*.*|RECURSE
-FileKey3=%CommonAppData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AB0000000001}|*.*|RECURSE
-FileKey4=%CommonAppData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AC0F074E4100}|*.*|RECURSE
+FileKey1=%CommonAppData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AA1000000001}|*.*|RECURSE
+FileKey2=%CommonAppData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AB0000000001}|*.*|RECURSE
+FileKey3=%CommonAppData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AC0F074E4100}|*.*|RECURSE
+FileKey4=%ProgramFiles%\Adobe\*Reader*\Setup Files|*.*|REMOVESELF
 
 [Agent NewsReader *]
 Section=Dangerous
@@ -301,6 +319,13 @@ Detect=HKLM\SOFTWARE\Microsoft\Exchange
 Default=False
 FileKey1=%WinDir%|*.JRS|RECURSE
 
+[Explorer MountPoints2 *]
+Section=Dangerous
+Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer
+Default=False
+Warning=Can cause issues with Windows 8 System Drive Icon.
+RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\MountPoints2
+
 [Firefox Recovered File Fragments *]
 Section=Dangerous
 SpecialDetect=DET_MOZILLA
@@ -312,13 +337,7 @@ Section=Dangerous
 Detect=HKLM\Software\Microsoft
 Default=False
 FileKey1=%SystemDrive%|*.SOL|RECURSE
-
-[Flash SOL Files *]
-LangSecRef=3022
-Detect=HKLM\Software\Microsoft
-Default=False
-FileKey1=%ProgramFiles%\gs|*.Sol
-FileKey2=%ProgramFiles%\PDF24\gs\lib|*.Sol
+ExcludeKey1=FILE|%SystemDrive%\*\|Fontmap.Sol
 
 [Future Technology E-dice Dongle Driver Installation Files *]
 Section=Dangerous
@@ -404,7 +423,7 @@ Default=False
 Warning=This entry cleans all text documents, which removes unnecessary files for most people. Don't run, if you need them.
 FileKey1=%ProgramFiles%\Audacity\help\manual|*.*|RECURSE
 FileKey2=%ProgramFiles%\OpenOffice*\program\*\lib\idlelib|CREDITS.txt;NEWS.txt;Todo.txt
-FileKey3=%SystemDrive%|*about*.doc;*about*.rtf;*about*.txt;*Acknowledgements*.rtf;*Acknowledgements*.txt;*agreement*.rtf;*agreement*.txt;*apache2.0*.txt;*bzip2*.txt;*change*.doc;*change*.txt;*changelog*.txt;*contents*.rtf;*contents*.txt;*copying*.doc;*copying*.txt;*copyright*.doc;*copyright*.rtf;*copyright*.txt;*cpl1.0*.txt;*epl*.txt;*eula*.doc;*eula*.html;*eula*.txt;*faq*.htm;*faq*.rtf;*faq*.txt;*gnu*.doc;*gnu*.rtf;*gnu*.txt;*gpl*.doc;*gpl*.rtf;*gpl*.txt;*help*.doc;*help*.htm;*help*.rtf;*help*.txt;*History.txt;*hypersonic*.txt;*icu4j*.txt;*libcurl*.txt;*LICENCE*.rtf;*LICENCE*.txt;*LICENSE*.rtf;*license*.txt;*liesdas*.doc;*liesdas*.rtf;*liesdas*.txt;*liesmich*.doc;*liesmich*.rtf;*liesmich*.txt;*LIZENS*.doc;*LIZENS*.rtf;*lizens*.txt;*Lizenz*.doc;*Lizenz*.rtf;*Lizenz*.txt;*loaderbinarylegal*.txt;*notice.txt;*NSIS*.txt;*openssl*.txt;*readme*.htm;*Readme*.htm;*readme*.rtf;*readme*.txt;*release*.rtf;*release*.txt;*THIRDPARTY*.doc;*THIRDPARTY*.rtf;*THIRDPARTY*.txt;*THIRDPARTYLICENSE.txt;*THIRDPARTYLICENSEREADME*.htm;*THIRDPARTYLICENSEREADME*.rtf;*THIRDPARTYLICENSEREADME*.txt;*THIRDPARTYLICENSEREADME.txt;*ThirdPartyNotices*.doc;*ThirdPartyNotices*.rtf;*ThirdPartyNotices*.txt;*whatsnew*.doc;*whatsnew*.rtf;*whatsnew*.txt;*xstream*.txt;libxml2.txt;release*notes*.txt;third-party_attributions.txt|RECURSE
+FileKey3=%SystemDrive%|*about*.doc;*about*.rtf;*about*.txt;*Acknowledgements*.rtf;*Acknowledgements*.txt;*agreement*.rtf;*agreement*.txt;*apache2.0*.txt;*bzip2*.txt;*change*.doc;*change*.txt;*changelog*.txt;*contents*.rtf;*contents*.txt;*copying*.doc;*copying*.txt;*copyright*.doc;*copyright*.rtf;*copyright*.txt;*cpl1.0*.txt;*epl*.txt;*eula*.doc;*eula*.html;*eula*.txt;*faq*.htm;*faq*.rtf;*faq*.txt;*gnu*.doc;*gnu*.rtf;*gnu*.txt;*gpl*.doc;*gpl*.rtf;*gpl*.txt;*help*.doc;*help*.htm;*help*.rtf;*help*.txt;*History.txt;*hypersonic*.txt;*icu4j*.txt;*libcurl*.txt;*LICENCE*.rtf;*LICENCE*.txt;*LICENSE*.rtf;*license*.txt;*liesdas*.doc;*liesdas*.rtf;*liesdas*.txt;*liesmich*.doc;*liesmich*.rtf;*liesmich*.txt;*LIZENS*.doc;*LIZENS*.rtf;*lizens*.txt;*Lizenz*.doc;*Lizenz*.rtf;*Lizenz*.txt;*loaderbinarylegal*.txt;*notice.txt;*NSIS*.txt;*openssl*.txt;*readme*.htm;*readme*.rtf;*readme*.txt;*release*.rtf;*release*.txt;*THIRDPARTY*.doc;*THIRDPARTY*.rtf;*THIRDPARTY*.txt;*THIRDPARTYLICENSE.txt;*THIRDPARTYLICENSEREADME*.htm;*THIRDPARTYLICENSEREADME*.rtf;*THIRDPARTYLICENSEREADME*.txt;*ThirdPartyNotices*.doc;*ThirdPartyNotices*.rtf;*ThirdPartyNotices*.txt;*whatsnew*.doc;*whatsnew*.rtf;*whatsnew*.txt;*xstream*.txt;libxml2.txt;release*notes*.txt;third-party_attributions.txt|RECURSE
 
 [Local Install Source MSOCache *]
 Section=Dangerous
@@ -458,16 +477,6 @@ FileKey3=%CommonAppData%\Nero|*.log|RECURSE
 FileKey4=%ProgramFiles%\Nero\Nero*\AudioPluginMgr|COPYING.FLAC;COPYING.LGPL;COPYING.XIPH;README
 FileKey5=%ProgramFiles%\Nero\Nero*\SMC|COPYING.FLAC;COPYING.LGPL;COPYING.XIPH;README
 FileKey6=%ProgramFiles%\Nero\Update|*.txt|RECURSE
-RegKey1=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Recent File List
-RegKey2=HKCU\Software\Nero\Nero 12\Nero Burning ROM\Settings|NeroCompilation
-RegKey3=HKCU\Software\Nero\Nero 12\Nero CoverDesigner\Recent File List
-RegKey4=HKCU\Software\Nero\Nero 12\Nero Express\General|OFDLastAudioDir
-RegKey5=HKCU\Software\Nero\Nero 12\Nero Express\General|OFDLastISODir
-RegKey6=HKCU\Software\Nero\Nero 12\Nero Express\General|OFDLastVideoDVDKey
-RegKey7=HKCU\Software\Nero\Nero 12\Nero Express\Recent File List
-RegKey8=HKCU\Software\Nero\Nero 12\Nero Express\Settings|BrowserDir
-RegKey9=HKCU\Software\Nero\Nero 12\Nero Express\Settings|WorkingDir
-RegKey10=HKCU\Software\Nero\Nero 12\Nero WaveEditor\Recent File List
 
 [Nexus Mod Manager old configs *]
 Section=Dangerous
@@ -518,14 +527,14 @@ FileKey1=%WinDir%\Prefetch|*.*
 
 [Project64 2.X Cache *]
 Section=Dangerous
-DetectFile=%ProgramFiles%\Project64 2*
+DetectFile=%ProgramFiles%\Project64 2.*
 Default=False
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Project64 2.*\Config|Project64.cache3;Project64.zcache
 FileKey2=%ProgramFiles%\Project64 2.*\Config|Project64.cache3;Project64.zcache
 
 [Project64 2.X Saves *]
 Section=Dangerous
-DetectFile=%ProgramFiles%\Project64 2*
+DetectFile=%ProgramFiles%\Project64 2.*
 Default=False
 Warning=This will delete your save files. Don't use if you need them.
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Project64 2.*\Save|*.*
@@ -533,11 +542,27 @@ FileKey2=%ProgramFiles%\Project64 2.*\Save|*.*
 
 [Project64 2.X Screenshots *]
 Section=Dangerous
-DetectFile=%ProgramFiles%\Project64 2*
+DetectFile=%ProgramFiles%\Project64 2.*
 Default=False
 Warning=This will delete your screenshots. Don't use if you need them.
 FileKey1=%LocalAppData%\VirtualStore\Program Files*\Project64 2.*\Screenshots|*.*
 FileKey2=%ProgramFiles%\Project64 2.*\Screenshots|*.*
+
+[QuickLaunch *]
+DetectOS=6.1|
+Section=Dangerous
+Detect=HKCU\Software\Microsoft\Internet Explorer
+Default=False
+Warning=This will remove all of your QuickLaunch icons.
+FileKey1=%AppData%\Microsoft\Internet Explorer\Quick Launch|*.lnk
+
+[QuickLaunch ImplicitAppShortcuts *]
+DetectOS=6.1|
+Section=Dangerous
+Detect=HKCU\Software\Microsoft\Internet Explorer
+Default=False
+Warning=This will break pinned configuration shortcuts (like control panel).
+FileKey1=%AppData%\Microsoft\Internet Explorer\Quick Launch\User Pinned\ImplicitAppShortcuts|*.*|RECURSE
 
 [ReadyBoot Trace Files *]
 Section=Dangerous
@@ -655,6 +680,14 @@ Detect=HKLM\SOFTWARE\Wow6432Node
 Default=False
 Warning=Only use if you use the 64-bit version.
 FileKey1=%ProgramFiles%\Speccy|Speccy.exe
+
+[Sticky Notes *]
+Section=Dangerous
+Detect=HKLM\Software\Classes\StickyNotes
+Default=False
+Warning=Selecting this will also delete all sticky notes currently in use.
+FileKey1=%AppData%\Microsoft\Sticky Notes|*.snt
+FileKey2=%UserProfile%\Searches|Sticky Notes (Windows Sticky Notes).searchconnector-ms
 
 [Task Scheduler Job Files *]
 Section=Dangerous


### PR DESCRIPTION
- Added new entries.
- Revised entries.
- Added ExcludeKey to [Flash Local Shared Object Files \*], to protect GhostScript file.
- Removed [Flash SOL Files \*], because it is covered by [Flash Local Shared Object Files \*].
- Removed RegKeys from [Nero More \*], because they are in CCleaner already [Nero 12 Platinum HD Suite].