### PR TITLE
Update Winapp2.ini

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -142,6 +142,13 @@ FileKey12=%SystemDrive%\first_launch|*.*|REMOVESELF
 ExcludeKey1=FILE|%LocalAppData%\COMODO\Dragon\User Data\|First Run
 ExcludeKey2=FILE|%LocalAppData%\COMODO\Dragon\User Data\|Local State
 
+[Downloads Folder *]
+LangSecRef/Section=3025
+Warning=This will clear all the content of the default web browser downloads folder, including all old downloaded files.
+Default=False
+FileKey1=%UserProfile%\Downloads\|*.*|REMOVESELF
+FileKey2=%UserProfile%\Downloads\|*.*|RECURSE
+
 [Extensions Databases *]
 LangSecRef=3029
 SpecialDetect=DET_CHROME


### PR DESCRIPTION
This will clear the contents of the downloads folder in the user profile, which everyone tends to forget about. 

Also, over time it tends to build up a good few GB of data which is only ever needed once.