### PR TITLE
Update Winapp2.ini

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -8922,7 +8922,7 @@ RegKey1=HKCU\Software\instedit.com\insted\MRU
 LangSecRef=3024
 DetectFile=%CommonAppData%\Intel\Intel Extreme Tuning Utility
 Default=False
-FileKey1=C:\ProgramData\Intel\Intel Extreme Tuning Utility\Logs|*.*
+FileKey1=%CommonAppData%\Intel\Intel Extreme Tuning Utility\Logs|*.*
 
 [Intel iCLS Client *]
 LangSecRef=3024

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
-; Version: 180703
-; # of entries: 2,034
+; Version: 180704
+; # of entries: 2,035
 ;
 ; Winapp2 is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2 for your own program or website, please ask first.
@@ -8917,6 +8917,12 @@ LangSecRef=3024
 Detect=HKCU\Software\instedit.com\insted
 Default=False
 RegKey1=HKCU\Software\instedit.com\insted\MRU
+
+[Intel Extreme Tuning Utility *]
+LangSecRef=3024
+DetectFile=%CommonAppData%\Intel\Intel Extreme Tuning Utility
+Default=False
+FileKey1=C:\ProgramData\Intel\Intel Extreme Tuning Utility\Logs|*.*
 
 [Intel iCLS Client *]
 LangSecRef=3024


### PR DESCRIPTION
Added Intel Extreme Tuning Utility. This stupid program by Intel keeps logging useless stuff to disk, this folder can grow to several gigabytes (currently 1,59 GB already) if not cleaned every so often.