### PR TITLE
Update Winapp2.ini - Remove SmartFTP Backup

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
-; Version: 180805
-; # of entries: 2,035
+; Version: 180816
+; # of entries: 2,034
 ;
 ; Winapp2 is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2 for your own program or website, please ask first.
@@ -15194,12 +15194,6 @@ LangSecRef=3024
 DetectFile=%AppData%\Smart PDF Creator Pro
 Default=False
 FileKey1=%AppData%\Smart PDF Creator Pro|Smart PDF Creator Pro_log*.*
-
-[SmartFTP Backups *]
-LangSecRef=3022
-Detect=HKCU\Software\SmartFTP
-Default=False
-FileKey1=%AppData%\SmartFTP\Client 2.0\Backup|*.*|RECURSE
 
 [Smileys We Love Toolbar for IE *]
 LangSecRef=3022


### PR DESCRIPTION
Removed SmartFTP Backup. The backup feature of SmartFTP which created these backup files has been removed a long time ago.