### PR TITLE
Removing old Nvidia installers

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -12581,6 +12581,7 @@ FileKey18=%LocalAppData%\VirtualStore\ProgramData\NVIDIA\NvBackend\Updatus\Downl
 FileKey19=%LocalAppData%\VirtualStore\ProgramData\NVIDIA\Updatus\DownloadManager|*.*
 FileKey20=%ProgramFiles%\NVIDIA Corporation\NetworkAccessManager\Apache Group\Apache2\logs|*.*
 FileKey21=%SystemDrive%\NvidiaLogging\GFExperience|GridClientLog.log*|RECURSE
+FileKey22=%ProgramFiles%\NVIDIA Corporation\Installer2|*.*|RECURSE
 
 [O&O Defrag *]
 LangSecRef=3024


### PR DESCRIPTION
Nvidia's drivers installer files can safely be removed. I confirmed this myself and then found some rough proof here: https://lifehacker.com/clean-up-old-nvidia-driver-folders-to-free-up-hard-driv-705780194.