### PR TITLE
'Media Player Classic' -> MPC

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -10584,7 +10584,7 @@ FileKey8=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\Ca
 FileKey9=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\navigationHistory|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\TempState|*.*|RECURSE
 
-[Media Player Classic *]
+[MPC-HC/MPC-BE (Media Player Classic) *]
 LangSecRef=3023
 Detect1=HKCU\Software\Gabest\Media Player Classic
 Detect2=HKCU\Software\MPC-BE


### PR DESCRIPTION
'Media Player Classic - Home Cinema' names itself now with his acronym 'MPC-HC'. See: https://mpc-hc.org/
'MPC-BE' is dead!
Expecting that the user have the latest version of this player, he should see what he (have to) clean.
-> 'Media Player Classic' -> 'MPC-HC'