### PR TITLE
Non-functional Messengers

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -2421,13 +2421,6 @@ Detect=HKCU\Software\aignes\wswatch
 Default=False
 FileKey1=%AppData%\aignes\website-watcher\bookmarks|*.*
 
-[AIM *]
-LangSecRef=3022
-DetectFile=%LocalAppData%\AOL\AIM
-Default=False
-FileKey1=%LocalAppData%\AOL\AIM|*.log|RECURSE
-FileKey2=%LocalAppData%\AOL\AIM\cache|*.*|REMOVESELF
-
 [Aimersoft DRM Media Converter *]
 LangSecRef=3023
 Detect=HKLM\Software\Aimersoft\351
@@ -8167,14 +8160,6 @@ Detect=HKCU\Software\Google\Picasa
 Default=False
 FileKey1=%LocalAppData%\Google\Picasa2Albums\backup|*.*|REMOVESELF
 
-[Google Talk *]
-LangSecRef=3022
-Detect=HKCU\Software\Google\Google Talk
-DetectFile=%LocalAppData%\Google\Google Talk Plugin
-Default=False
-FileKey1=%LocalAppData%\Google\Google Talk Plugin|*.log
-FileKey2=%LocalAppData%\Google\Google Talk\avatars|*.*
-
 [Google Toolbar Notifier *]
 LangSecRef=3022
 Detect=HKCU\Software\Google\GoogleToolbarNotifier
@@ -12907,18 +12892,6 @@ FileKey4=%LocalAppData%\Packages\Ookla.SpeedtestbyOokla_*\LocalState|*.tmp|RECUR
 FileKey5=%LocalAppData%\Packages\Ookla.SpeedtestbyOokla_*\LocalState\Unity\Local.*\Analytics\ArchivedEvents\*|*.*|REMOVESELF
 FileKey6=%LocalAppData%\Packages\Ookla.SpeedtestbyOokla_*\TempState|*.*|RECURSE
 
-[ooVoo Chat History *]
-LangSecRef=3022
-Detect=HKCU\Software\ooVoo
-Default=False
-FileKey1=%AppData%\ooVoo Details\Users|chathistory.db|RECURSE
-
-[ooVoo Toolbar *]
-LangSecRef=3022
-DetectFile=%LocalLowAppData%\oovootoolbar
-Default=False
-FileKey1=%LocalLowAppData%\oovootoolbar|log.txt
-
 [OpalCalc *]
 LangSecRef=3021
 DetectFile1=%AppData%\OpalCalc_prefs
@@ -14383,23 +14356,6 @@ FileKey1=%CommonAppData%\FreshGames\RanchRush\*|*.log;temp_data.ssp
 FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ranch Rush*|*.html;*.nfo
 FileKey3=%LocalAppData%\VirtualStore\ProgramData\FreshGames\RanchRush\*|*.log;temp_data.ssp
 FileKey4=%ProgramFiles%\Ranch Rush*|*.html;*.nfo
-
-[Raptr *]
-LangSecRef=3021
-Detect=HKCU\Software\Raptr
-DetectFile=%ProgramFiles%\Raptr
-Default=False
-FileKey1=%AppData%\Raptr|*.log|RECURSE
-FileKey2=%AppData%\Raptr\Avatars|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Raptr|*.log
-FileKey4=%ProgramFiles%\Raptr|*.log
-ExcludeKey1=FILE|%ProgramFiles%\Raptr\|install.log
-
-[Raptr Chat History *]
-Section=Games
-Detect=HKCU\Software\Raptr
-Default=False
-FileKey1=%AppData%\Raptr\Data\*|chat_history.db
 
 [Razer Software *]
 LangSecRef=3024
@@ -18443,28 +18399,6 @@ FileKey4=%LocalAppData%\Microsoft\Windows*Mail\*\Backup|*.*|REMOVESELF
 FileKey5=%LocalAppData%\Microsoft\Windows*Mail\Backup|*.*|REMOVESELF
 RegKey1=HKCU\Software\Microsoft\Windows Live Mail|SearchFolderVersion
 
-[Windows Live Messenger *]
-LangSecRef=3022
-Detect=HKLM\Software\Microsoft\Windows Live\Messenger
-Default=False
-FileKey1=%CommonProgramFiles%\Windows Live\.cache|*.*|RECURSE
-FileKey2=%LocalAppData%\Microsoft\Messenger|*.txt|RECURSE
-FileKey3=%LocalAppData%\Microsoft\Windows Live|*.log;*.jrs;*.sqm|RECURSE
-FileKey4=%LocalAppData%\Microsoft\Windows Live Contacts|*.log;*.jrs|RECURSE
-FileKey5=%LocalAppData%\Microsoft\Windows Live Contacts\*\*\*\Backup|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Common Files\Windows Live\.cache|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Windows Live\Messenger|*.bak|RECURSE
-FileKey8=%ProgramFiles%\Windows Live\Messenger|*.bak|RECURSE
-FileKey9=%WinDir%\System32\config\systemprofile\Documents|wlidsvctrace*.txt
-FileKey10=%WinDir%\SysWOW64\config\systemprofile\Documents|wlidsvctrace*.txt
-
-[Windows Live Messenger Chat History *]
-LangSecRef=3022
-Detect=HKLM\Software\Microsoft\Windows Live\Messenger
-Default=False
-Warning=Removes Windows Live Messenger chat history.
-FileKey1=%Documents%\*\*\Histor*|*.*
-
 [Windows Live Movie Maker *]
 LangSecRef=3023
 Detect=HKCU\Software\Microsoft\Windows Live\Movie Maker
@@ -19381,19 +19315,6 @@ DetectFile=%CommonAppData%\Yahoo! Companion
 Default=False
 FileKey1=%CommonAppData%\Yahoo! Companion\Cache|*.*
 FileKey2=%LocalAppData%\VirtualStore\ProgramData\Yahoo! Companion\Cache|*.*
-
-[Yahoo Messenger *]
-LangSecRef=3022
-Detect=HKCU\Software\Yahoo\Messenger
-Default=False
-FileKey1=%LocalAppData%\yahoomessenger|SquirrelSetup.log
-
-[Yahoo Messenger Cache *]
-LangSecRef=3022
-Detect=HKCU\Software\Yahoo\Messenger
-Default=False
-Warning=You will need to reload the App next time its started. Select View, Reload from the menu.
-FileKey1=%AppData%\Yahoo Messenger\Cache|*.*|RECURSE
 
 [YourPhone *]
 DetectOS=10.0|


### PR DESCRIPTION
Removed non-functional messengers (servers have been shut down):
- AIM AOL Instant Messenger (2017-12) - https://en.wikipedia.org/wiki/AIM_(software)
- Google Talk (2017-06) - https://en.wikipedia.org/wiki/Google_Talk
- ooVoo (2017-11) - https://en.wikipedia.org/wiki/OoVoo
- Raptr (2017-09) - https://en.wikipedia.org/wiki/Raptr
- Windows Live Messenger (2014-10) - https://en.wikipedia.org/wiki/Windows_Live_Messenger 
- Yahoo Messenger (2018-07) - https://en.wikipedia.org/wiki/Yahoo!_Messenger