### PR TITLE
VirtualStore

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
-; Version: 190117
-; # of entries: 2,036
+; Version: 190121
+; # of entries: 2,037
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -13537,6 +13537,15 @@ Detect=HKCU\Software\QuickPar
 Default=False
 FileKey1=%LocalAppData%\QuickPar|*.*
 
+[QuickTime Player *]
+LangSecRef=3023
+Detect=HKLM\Software\Apple Computer, Inc.\QuickTime
+Default=False
+RegKey1=HKLM\Software\Apple Computer, Inc.\QuickTime\Favorite Movies
+RegKey2=HKLM\Software\Apple Computer, Inc.\QuickTime\Recent Movies
+RegKey3=HKLM\Software\WOW6432Node\Apple Computer, Inc.\QuickTime\Favorite Movies
+RegKey4=HKLM\Software\WOW6432Node\Apple Computer, Inc.\QuickTime\Recent Movies
+
 [QuizUp *]
 Section=Games
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\QuizUp.QuizUp_n36z36qeaxk8a
@@ -17718,9 +17727,10 @@ FileKey17=%WinDir%\system32\spool|spooler.xml
 FileKey18=%WinDir%\System32\sru|*.*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Direct3D\MostRecentApplication
 RegKey2=HKLM\Software\Microsoft\Direct3D\MostRecentApplication
-RegKey3=HKLM\Software\Microsoft\Windows\CurrentVersion\Setup|Installation Sources
-RegKey4=HKLM\Software\Wow6432Node\Microsoft\Direct3D\MostRecentApplication
-RegKey5=HKLM\Software\Wow6432Node\Microsoft\DirectDraw\MostRecentApplication
+RegKey3=HKLM\Software\Microsoft\DirectDraw\MostRecentApplication
+RegKey4=HKLM\Software\Microsoft\Windows\CurrentVersion\Setup|Installation Sources
+RegKey5=HKLM\Software\Wow6432Node\Microsoft\Direct3D\MostRecentApplication
+RegKey6=HKLM\Software\Wow6432Node\Microsoft\DirectDraw\MostRecentApplication
 
 [Windows Update *]
 LangSecRef=3025

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
 ; Version: 190117
-; # of entries: 2,041
+; # of entries: 2,036
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -1627,7 +1627,6 @@ LangSecRef=3023
 DetectFile=%CommonAppData%\1click dvd copy pro
 Default=False
 FileKey1=%CommonAppData%\1click dvd copy pro|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\1click dvd copy pro|*.log
 
 [3 Stars of Destiny *]
 Section=Games
@@ -1652,8 +1651,7 @@ DetectFile=%Documents%\3DMark
 Default=False
 FileKey1=%Documents%\3DMark|*.log
 FileKey2=%Documents%\3DMark\Log|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\3DMark|*.log|RECURSE
-FileKey4=%ProgramFiles%\Steam\SteamApps\common\3DMark|*.log|RECURSE
+FileKey3=%ProgramFiles%\Steam\SteamApps\common\3DMark|*.log|RECURSE
 
 [3DViewer *]
 DetectOS=10.0|
@@ -1711,8 +1709,7 @@ RegKey1=HKCU\Software\7z SFX Builder\MRU
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\339240
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\10 Years After\10 Years After_Data|output_log.txt
-FileKey2=%ProgramFiles%\Steam\SteamApps\common\10 Years After\10 Years After_Data|output_log.txt
+FileKey1=%ProgramFiles%\Steam\SteamApps\common\10 Years After\10 Years After_Data|output_log.txt
 
 [18 Wheels of Steel *]
 Section=Games
@@ -1724,39 +1721,34 @@ FileKey1=%Documents%\18 WoS*|*.log;*.crash
 LangSecRef=3022
 DetectFile=%ProgramFiles%\32BITWEB\32BW.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\32BITWEB\Data|LastURL.dat;LastURL.da0
-FileKey2=%ProgramFiles%\32BITWEB\Data|LastURL.dat;LastURL.da0
+FileKey1=%ProgramFiles%\32BITWEB\Data|LastURL.dat;LastURL.da0
 
 [140 *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\242820
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\140\140_Data|output_log.txt
-FileKey2=%ProgramFiles%\Steam\SteamApps\common\140\140_Data|output_log.txt
+FileKey1=%ProgramFiles%\Steam\SteamApps\common\140\140_Data|output_log.txt
 
 [360 Internet Security *]
 LangSecRef=3024
 Detect=HKCU\Software\360Safe
 Default=False
 FileKey1=%AppData%\360safe\360ScanLog|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\360\360 Internet Security|*.log*|RECURSE
-FileKey3=%ProgramFiles%\360\360 Internet Security|*.log*|RECURSE
-FileKey4=%SystemDrive%\360SANDBOX|*.log*|RECURSE
+FileKey2=%ProgramFiles%\360\360 Internet Security|*.log*|RECURSE
+FileKey3=%SystemDrive%\360SANDBOX|*.log*|RECURSE
 
 [1000 Amps *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\205690
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\1000 Amps|stdout.txt
-FileKey2=%ProgramFiles%\Steam\SteamApps\common\1000 Amps|stdout.txt
+FileKey1=%ProgramFiles%\Steam\SteamApps\common\1000 Amps|stdout.txt
 
 [1954 Alcatraz *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\255280
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\1954 Alcatraz\Alcatraz_Data|output_log.txt
-FileKey2=%LocalLowAppData%\Daedalic Entertainment\1954 Alcatraz|*.log
-FileKey3=%ProgramFiles%\Steam\SteamApps\common\1954 Alcatraz\Alcatraz_Data|output_log.txt
+FileKey1=%LocalLowAppData%\Daedalic Entertainment\1954 Alcatraz|*.log
+FileKey2=%ProgramFiles%\Steam\SteamApps\common\1954 Alcatraz\Alcatraz_Data|output_log.txt
 
 [A Hat in Time *]
 Section=Games
@@ -1768,8 +1760,7 @@ FileKey1=%ProgramFiles%\Steam\steamapps\common\HatinTime\HatinTimeGame\Logs|*.*
 LangSecRef=3024
 DetectFile=%ProgramFiles%\A58-Easytune6
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\A58-Easytune6|*.log
-FileKey2=%ProgramFiles%\A58-Easytune6|*.log
+FileKey1=%ProgramFiles%\A58-Easytune6|*.log
 
 [ABBYY FineReader *]
 LangSecRef=3021
@@ -1930,8 +1921,7 @@ RegKey1=HKCU\Software\Ace Explorer\Ace Explorer\Recent File List
 Section=Games
 DetectFile=%ProgramFiles%\Steam\steamapps\common\aceofspades
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\aceofspades\logs|*.*
-FileKey2=%ProgramFiles%\Steam\steamapps\common\aceofspades\logs|*.*
+FileKey1=%ProgramFiles%\Steam\steamapps\common\aceofspades\logs|*.*
 
 [Ace Stream *]
 LangSecRef=3023
@@ -1953,7 +1943,6 @@ LangSecRef=3024
 Detect=HKCU\Software\AceBIT
 Default=False
 FileKey1=%CommonAppData%\Acebyte\Acebyte Utilities*\Log|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Acebyte\Acebyte Utilities*\Log|*.*|RECURSE
 
 [Acer Arcade Deluxe *]
 Section=Games
@@ -1961,7 +1950,6 @@ DetectFile=%LocalAppData%\Acer Arcade Deluxe
 Default=False
 FileKey1=%CommonAppData%|ArcadeDexluxe2.log
 FileKey2=%LocalAppData%\Acer Arcade Deluxe|*.log
-FileKey3=%LocalAppData%\VirtualStore\ProgramData|ArcadeDexluxe2.log
 
 [AcooBrowser *]
 LangSecRef=3022
@@ -1977,8 +1965,7 @@ Default=False
 FileKey1=%AppData%\Acoustica\CD Label Maker\*\cache|*.*|RECURSE
 FileKey2=%AppData%\Acoustica\CD Label Maker\cache|*.*|RECURSE
 FileKey3=%AppData%\Acoustica\CD Label Maker\shapes|*.*
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Acoustica CD Label Maker\thumbs|*.*|RECURSE
-FileKey5=%ProgramFiles%\Acoustica CD Label Maker\thumbs|*.*|RECURSE
+FileKey4=%ProgramFiles%\Acoustica CD Label Maker\thumbs|*.*|RECURSE
 
 [Acoustica Premium Edition 6 *]
 LangSecRef=3023
@@ -2009,24 +1996,20 @@ RegKey2=HKLM\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\Volu
 LangSecRef=3024
 Detect=HKLM\Software\LSoft Technologies\Active Disk Image
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\LSoft Technologies\Active@ Disk Image|*.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\LSoft Technologies\Active@ Disk Image\Logs|*.*|RECURSE
-FileKey3=%ProgramFiles%\LSoft Technologies\Active@ Disk Image|*.txt
-FileKey4=%ProgramFiles%\LSoft Technologies\Active@ Disk Image\Logs|*.*|RECURSE
+FileKey1=%ProgramFiles%\LSoft Technologies\Active@ Disk Image|*.txt
+FileKey2=%ProgramFiles%\LSoft Technologies\Active@ Disk Image\Logs|*.*|RECURSE
 
 [Active@ File Recovery *]
 LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{C34F36E0-4D8B-42E8-90AD-50C76E1AE282}_is1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\LSoft Technologies\Active@ File Recovery*|Active File Recovery Log.txt;he_log.txt;*.scn;*.xml
-FileKey2=%ProgramFiles%\LSoft Technologies\Active@ File Recovery*|Active File Recovery Log.txt;he_log.txt;*.scn;*.xml
+FileKey1=%ProgramFiles%\LSoft Technologies\Active@ File Recovery*|Active File Recovery Log.txt;he_log.txt;*.scn;*.xml
 
 [Active@ KillDisk *]
 LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{0F62EFB8-3C1C-4EE6-B6EF-9593007F9B03}_is1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\LSoft Technologies\Active@ KillDisk*|*.log;*.xml
-FileKey2=%ProgramFiles%\LSoft Technologies\Active@ KillDisk*|*.log;*.xml
+FileKey1=%ProgramFiles%\LSoft Technologies\Active@ KillDisk*|*.log;*.xml
 
 [ActiveSync *]
 LangSecRef=3031
@@ -2043,10 +2026,6 @@ FileKey2=%CommonAppData%\Ad-Aware Antivirus\Logs|*.*|RECURSE
 FileKey3=%CommonAppData%\Lavasoft\AntiMalware\Events|*.*|RECURSE
 FileKey4=%CommonAppData%\Lavasoft\AntiMalware\History|*.*|RECURSE
 FileKey5=%CommonAppData%\Lavasoft\AntiMalware\Logs|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Ad-Aware Antivirus\Logs|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Lavasoft\AntiMalware\Events|*.*|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Lavasoft\AntiMalware\History|*.*|RECURSE
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Lavasoft\AntiMalware\Logs|*.*|RECURSE
 
 [Adaptec's Audio CD *]
 LangSecRef=3024
@@ -2097,15 +2076,6 @@ Default=False
 FileKey1=%AppData%\Adobe\Acrobat\Distiller 11|*.log
 FileKey2=%AppData%\Adobe\Acrobat\Distiller 11\Cache|*.*
 RegKey1=HKCU\Software\Adobe\Acrobat Distiller\PrinterJobControl
-
-[Adobe Acrobat Reader 7.0 *]
-LangSecRef=3021
-Detect=HKCU\Software\Adobe\Acrobat Reader\7.0\AVGeneral
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Adobe\Acrobat 7.0\ActiveX|*.bak
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Adobe\Acrobat 7.0\Reader|*.bak
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Adobe\Acrobat 7.0\Reader\plug_ins|*.bak
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Adobe\Acrobat 7.0\Reader\Updater|*.bak
 
 [Adobe Acrobat XI *]
 LangSecRef=3021
@@ -2303,12 +2273,6 @@ DetectFile=%AppData%\Hulubulu\Advanced Renamer 3
 Default=False
 FileKey1=%AppData%\Hulubulu\Advanced Renamer 3\Data\UndoLists|*.*
 
-[Advanced Searchbar *]
-LangSecRef=3022
-DetectFile=%ProgramFiles%\AdvancedSearchbar\advancedsearchbar.dll
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\AdvancedSearchbar\Cache|*.*
-
 [Advanced System Optimizer 3 *]
 LangSecRef=3024
 Detect=HKLM\Software\Systweak\ASO3
@@ -2352,8 +2316,7 @@ FileKey1=%AppData%\Aegisub|mru.json
 FileKey2=%AppData%\Aegisub\log|*.*|REMOVESELF
 FileKey3=%AppData%\Aegisub\recovered|*.*|REMOVESELF
 FileKey4=%LocalAppData%\Aegisub\ffms2cache|*.*|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Aegisub|*.txt
-FileKey6=%ProgramFiles%\Aegisub|*.txt
+FileKey5=%ProgramFiles%\Aegisub|*.txt
 
 [Aegisub Backups *]
 LangSecRef=3023
@@ -2367,10 +2330,8 @@ FileKey2=%AppData%\Aegisub\autosave|*.*|REMOVESELF
 Section=Games
 Detect=HKLM\Software\Funcom\Age of Conan
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Funcom\Age of Conan|patcher.log;chrome_debug.log;MiniDump.dmp;CrashLog.txt;ConanPatcher.exe.0.tmp;AgeOfConan.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Funcom\Age of Conan\OldLogs|*.*
-FileKey3=%ProgramFiles%\Funcom\Age of Conan|patcher.log;chrome_debug.log;MiniDump.dmp;CrashLog.txt;ConanPatcher.exe.0.tmp;AgeOfConan.log
-FileKey4=%ProgramFiles%\Funcom\Age of Conan\OldLogs|*.*
+FileKey1=%ProgramFiles%\Funcom\Age of Conan|patcher.log;chrome_debug.log;MiniDump.dmp;CrashLog.txt;ConanPatcher.exe.0.tmp;AgeOfConan.log
+FileKey2=%ProgramFiles%\Funcom\Age of Conan\OldLogs|*.*
 
 [Age of Empires *]
 Section=Games
@@ -2391,51 +2352,41 @@ RegKey5=HKLM\Software\Microsoft\Microsoft Games\Age of Empires\2.0|Zone
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\105430
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Age Of Empires Online|PatchLog.txt;PatchLogDetail.txt
-FileKey2=%ProgramFiles%\Steam\steamapps\common\Age Of Empires Online|PatchLog.txt;PatchLogDetail.txt
+FileKey1=%ProgramFiles%\Steam\steamapps\common\Age Of Empires Online|PatchLog.txt;PatchLogDetail.txt
 
 [Age of Oracles: Tara's Journey *]
 Section=Games
 DetectFile=%CommonAppData%\JollyBear\Age of Oracles Taras Journey
 Default=False
 FileKey1=%CommonAppData%\JollyBear\Age of Oracles Taras Journey|error.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\JollyBear\Age of Oracles Taras Journey|error.*
 
 [Age of Wonders II *]
 Section=Games
 DetectFile=%ProgramFiles%\Age of Wonders II
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Age of Wonders II|*aow2Log.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Age of Wonders II\Resource\FX\Spell|*.lnk
-FileKey3=%ProgramFiles%\Age of Wonders II|*aow2Log.txt
-FileKey4=%ProgramFiles%\Age of Wonders II\Resource\FX\Spell|*.lnk
+FileKey1=%ProgramFiles%\Age of Wonders II|*aow2Log.txt
+FileKey2=%ProgramFiles%\Age of Wonders II\Resource\FX\Spell|*.lnk
 
 [Age of Wonders: Shadow Magic *]
 Section=Games
 DetectFile=%ProgramFiles%\Age of Wonders II
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Age of Wonders Shadow Magic|*aowsmLog.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Age of Wonders Shadow Magic\Resource\Maps|*.bak
-FileKey3=%ProgramFiles%\Age of Wonders Shadow Magic|*aowsmLog.txt
-FileKey4=%ProgramFiles%\Age of Wonders Shadow Magic\Resource\Maps|*.bak
+FileKey1=%ProgramFiles%\Age of Wonders Shadow Magic|*aowsmLog.txt
+FileKey2=%ProgramFiles%\Age of Wonders Shadow Magic\Resource\Maps|*.bak
 
 [Agnitum Outpost Pro *]
 LangSecRef=3022
 Detect=HKLM\Software\Agnitum\Outpost Firewall
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Agnitum\Outpost Firewall|op_data.mdb
-FileKey2=%ProgramFiles%\Agnitum\Outpost Firewall|op_data.mdb
+FileKey1=%ProgramFiles%\Agnitum\Outpost Firewall|op_data.mdb
 
 [Agomo *]
 LangSecRef=3024
 DetectFile=%CommonAppData%\Piriform\Agomo
 Default=False
 FileKey1=%CommonAppData%\Piriform\Agomo\Logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Agomo\Logs|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Agomo\tmp_update|*.*
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Piriform\Agomo\Logs|*.*
-FileKey5=%ProgramFiles%\Agomo\Logs|*.*
-FileKey6=%ProgramFiles%\Agomo\tmp_update|*.*
+FileKey2=%ProgramFiles%\Agomo\Logs|*.*
+FileKey3=%ProgramFiles%\Agomo\tmp_update|*.*
 
 [AHA Dialer *]
 LangSecRef=3022
@@ -2443,7 +2394,6 @@ Detect=HKLM\System\CurrentControlSet\Services\HWDeviceService.exe
 DetectFile=%CommonAppData%\DatacardService\DataCardMonitor.exe
 Default=False
 FileKey1=%CommonAppData%\DatacardService\log|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\DatacardService\log|*.*
 
 [AI Roboform *]
 LangSecRef=3022
@@ -2487,8 +2437,7 @@ FileKey1=%AppData%\aignes\website-watcher\bookmarks|*.*
 LangSecRef=3023
 Detect=HKLM\Software\Aimersoft\351
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Aimersoft\DRM Media Converter\Log|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Aimersoft\DRM Media Converter\Log|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\Aimersoft\DRM Media Converter\Log|*.*|REMOVESELF
 
 [Aimersoft Helper Compact *]
 LangSecRef=3021
@@ -2498,9 +2447,6 @@ FileKey1=%CommonProgramFiles%\Aimersoft\Aimersoft Helper Compact|ProductUpdateLi
 FileKey2=%CommonProgramFiles%\Aimersoft\Aimersoft Helper Compact\DATADICT|*.*|RECURSE
 FileKey3=%CommonProgramFiles%\Aimersoft\Aimersoft Helper Compact\Log|*.*|RECURSE
 FileKey4=%CommonProgramFiles%\Aimersoft\Aimersoft Helper Compact\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Common Files\Aimersoft\Aimersoft Helper Compact|ProductUpdateLists.xml;ASHelper.exe_temp;ASHelperSetup.exe_temp
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Common Files\Aimersoft\Aimersoft Helper Compact\Log|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Common Files\Aimersoft\Aimersoft Helper Compact\Temp|*.*|RECURSE
 RegKey1=HKLM\Software\Aimersoft\Aimersoft Helper Compact
 RegKey2=HKLM\Software\Wow6432Node\Aimersoft\Aimersoft Helper Compact
 
@@ -2509,8 +2455,7 @@ LangSecRef=3023
 Detect=HKLM\Software\Aimersoft\Aimersoft Video Converter Ultimate
 Default=False
 FileKey1=%CommonAppData%\Aimersoft\ProductFeatures\*Logs|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Aimersoft\Video Converter Ultimate\TempThumbDir|*.*|RECURSE
-FileKey3=%ProgramFiles%\Aimersoft\Video Converter Ultimate\TempThumbDir|*.*|RECURSE
+FileKey2=%ProgramFiles%\Aimersoft\Video Converter Ultimate\TempThumbDir|*.*|RECURSE
 
 [AIMP *]
 LangSecRef=3023
@@ -2519,18 +2464,15 @@ DetectFile2=%ProgramFiles%\AIMP\AIMP.exe
 DetectFile3=%ProgramFiles%\AIMP2\AIMP2.exe
 Default=False
 FileKey1=%AppData%\AIMP|*.bak
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\AIMP*\Data|*.bak|RECURSE
-FileKey3=%ProgramFiles%\AIMP*\!Backup|*.*|REMOVESELF
-FileKey4=%ProgramFiles%\AIMP*\Data|*.bak|RECURSE
+FileKey2=%ProgramFiles%\AIMP*\!Backup|*.*|REMOVESELF
+FileKey3=%ProgramFiles%\AIMP*\Data|*.bak|RECURSE
 
 [AirBuccaneers *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\223630
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\AirBuccaneers\abu_data|output_log.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\AirBuccaneers\logs|*.*
-FileKey3=%ProgramFiles%\Steam\Steamapps\common\AirBuccaneers\abu_data|output_log.txt
-FileKey4=%ProgramFiles%\Steam\Steamapps\common\AirBuccaneers\logs|*.*
+FileKey1=%ProgramFiles%\Steam\Steamapps\common\AirBuccaneers\abu_data|output_log.txt
+FileKey2=%ProgramFiles%\Steam\Steamapps\common\AirBuccaneers\logs|*.*
 
 [AirStrike 3D *]
 Section=Games
@@ -2587,8 +2529,7 @@ FileKey1=%LocalAppData%\Alibaba\AliSetup\*|*.log
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\630
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\alien swarm\swarm|tilegen_log.txt
-FileKey2=%ProgramFiles%\Steam\steamapps\common\alien swarm\swarm|tilegen_log.txt
+FileKey1=%ProgramFiles%\Steam\steamapps\common\alien swarm\swarm|tilegen_log.txt
 
 [Aliens: Colonial Marines *]
 Section=Games
@@ -2608,8 +2549,7 @@ FileKey2=%SystemDrive%\AiO-Files|*.*|RECURSE
 LangSecRef=3021
 DetectFile=%ProgramFiles%\All Office Converter Platinum
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\All Office Converter Platinum|Eventlog.txt
-FileKey2=%ProgramFiles%\All Office Converter Platinum|Eventlog.txt
+FileKey1=%ProgramFiles%\All Office Converter Platinum|Eventlog.txt
 
 [All Zombies Must Die! *]
 Section=Games
@@ -2639,8 +2579,7 @@ FileKey1=%AppData%\Alternate\FileShredder|FileShredderLog*.txt
 LangSecRef=3024
 Detect=HKCU\Software\AlwaysRight
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Superhunter\Always Right\*Backup|*.*
-FileKey2=%ProgramFiles%\Superhunter\Always Right\*Backup|*.*
+FileKey1=%ProgramFiles%\Superhunter\Always Right\*Backup|*.*
 
 [Alwin 6 *]
 LangSecRef=3023
@@ -2665,10 +2604,8 @@ FileKey2=%UserProfile%\amaya\*|*.*|REMOVESELF
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\293500
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\Amazing World\AmazingWorld_Data|output_log.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Amazing World\Cache|*.*|REMOVESELF
-FileKey3=%ProgramFiles%\Steam\SteamApps\common\Amazing World\AmazingWorld_Data|output_log.txt
-FileKey4=%ProgramFiles%\Steam\SteamApps\Common\Amazing World\Cache|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\Steam\SteamApps\common\Amazing World\AmazingWorld_Data|output_log.txt
+FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Amazing World\Cache|*.*|REMOVESELF
 
 [Amazon Cloud Player *]
 LangSecRef=3024
@@ -2731,30 +2668,22 @@ FileKey2=%CommonAppData%\AMD\KDB|*.log
 FileKey3=%LocalAppData%\AMD\Fuel|ClientProxyLog*.*
 FileKey4=%LocalAppData%\AMD\GLCache|*.*|RECURSE
 FileKey5=%LocalAppData%\ATI\ACE|*.txt
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\AMD\amdkmpfd|*.*|REMOVESELF
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\AMD\OverDrive|*.log
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\ATI Technologies|*.log|RECURSE
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\ATI Technologies|cccutil64.txt
-FileKey10=%LocalAppData%\VirtualStore\Program Files*\ATI\CIM\Reports|*.*
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\AMD\Fuel|*.txt
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\AMD\KDB|*.log
-FileKey13=%ProgramFiles%\AMD\amdkmpfd|*.*|REMOVESELF
-FileKey14=%ProgramFiles%\AMD\OverDrive|*.log
-FileKey15=%ProgramFiles%\ATI Technologies|*.log|RECURSE
-FileKey16=%ProgramFiles%\ATI Technologies|cccutil64.txt
-FileKey17=%ProgramFiles%\ATI\CIM\Reports|*.*
-FileKey18=%SystemDrive%\AMD|*.*|REMOVESELF
-FileKey19=%SystemDrive%\ATI|*.*|REMOVESELF
-FileKey20=%WinDir%\System32|CCCInstall*.log
-FileKey21=%WinDir%\SysWOW64|CCCInstall*.log
+FileKey6=%ProgramFiles%\AMD\amdkmpfd|*.*|REMOVESELF
+FileKey7=%ProgramFiles%\AMD\OverDrive|*.log
+FileKey8=%ProgramFiles%\ATI Technologies|*.log|RECURSE
+FileKey9=%ProgramFiles%\ATI Technologies|cccutil64.txt
+FileKey10=%ProgramFiles%\ATI\CIM\Reports|*.*
+FileKey11=%SystemDrive%\AMD|*.*|REMOVESELF
+FileKey12=%SystemDrive%\ATI|*.*|REMOVESELF
+FileKey13=%WinDir%\System32|CCCInstall*.log
+FileKey14=%WinDir%\SysWOW64|CCCInstall*.log
 
 [America's Army 2 *]
 Section=Games
 DetectFile=%ProgramFiles%\USArmy\America's Army 2
 Default=False
 FileKey1=%LocalAppData%\AA2DeployClient|debug*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\USArmy\America's Army 2|*.log|RECURSE
-FileKey3=%ProgramFiles%\USArmy\America's Army 2|*.log|RECURSE
+FileKey2=%ProgramFiles%\USArmy\America's Army 2|*.log|RECURSE
 
 [Amnesia: The Dark Descent *]
 Section=Games
@@ -2766,19 +2695,17 @@ FileKey1=%Documents%\Amnesia|*.log|RECURSE
 LangSecRef=3022
 Detect=HKCU\Software\aMSN
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\amsn\scripts\amsn_received|*.incomplete
-FileKey2=%ProgramFiles%\amsn\scripts\amsn_received|*.incomplete
-FileKey3=%UserProfile%\amsn\*\FT\cache|*.*
-FileKey4=%UserProfile%\amsn\*\logs\*|*.log
-FileKey5=%UserProfile%\amsn\*\winks\cache\tmp|*.*
-FileKey6=%UserProfile%\amsn\displaypic\cache|*.*
+FileKey1=%ProgramFiles%\amsn\scripts\amsn_received|*.incomplete
+FileKey2=%UserProfile%\amsn\*\FT\cache|*.*
+FileKey3=%UserProfile%\amsn\*\logs\*|*.log
+FileKey4=%UserProfile%\amsn\*\winks\cache\tmp|*.*
+FileKey5=%UserProfile%\amsn\displaypic\cache|*.*
 
 [AMYUNI PDF Converter *]
 LangSecRef=3021
 DetectFile=%CommonAppData%\Package Cache\3DBECED19CFC2819A7E0BE14463CF18FC8720D91\amyuni_pdfconverter_5_00
 Default=False
 FileKey1=%CommonAppData%\Package Cache\3DBECED19CFC2819A7E0BE14463CF18FC8720D91\amyuni_pdfconverter_5_00|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Package Cache\3DBECED19CFC2819A7E0BE14463CF18FC8720D91\amyuni_pdfconverter_5_00|*.log|RECURSE
 
 [And Yet It Moves *]
 Section=Games
@@ -2805,7 +2732,6 @@ LangSecRef=3021
 Detect=HKCU\Software\Anfibia Switch
 Default=False
 FileKey1=%CommonAppData%\Anfibia Switch|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Anfibia Switch|*.log|RECURSE
 
 [Angry Birds Space *]
 Section=Games
@@ -2862,14 +2788,10 @@ LangSecRef=3024
 Detect=HKLM\Software\Anvisoft\Cloud System Booster
 Default=False
 FileKey1=%LocalAppData%\Anvisoft\Anvi Slim Toolbar\FFToobar\tmp|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Anvisoft\Cloud System Booster|*.log;*.txt
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Anvisoft\Cloud System Booster\logs|*.*
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Anvisoft\Cloud System Booster\reports|*.*
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Anvisoft\Cloud System Booster\VLog|*.*
-FileKey6=%ProgramFiles%\Anvisoft\Cloud System Booster|*.log;*.txt
-FileKey7=%ProgramFiles%\Anvisoft\Cloud System Booster\logs|*.*
-FileKey8=%ProgramFiles%\Anvisoft\Cloud System Booster\reports|*.*
-FileKey9=%ProgramFiles%\Anvisoft\Cloud System Booster\VLog|*.*
+FileKey2=%ProgramFiles%\Anvisoft\Cloud System Booster|*.log;*.txt
+FileKey3=%ProgramFiles%\Anvisoft\Cloud System Booster\logs|*.*
+FileKey4=%ProgramFiles%\Anvisoft\Cloud System Booster\reports|*.*
+FileKey5=%ProgramFiles%\Anvisoft\Cloud System Booster\VLog|*.*
 
 [AnvSoft Any Audio Converter *]
 LangSecRef=3023
@@ -2911,19 +2833,14 @@ FileKey2=%CommonAppData%\AOL Downloads|*.*|RECURSE
 FileKey3=%CommonAppData%\AOL\C_AOL*|*.tmp|RECURSE
 FileKey4=%CommonAppData%\AOL\C_AOL*\bart|*.*|RECURSE
 FileKey5=%CommonAppData%\AOL\C_AOL*\spool|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\AOL Downloads|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\AOL\C_AOL*|*.tmp|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\AOL\C_AOL*\bart|*.*|RECURSE
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\AOL\C_AOL*\spool|*.*|RECURSE
 
 [APC PowerChute Personal Edition *]
 LangSecRef=3024
 Detect=HKCU\Software\APC\PowerChute Personal Edition
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\APC\PowerChute Personal Edition|PCPELog.txt
-FileKey2=%ProgramFiles%\APC\PowerChute Personal Edition|PCPELog.txt
-FileKey3=%WinDir%\System32|PCPELog.txt
-FileKey4=%WinDir%\SysWOW64|PCPELog.txt
+FileKey1=%ProgramFiles%\APC\PowerChute Personal Edition|PCPELog.txt
+FileKey2=%WinDir%\System32|PCPELog.txt
+FileKey3=%WinDir%\SysWOW64|PCPELog.txt
 
 [ApHeMo *]
 LangSecRef=3022
@@ -2970,7 +2887,6 @@ DetectFile=%AppData%\Appupdater
 Default=False
 FileKey1=%AppData%\Appupdater|appupdaterw.log
 FileKey2=%CommonAppData%\Appupdater|*.log
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Appupdater|*.log
 
 [AQQ *]
 LangSecRef=3022
@@ -3022,8 +2938,7 @@ LangSecRef=3024
 Detect=HKCU\Software\Argotronic\Argus Monitor
 Default=False
 FileKey1=%Documents%|ArgusMonitor_EventLog.txt;ArgusMonitor_CSVLog.csv
-FileKey2=%LocalAppData%\VirtualStore\Program Files*|ArgusMonitor_EventLog.txt;ArgusMonitor_CSVLog.csv
-FileKey3=%ProgramFiles%|ArgusMonitor_EventLog.txt;ArgusMonitor_CSVLog.csv
+FileKey2=%ProgramFiles%|ArgusMonitor_EventLog.txt;ArgusMonitor_CSVLog.csv
 
 [ARO *]
 LangSecRef=3024
@@ -3210,8 +3125,7 @@ Default=False
 FileKey1=%AppData%\Ashampoo|*.log;*.txt;*.xml|RECURSE
 FileKey2=%LocalAppData%\Ashampoo\BaNT|*.*|RECURSE
 FileKey3=%LocalAppData%\CrashRpt\UnsentCrashReports|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Ashampoo\Ashampoo Snap *|_NLogMsg.txt
-FileKey5=%ProgramFiles%\Ashampoo\Ashampoo Snap *|_NLogMsg.txt
+FileKey4=%ProgramFiles%\Ashampoo\Ashampoo Snap *|_NLogMsg.txt
 
 [Ashampoo Snap AutoSaves *]
 LangSecRef=3024
@@ -3243,10 +3157,8 @@ DetectFile3=%ProgramFiles%\ASUS\AI Suite
 Default=False
 FileKey1=%AppData%\ASUS WebStorage\Logs|*.*
 FileKey2=%CommonAppData%\Asus\AsusAppStore|*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\ASUS\*|*.log;*log*.txt|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Asus\AsusAppStore|*.log|RECURSE
-FileKey5=%ProgramFiles%\ASUS\*|*.log;*log*.txt|RECURSE
-FileKey6=%SystemDrive%|wifi.log
+FileKey3=%ProgramFiles%\ASUS\*|*.log;*log*.txt|RECURSE
+FileKey4=%SystemDrive%|wifi.log
 
 [Atheros Driver *]
 LangSecRef=3021
@@ -3254,8 +3166,6 @@ Detect=HKLM\Atheros
 Default=False
 FileKey1=%CommonAppData%\Atheros|*.log|RECURSE
 FileKey2=%CommonAppData%\Qualcomm Atheros WiFi Driver Installation|*.Log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Atheros|*.log|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Qualcomm Atheros WiFi Driver Installation|*.Log|RECURSE
 
 [Audials 10 *]
 LangSecRef=3023
@@ -3265,14 +3175,12 @@ FileKey1=%AppData%\CrashRpt\UnsentCrashReports|*.dmp;*.log;*.xml|RECURSE
 FileKey2=%CommonAppData%\RapidSolution\Audials_2013\ChildMSILogs|*.txt
 FileKey3=%LocalAppData%\RapidSolution\Audials_2013\Log|*.log;*.txt|RECURSE
 FileKey4=%LocalAppData%\RapidSolution\Audials_Software\RapidSolution\Audials_2013\Log|*.log;*.txt|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\RapidSolution\Audials_2013\ChildMSILogs|*.txt
 
 [Audio Sliders *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Audio Sliders
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Audio Sliders|*.log
-FileKey2=%ProgramFiles%\Audio Sliders|*.log
+FileKey1=%ProgramFiles%\Audio Sliders|*.log
 
 [Audio/Video Stats *]
 DetectOS=|5.1
@@ -3293,8 +3201,7 @@ Detect=HKCU\Software\Auslogics\BoostSpeed
 Default=False
 FileKey1=%AppData%\Auslogics|*.htm;*.html;*.log;*.rsc;*.sta;*.xml|RECURSE
 FileKey2=%CommonAppData%\Auslogics\BoostSpeed\*.x|*.err;*.htm;*.html;*.log;*.rsc;*.sta;*.xml|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Auslogics\Auslogics BoostSpeed|rdboot.log
-FileKey4=%ProgramFiles%\Auslogics\Auslogics BoostSpeed|rdboot.log
+FileKey3=%ProgramFiles%\Auslogics\Auslogics BoostSpeed|rdboot.log
 RegKey1=HKCU\Software\Auslogics\BoostSpeed\5.x\Settings|DiskCleaner.AppLogic.ErrorsFailed
 RegKey2=HKCU\Software\Auslogics\BoostSpeed\5.x\Settings|DiskCleaner.AppLogic.ErrorsFound
 RegKey3=HKCU\Software\Auslogics\BoostSpeed\5.x\Settings|DiskCleaner.AppLogic.ErrorsRemoved
@@ -3350,7 +3257,6 @@ Default=False
 Warning=This will reset your scan results.
 FileKey1=%AppData%\Auslogics|*.htm;*.html;*.log;*.rsc;*.sta;*.xml|RECURSE
 FileKey2=%CommonAppData%\Auslogics\Registry Cleaner\*.x|*.htm;*.html;*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Auslogics\Registry Cleaner\*.x|*.htm;*.html;*.log|RECURSE
 RegKey1=HKCU\Software\Auslogics\Registry Cleaner\2.x\Settings|RegCleaner.AppLogic.ErrorsFailed
 RegKey2=HKCU\Software\Auslogics\Registry Cleaner\2.x\Settings|RegCleaner.AppLogic.ErrorsFound
 RegKey3=HKCU\Software\Auslogics\Registry Cleaner\2.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
@@ -3478,12 +3384,6 @@ FileKey3=%CommonAppData%\AVAST Software\Avast\log|*.*
 FileKey4=%CommonAppData%\AVAST Software\Avast\report|*.txt
 FileKey5=%CommonAppData%\AVAST Software\Browser|*.*|RECURSE
 FileKey6=%CommonAppData%\AVAST Software\Persistent Data\Avast\Logs|*.log
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\AVAST Software\Avast|Log.db;backend.txt
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\AVAST Software\Avast\backup|*.*|RECURSE
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\AVAST Software\Avast\log|*.*
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\AVAST Software\Avast\report|*.txt
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\AVAST Software\Browser|*.*|RECURSE
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\AVAST Software\Persistent Data\Avast\Logs|*.log
 RegKey1=HKCU\Software\AVAST Software\Avast Browser Cleanup
 
 [AVG *]
@@ -3547,8 +3447,7 @@ FileKey27=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Avg\Log\tu16|*.lo
 LangSecRef=3023
 DetectFile=%ProgramFiles%\AVIMuxGUI\AVIMux_GUI.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\AVIMuxGUI|AVI-Mux GUI - Logfile*.*;*.dmp
-FileKey2=%ProgramFiles%\AVIMuxGUI|AVI-Mux GUI - Logfile*.*;*.dmp
+FileKey1=%ProgramFiles%\AVIMuxGUI|AVI-Mux GUI - Logfile*.*;*.dmp
 
 [AVI Toolbox *]
 LangSecRef=3023
@@ -3576,7 +3475,6 @@ Detect2=HKLM\Software\Avidemux 2.5
 Detect3=HKLM\Software\Avidemux 2.6
 Default=False
 FileKey1=%AppData%\avidemux|admlog.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Avidemux*|admlog.txt
 
 [Avira AntiVir Desktop *]
 LangSecRef=3024
@@ -3585,10 +3483,7 @@ Detect2=HKLM\Software\Avira\AntiVir Desktop
 Default=False
 FileKey1=%CommonAppData%\Avira\AntiVir*\IPM|*.*|RECURSE
 FileKey2=%CommonAppData%\Avira\AntiVir*\REPORTS|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Avira GmbH|*.log|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Avira\AntiVir*\IPM|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Avira\AntiVir*\REPORTS|*.*
-FileKey6=%ProgramFiles%\Avira GmbH|*.log|RECURSE
+FileKey3=%ProgramFiles%\Avira GmbH|*.log|RECURSE
 
 [Avira Phantom VPN *]
 LangSecRef=3024
@@ -3657,7 +3552,6 @@ LangSecRef=3022
 DetectFile=%CommonAppData%\AzureWave
 Default=False
 FileKey1=%CommonAppData%\AzureWave|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\AzureWave|*.log
 
 [Babylon *]
 LangSecRef=3024
@@ -3669,15 +3563,13 @@ RegKey1=HKCU\Software\Babylon\Babylon Translator\UserInfo\History
 Section=Games
 DetectFile=%ProgramFiles%\Atari\Backyard Basketball 2004
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Atari\Backyard Basketball 2004|*.log
-FileKey2=%ProgramFiles%\Atari\Backyard Basketball 2004|*.log
+FileKey1=%ProgramFiles%\Atari\Backyard Basketball 2004|*.log
 
 [Bad Piggies *]
 Section=Games
 DetectFile=%ProgramFiles%\Rovio\Bad Piggies
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Rovio\Bad Piggies\BadPiggies_Data|output_log.txt
-FileKey2=%ProgramFiles%\Rovio\Bad Piggies\BadPiggies_Data|output_log.txt
+FileKey1=%ProgramFiles%\Rovio\Bad Piggies\BadPiggies_Data|output_log.txt
 
 [Baidu PC Faster *]
 LangSecRef=3024
@@ -3687,7 +3579,6 @@ FileKey1=%CommonAppData%\Baidu Security\RpData|*.tmp
 FileKey2=%Documents%\Baidu Security\Bav\Dump|*.*|REMOVESELF
 FileKey3=%Documents%\Baidu Security\PC Faster\*\Dump|*.*|REMOVESELF
 FileKey4=%Documents%\Baidu Security\PC Faster\*\log|*.*|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Baidu Security\RpData|*.tmp
 
 [Baidu Spark *]
 LangSecRef=3021
@@ -3738,8 +3629,7 @@ FileKey1=%Documents%\WB Games\Batman Arkham City*\BmGame\Logs|*.*
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\209000
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Batman Arkham Origins\SinglePlayer\BMGame\Logs|*.*
-FileKey2=%ProgramFiles%\Steam\steamapps\common\Batman Arkham Origins\SinglePlayer\BMGame\Logs|*.*
+FileKey1=%ProgramFiles%\Steam\steamapps\common\Batman Arkham Origins\SinglePlayer\BMGame\Logs|*.*
 
 [Battle Islands *]
 Section=Games
@@ -3761,10 +3651,6 @@ FileKey7=%LocalAppData%\Battle.net\Errors|*.*
 FileKey8=%LocalAppData%\Battle.net\Logs|*.*|RECURSE
 FileKey9=%LocalAppData%\Blizzard Entertainment\System Survey|*.log|RECURSE
 FileKey10=%LocalAppData%\Blizzard Entertainment\System Survey|log.txt
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\Battle.net|*.log|RECURSE
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\Battle.net\*\Logs|*.*|RECURSE
-FileKey13=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Agent\Agent.*\Logs|*.*|RECURSE
-FileKey14=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Client\Blizzard Launcher.*\Logs|*.*|RECURSE
 
 [Battle.net Cache *]
 Section=Games
@@ -3774,14 +3660,12 @@ FileKey1=%CommonAppData%\Blizzard Entertainment\Battle.net\Cache|*.*|RECURSE
 FileKey2=%LocalAppData%\Battle.net\BrowserCache|*.*|RECURSE
 FileKey3=%LocalAppData%\Battle.net\Cache|*.*|RECURSE
 FileKey4=%LocalAppData%\Blizzard Entertainment\Battle.net\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Blizzard Entertainment\Battle.net\Cache|*.*|RECURSE
 
 [Battlefield 3 *]
 Section=Games
 Detect=HKLM\Software\EA Games\Battlefield 3
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Origin Games\Battlefield 3\__Installer|InstallLog.txt
-FileKey2=%ProgramFiles%\Origin Games\Battlefield 3\__Installer|InstallLog.txt
+FileKey1=%ProgramFiles%\Origin Games\Battlefield 3\__Installer|InstallLog.txt
 
 [BB FlashBack/TestAssistant *]
 LangSecRef=3023
@@ -3794,10 +3678,8 @@ Default=False
 FileKey1=%AppData%\Blueberry|ExportToAVIStat.txt;ExportToQTStat.txt;ExportToSWFStat.txt;ExportToWMVStat.txt;* CrashTracking.xml;* UsageTracking.xml;RecorderStat.txt;RecorderStaticStat.txt
 FileKey2=%AppData%\LogSys|*.*|REMOVESELF
 FileKey3=%CommonProgramFiles%\Blueberry Software|*.log
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Blueberry Software\*|drvinstlog.txt;*.log
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Common Files\Blueberry Software|*.log
-FileKey6=%ProgramFiles%\Blueberry Software\*|drvinstlog.txt;*.log
-FileKey7=%WinDir%\system32\MTSLog|*.*|REMOVESELF
+FileKey4=%ProgramFiles%\Blueberry Software\*|drvinstlog.txt;*.log
+FileKey5=%WinDir%\system32\MTSLog|*.*|REMOVESELF
 
 [Beckhoff TwinCat *]
 LangSecRef=3021
@@ -3810,13 +3692,10 @@ FileKey2=%UserProfile%|*TwinCat*.log;TC*.log;TF*.log
 LangSecRef=3024
 Detect=HKCU\Software\Belarc
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Belarc\*Advisor\System|Progress.Log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Belarc\*Advisor\System\Security\BelNotify|BelNotify.log;History.log;HistoryHF.log
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Belarc\*Advisor\System\Tmp|*.*
-FileKey4=%ProgramFiles%\Belarc\*Advisor|install.log
-FileKey5=%ProgramFiles%\Belarc\*Advisor\System|Progress.Log
-FileKey6=%ProgramFiles%\Belarc\*Advisor\System\Security\BelNotify|BelNotify.log;History.log;HistoryHF.log
-FileKey7=%ProgramFiles%\Belarc\*Advisor\System\Tmp|*.*
+FileKey1=%ProgramFiles%\Belarc\*Advisor|install.log
+FileKey2=%ProgramFiles%\Belarc\*Advisor\System|Progress.Log
+FileKey3=%ProgramFiles%\Belarc\*Advisor\System\Security\BelNotify|BelNotify.log;History.log;HistoryHF.log
+FileKey4=%ProgramFiles%\Belarc\*Advisor\System\Tmp|*.*
 
 [BestBuy Software Installer *]
 LangSecRef=3024
@@ -3834,8 +3713,7 @@ FileKey1=%Documents%\Betrayer\UDKGame\Logs|*.*
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Better Explorer
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Better Explorer|log.txt
-FileKey2=%ProgramFiles%\Better Explorer|log.txt
+FileKey1=%ProgramFiles%\Better Explorer|log.txt
 
 [BetterDiscord *]
 LangSecRef=3022
@@ -3856,7 +3734,6 @@ Detect1=HKCU\Software\JollyBear\Big City Adventure San Francisco
 Detect2=HKCU\Software\JollyBear\Big City Adventure Sydney
 Default=False
 FileKey1=%CommonAppData%\JollyBear\Big City Adventure *|error.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\JollyBear\Big City Adventure *|error.*
 
 [Big Fish Games *]
 Section=Games
@@ -3866,17 +3743,12 @@ FileKey1=%CommonAppData%\Big Fish Games\Game Manager\resources-old|*.*|RECURSE
 FileKey2=%CommonAppData%\Big Fish\Game Manager\Addons\BFGameLauncher|*.log|RECURSE
 FileKey3=%CommonAppData%\BigFishCache\GameManager\log|*.txt|RECURSE
 FileKey4=%CommonAppData%\BigFishGamesCache\GameManager\log|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Big Fish Games\Game Manager\resources-old|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Big Fish\Game Manager\Addons\BFGameLauncher|*.log|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\BigFishCache\GameManager\log|*.txt|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\BigFishGamesCache\GameManager\log|*.*
 
 [Big Fish Games Installers *]
 Section=Games
 Detect=HKCU\Software\Big Fish Games
 Default=False
 FileKey1=%CommonAppData%\BigFishCache|*.exe|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\BigFishCache|*.exe|RECURSE
 
 [BiglyBT *]
 LangSecRef=3022
@@ -4004,9 +3876,8 @@ Detect3=HKLM\Software\Bitdefender\Bitdefender Total Security 2015
 Detect4=HKLM\Software\Softwin\Bitdefender Antivirus
 Default=False
 FileKey1=%AppData%\Bitdefender\Desktop\profiles\Logs\*|*.xml
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Softwin\Bitdefender*\Logs|*.*
-FileKey3=%ProgramFiles%\Softwin\Bitdefender*\Logs|*.*
-FileKey4=%SystemDrive%|bdlog.txt
+FileKey2=%ProgramFiles%\Softwin\Bitdefender*\Logs|*.*
+FileKey3=%SystemDrive%|bdlog.txt
 
 [BitTorrent *]
 LangSecRef=3022
@@ -4062,8 +3933,7 @@ FileKey1=%AppData%\Research In Motion\BlackBerry\Intellisync|*.log|RECURSE
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\225600
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\Blade Symphony\workshop_temp|*.*|RECURSE
-FileKey2=%ProgramFiles%\Steam\Steamapps\common\Blade Symphony\workshop_temp|*.*|RECURSE
+FileKey1=%ProgramFiles%\Steam\Steamapps\common\Blade Symphony\workshop_temp|*.*|RECURSE
 
 [Blades of Time *]
 Section=Games
@@ -4075,8 +3945,7 @@ FileKey1=%LocalAppData%\BladesOfTime\_debuginfo|*.*
 LangSecRef=3024
 Detect=HKCU\Software\BleachBit
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\BleachBit|bleachbit.exe.log
-FileKey2=%ProgramFiles%\BleachBit|bleachbit.exe.log
+FileKey1=%ProgramFiles%\BleachBit|bleachbit.exe.log
 
 [Blender *]
 LangSecRef=3023
@@ -4099,8 +3968,7 @@ Detect=HKCU\Software\Blue-cloner
 Default=False
 FileKey1=%AppData%\Blue-Cloner|*.log
 FileKey2=%AppData%\Blue-Cloner\ReadCache|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Blue-Cloner|*.log;*.txt
-FileKey4=%ProgramFiles%\Blue-Cloner|*.log;*.txt
+FileKey3=%ProgramFiles%\Blue-Cloner|*.log;*.txt
 
 [BlueGriffon *]
 LangSecRef=3021
@@ -4112,15 +3980,7 @@ FileKey1=%LocalAppData%\Disruptive Innovations SARL\BlueGriffon\Profiles\*\Cache
 LangSecRef=3022
 DetectFile=%ProgramFiles%\BlueSky Interactive
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\BlueSky Interactive\PTP\Settings|*.tmp
-FileKey2=%ProgramFiles%\BlueSky Interactive\PTP\Settings|*.tmp
-
-[BlueStacks *]
-LangSecRef=3021
-Detect1=HKCU\Software\Bluestacks
-Detect2=HKLM\Software\Bluestacks
-Default=False
-FileKey1=%LocalAppData%\VirtualStore\ProgramData\BlueStacks|*.log;*.log.*|RECURSE
+FileKey1=%ProgramFiles%\BlueSky Interactive\PTP\Settings|*.tmp
 
 [BlueStacks APKs *]
 LangSecRef=3021
@@ -4128,30 +3988,18 @@ Detect1=HKCU\Software\BlueStacks
 Detect2=HKLM\Software\BlueStacks
 Default=False
 FileKey1=%CommonAppData%\BlueStacksSetup|*.apk
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\BlueStacksSetup|*.apk
-
-[BlueStacks Installer *]
-LangSecRef=3021
-Detect1=HKCU\Software\Bluestacks
-Detect2=HKLM\Software\Bluestacks
-Default=False
-Warning=You will have to redownload these files in order to reinstall the application.
-FileKey1=%LocalAppData%\VirtualStore\ProgramData\BlueStacksSetup|runtimedata_*.zip;runtimedata_*.zip.manifest
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\BlueStacksSetup\Images|*.*|REMOVESELF
 
 [Bluetack Blocklist Manager *]
 LangSecRef=3024
 Detect=HKCU\Software\Bluetack\Blocklist Manager
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Bluetack\Blocklist Manager\Cache|*.*
-FileKey2=%ProgramFiles%\Bluetack\Blocklist Manager\Cache|*.*
+FileKey1=%ProgramFiles%\Bluetack\Blocklist Manager\Cache|*.*
 
 [Blumentals Easy GIF Animator *]
 LangSecRef=3023
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Easy GIF Animator_is1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Easy GIF Animator|*.txt|RECURSE
-FileKey2=%ProgramFiles%\Easy GIF Animator|*.txt|RECURSE
+FileKey1=%ProgramFiles%\Easy GIF Animator|*.txt|RECURSE
 
 [Blurity *]
 LangSecRef=3023
@@ -4163,8 +4011,7 @@ FileKey1=%AppData%\Blurity|event.log
 LangSecRef=3024
 Detect=HKCU\Software\Space Sciences Laboratory, U.C. Berkeley\BOINC Manager
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\BOINC|stdout*.*;stderr*.*
-FileKey2=%ProgramFiles%\BOINC|stdout*.*;stderr*.*
+FileKey1=%ProgramFiles%\BOINC|stdout*.*;stderr*.*
 
 [Borderlands *]
 Section=Games
@@ -4234,15 +4081,13 @@ FileKey1=%SystemDrive%\Drivers\Broadcom Wireless LAN Driver|*.log|RECURSE
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\274190
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Broforce\*\Broforce Logs|*.csv
-FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Broforce\*\Broforce Logs|*.csv
+FileKey1=%ProgramFiles%\Steam\SteamApps\Common\Broforce\*\Broforce Logs|*.csv
 
 [Broken Shortcut Fixer *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\ConsumerSoft\Broken Shortcut Fixer
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ConsumerSoft\Broken Shortcut Fixer|ht.htm
-FileKey2=%ProgramFiles%\ConsumerSoft\Broken Shortcut Fixer|ht.htm
+FileKey1=%ProgramFiles%\ConsumerSoft\Broken Shortcut Fixer|ht.htm
 
 [Brother P-touch *]
 LangSecRef=3021
@@ -4256,8 +4101,7 @@ Detect=HKLM\Software\Brother
 DetectFile=%CommonAppData%\Brother
 Default=False
 FileKey1=%CommonAppData%\Brother\BrLog|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Brother|*.tmp|RECURSE
-FileKey3=%ProgramFiles%\Brother|*.tmp|RECURSE
+FileKey2=%ProgramFiles%\Brother|*.tmp|RECURSE
 
 [Brothers - A Tale of Two Sons *]
 Section=Games
@@ -4291,10 +4135,8 @@ FileKey4=%AppData%\BSplayer\Flash Video (FLV)|unreg.log
 FileKey5=%AppData%\BSplayer\Haali media splitter|unreg.log
 FileKey6=%AppData%\BSplayer\MPEG*decoder|unreg.log
 FileKey7=%AppData%\BSplayer\RealMedia splitter|unreg.log
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\Webteh\BSplayerPro|*.jpg
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\Webteh\BSplayerPro\cache|*.mpos
-FileKey10=%ProgramFiles%\Webteh\BSplayerPro|*.jpg
-FileKey11=%ProgramFiles%\Webteh\BSplayerPro\cache|*.mpos
+FileKey8=%ProgramFiles%\Webteh\BSplayerPro|*.jpg
+FileKey9=%ProgramFiles%\Webteh\BSplayerPro\cache|*.mpos
 
 [Buchstabenzoo BHV *]
 LangSecRef=3021
@@ -4340,20 +4182,15 @@ Detect1=HKCU\Software\GoBit\BurgerShop
 Detect2=HKCU\Software\GoBit\BurgerShop2
 Default=False
 FileKey1=%CommonAppData%\GoBit Games\BurgerShop2\*\cached|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Burger Shop|*.db;*.txt|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Burger Shop\cached|*.*|REMOVESELF
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\GoBit Games\Burger Shop 2|*.db;*.txt|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\GoBit Games\BurgerShop2\*\cached|*.*|REMOVESELF
-FileKey6=%ProgramFiles%\Burger Shop|*.db;*.txt|RECURSE
-FileKey7=%ProgramFiles%\Burger Shop\cached|*.*|REMOVESELF
-FileKey8=%ProgramFiles%\GoBit Games\Burger Shop 2|*.db;*.txt|RECURSE
+FileKey2=%ProgramFiles%\Burger Shop|*.db;*.txt|RECURSE
+FileKey3=%ProgramFiles%\Burger Shop\cached|*.*|REMOVESELF
+FileKey4=%ProgramFiles%\GoBit Games\Burger Shop 2|*.db;*.txt|RECURSE
 
 [Burn Zombie Burn! *]
 Section=Games
 Detect=HKLM\Software\Burn Zombie Burn
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\P2 Games\Burn Zombie Burn|*.log
-FileKey2=%ProgramFiles%\P2 Games\Burn Zombie Burn|*.log
+FileKey1=%ProgramFiles%\P2 Games\Burn Zombie Burn|*.log
 
 [Burn Zombie Burn! .NET Installer *]
 Section=Games
@@ -4366,23 +4203,20 @@ FileKey1=%ProgramFiles%\P2 Games\Burn Zombie Burn\REQS\NET|*.*|REMOVESELF
 Section=Games
 DetectFile=%ProgramFiles%\Bus-Simulator 2009
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Bus-Simulator 2009|*.dmp;*.log|RECURSE
-FileKey2=%ProgramFiles%\Bus-Simulator 2009|*.dmp;*.log|RECURSE
+FileKey1=%ProgramFiles%\Bus-Simulator 2009|*.dmp;*.log|RECURSE
 
 [Business Objects Enterprise 11 *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Business Objects\Business Objects Enterprise 11
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Business Objects\Business Objects Enterprise 11\Logging|*.*
-FileKey2=%ProgramFiles%\Business Objects\Business Objects Enterprise 11\Logging|*.*
+FileKey1=%ProgramFiles%\Business Objects\Business Objects Enterprise 11\Logging|*.*
 
 [CA Security Center *]
 LangSecRef=3021
 Detect=HKLM\Software\CA\CAPF
 Default=False
 FileKey1=%CommonAppData%\CA|*.log;*.txt|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\CA|*.log;*.txt|RECURSE
-FileKey3=%LocalLowAppData%\CA\Consumer\APH|*.log
+FileKey2=%LocalLowAppData%\CA\Consumer\APH|*.log
 
 [Cached Certification Files *]
 LangSecRef=3025
@@ -4423,18 +4257,16 @@ LangSecRef=3021
 DetectFile1=%ProgramFiles%\EuroSoft\Calendar Magic
 DetectFile2=%SystemDrive%\EuroSoft\Calendar Magic
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\EuroSoft\Calendar Magic|debug.txt
-FileKey2=%ProgramFiles%\EuroSoft\Calendar Magic|debug.txt
-FileKey3=%SystemDrive%\EuroSoft\Calendar Magic|debug.txt
+FileKey1=%ProgramFiles%\EuroSoft\Calendar Magic|debug.txt
+FileKey2=%SystemDrive%\EuroSoft\Calendar Magic|debug.txt
 
 [Calendar Magic Backups *]
 LangSecRef=3021
 DetectFile1=%ProgramFiles%\EuroSoft\Calendar Magic
 DetectFile2=%SystemDrive%\EuroSoft\Calendar Magic
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\EuroSoft\Calendar Magic|*.bak
-FileKey2=%ProgramFiles%\EuroSoft\Calendar Magic|*.bak
-FileKey3=%SystemDrive%\EuroSoft\Calendar Magic|*.bak
+FileKey1=%ProgramFiles%\EuroSoft\Calendar Magic|*.bak
+FileKey2=%SystemDrive%\EuroSoft\Calendar Magic|*.bak
 
 [Calibre *]
 LangSecRef=3021
@@ -4447,7 +4279,6 @@ Section=Games
 Detect=HKLM\Software\Playrix\Call of Atlantis
 Default=False
 FileKey1=%CommonAppData%\Playrix Entertainment\Call of Atlantis\Log|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Playrix Entertainment\Call of Atlantis\Log|*.*
 
 [Call of Juarez *]
 Section=Games
@@ -4523,7 +4354,6 @@ LangSecRef=3021
 DetectFile=%CommonAppData%\CanonBJ
 Default=False
 FileKey1=%CommonAppData%\CanonBJ\IJPrinter\CNMWindows|drvlog*;drvlog*.*;plmlog*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\CanonBJ\IJPrinter\CNMWindows|drvlog*;drvlog*.*;plmlog*.*|RECURSE
 
 [Canon Zoom Browser *]
 LangSecRef=3021
@@ -4545,16 +4375,13 @@ DetectFile=%AppData%\CasualArts
 Default=False
 FileKey1=%AppData%\casualArts\*|logfile.*;*.txt|RECURSE
 FileKey2=%CommonAppData%\casualArts|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\casualArts|*.*|REMOVESELF
 
 [Cave Story+ *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\200900
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\cave story+|log.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\cave story+\data|*.DS_STORE|RECURSE
-FileKey3=%ProgramFiles%\Steam\steamapps\common\cave story+|log.txt
-FileKey4=%ProgramFiles%\Steam\steamapps\common\cave story+\data|*.DS_STORE|RECURSE
+FileKey1=%ProgramFiles%\Steam\steamapps\common\cave story+|log.txt
+FileKey2=%ProgramFiles%\Steam\steamapps\common\cave story+\data|*.DS_STORE|RECURSE
 
 [CC Magic *]
 Section=Games
@@ -4579,17 +4406,15 @@ FileKey1=%LocalAppData%\FlickrNet|responseCache.dat
 LangSecRef=3024
 Detect=HKCU\Software\Piriform\CCleaner
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\CCleaner|*.log;CCleaner_log*.txt
-FileKey2=%ProgramFiles%\CCleaner|*.log;CCleaner_log*.txt
-FileKey3=%ProgramFiles%\CCleaner\Setup|*.*|REMOVESELF
-FileKey4=%UserProfile%|CCleaner_log*.txt
+FileKey1=%ProgramFiles%\CCleaner|*.log;CCleaner_log*.txt
+FileKey2=%ProgramFiles%\CCleaner\Setup|*.*|REMOVESELF
+FileKey3=%UserProfile%|CCleaner_log*.txt
 
 [CCTV Security *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\CCTV Security
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Log|*.*
-FileKey2=%ProgramFiles%\CCTV Security\Log|*.*
+FileKey1=%ProgramFiles%\CCTV Security\Log|*.*
 
 [CD Burning *]
 LangSecRef=3025
@@ -4630,8 +4455,7 @@ LangSecRef=3021
 DetectFile=%ProgramFiles%\CFE Exam Prep Course
 Default=False
 FileKey1=%AppData%\ACFEExamPrep|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\CFE Exam Prep Course\Log|*.*|RECURSE
-FileKey3=%ProgramFiles%\CFE Exam Prep Course\Log|*.*|RECURSE
+FileKey2=%ProgramFiles%\CFE Exam Prep Course\Log|*.*|RECURSE
 
 [Chameleon *]
 LangSecRef=3024
@@ -4645,33 +4469,28 @@ Section=Games
 Detect1=HKCU\Software\Cryptic\Champions Online
 Detect2=HKCU\Software\Valve\Steam\Apps\9880
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Champions Online\*\Logs\GameClient|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\Champions Online\Champions Online\*\Cache|*.*
-FileKey3=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\*\Logs\GameClient|*.*
-FileKey4=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\Champions Online\*\Cache|*.*
-FileKey5=%Public%\Games\cryptic studios\Champions Online\*\Cache|*.*
-FileKey6=%Public%\Games\cryptic studios\Champions Online\*\Logs\GameClient|*.*
+FileKey1=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\*\Logs\GameClient|*.*
+FileKey2=%ProgramFiles%\Steam\Steamapps\Common\Champions Online\Champions Online\*\Cache|*.*
+FileKey3=%Public%\Games\cryptic studios\Champions Online\*\Cache|*.*
+FileKey4=%Public%\Games\cryptic studios\Champions Online\*\Logs\GameClient|*.*
 
 [Cheat Engine *]
 LangSecRef=3021
 Detect=HKCU\Software\Cheat Engine
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Cheat Engine*|*.tmp
-FileKey2=%ProgramFiles%\Cheat Engine*|*.tmp
+FileKey1=%ProgramFiles%\Cheat Engine*|*.tmp
 
 [CheatBook *]
 LangSecRef=3021
 Detect=HKLM\Software\CheatBook
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Cheatbook Database *|*cheatlog.txt;*suchlog.txt
-FileKey2=%ProgramFiles%\Cheatbook Database *|*cheatlog.txt;*suchlog.txt
+FileKey1=%ProgramFiles%\Cheatbook Database *|*cheatlog.txt;*suchlog.txt
 
 [Chicken Hunter *]
 Section=Games
 Detect=HKLM\Software\Chicken Hunter
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Chicken Hunter|debug.txt
-FileKey2=%ProgramFiles%\Chicken Hunter|debug.txt
+FileKey1=%ProgramFiles%\Chicken Hunter|debug.txt
 
 [Chicken Invaders *]
 Section=Games
@@ -4681,11 +4500,8 @@ DetectFile3=%ProgramFiles%\Chicken*Invaders*
 Default=False
 FileKey1=%AppData%\InterAction studios|*.log|RECURSE
 FileKey2=%CommonAppData%\InterAction studios|*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\*\Chicken Invaders*|*.log;*.html;*.png|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Chicken*Invaders*|*.log|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\InterAction studios|*.log|RECURSE
-FileKey6=%ProgramFiles%\*\Chicken Invaders*|*.log;*.html;*.png|RECURSE
-FileKey7=%ProgramFiles%\Chicken*Invaders*|*.log|RECURSE
+FileKey3=%ProgramFiles%\*\Chicken Invaders*|*.log;*.html;*.png|RECURSE
+FileKey4=%ProgramFiles%\Chicken*Invaders*|*.log|RECURSE
 
 [Children of the Nile *]
 Section=Games
@@ -4714,19 +4530,15 @@ Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Adven
 DetectFile=%ProgramFiles%\Christmas Adventure - Candy Storm
 Default=False
 FileKey1=%AppData%\Argali|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Christmas Adventure - Candy Storm|*.nfo;*.txt
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Foxy Games\Christmas Adventure - Candy Storm|*.html;*.msi;*.nfo;*.txt;*.url
-FileKey4=%ProgramFiles%\Christmas Adventure - Candy Storm|*.nfo;*.txt
-FileKey5=%ProgramFiles%\Foxy Games\Christmas Adventure - Candy Storm|*.html;*.msi;*.nfo;*.txt;*.url
+FileKey2=%ProgramFiles%\Christmas Adventure - Candy Storm|*.nfo;*.txt
+FileKey3=%ProgramFiles%\Foxy Games\Christmas Adventure - Candy Storm|*.html;*.msi;*.nfo;*.txt;*.url
 
 [Christmas Griddlers 2014 *]
 Section=Games
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Griddlers 20141.1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\*\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
-FileKey3=%ProgramFiles%\*\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
-FileKey4=%ProgramFiles%\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
+FileKey1=%ProgramFiles%\*\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
+FileKey2=%ProgramFiles%\Christmas Griddlers*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
 
 [Christmas Wonderland *]
 Section=Games
@@ -4737,18 +4549,15 @@ Detect4=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonde
 Detect5=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonderland 31.0
 Detect6=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Christmas Wonderland 41.1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Christmas Wonderland *|*.html;*.nfo;*.txt;*.url|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Foxy Games\Christmas Wonderland *|*.html;*.nfo;*.txt;*.url|RECURSE
-FileKey3=%ProgramFiles%\Christmas Wonderland *|*.html;*.nfo;*.txt;*.url|RECURSE
-FileKey4=%ProgramFiles%\Foxy Games\Christmas Wonderland *|*.html;*.nfo;*.txt;*.url|RECURSE
-FileKey5=%SystemDrive%\Games\Christmas Wonderland *|*.html;*.nfo;*.txt;*.url|RECURSE
+FileKey1=%ProgramFiles%\Christmas Wonderland *|*.html;*.nfo;*.txt;*.url|RECURSE
+FileKey2=%ProgramFiles%\Foxy Games\Christmas Wonderland *|*.html;*.nfo;*.txt;*.url|RECURSE
+FileKey3=%SystemDrive%\Games\Christmas Wonderland *|*.html;*.nfo;*.txt;*.url|RECURSE
 
 [Chuzzle Deluxe *]
 Section=Games
 DetectFile=%ProgramFiles%\HP Games\Chuzzle Deluxe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\HP Games\Chuzzle Deluxe|DEBUG.TXT
-FileKey2=%ProgramFiles%\HP Games\Chuzzle Deluxe|DEBUG.TXT
+FileKey1=%ProgramFiles%\HP Games\Chuzzle Deluxe|DEBUG.TXT
 
 [Cinema Tycoon *]
 Section=Games
@@ -4764,7 +4573,6 @@ LangSecRef=3022
 DetectFile=%CommonAppData%\Cisco Systems\Cisco Connect
 Default=False
 FileKey1=%CommonAppData%\Cisco Systems\Cisco Connect\Log|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Cisco Systems\Cisco Connect\Log|*.*
 
 [Cisco HostScan *]
 LangSecRef=3021
@@ -4830,20 +4638,16 @@ Default=False
 FileKey1=%Documents%\My Games\Beyond the Sword\Logs|*.*
 FileKey2=%Documents%\My Games\Sid Meier's Civilization *\Logs|*.*
 FileKey3=%Documents%\My Games\Warlords\Logs|*.*
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\2K Games\Firaxis Games\Sid Meier's Civilization IV Colonization|*.txt
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Firaxis Games\Sid Meier's Civilization 4|*.txt
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Firaxis Games\Sid Meier's Civilization 4\*|*.txt
-FileKey7=%ProgramFiles%\2K Games\Firaxis Games\Sid Meier's Civilization IV Colonization|*.txt
-FileKey8=%ProgramFiles%\Firaxis Games\Sid Meier's Civilization 4|*.txt
-FileKey9=%ProgramFiles%\Firaxis Games\Sid Meier's Civilization 4\*|*.txt
+FileKey4=%ProgramFiles%\2K Games\Firaxis Games\Sid Meier's Civilization IV Colonization|*.txt
+FileKey5=%ProgramFiles%\Firaxis Games\Sid Meier's Civilization 4|*.txt
+FileKey6=%ProgramFiles%\Firaxis Games\Sid Meier's Civilization 4\*|*.txt
 
 [Clam Sentinel *]
 LangSecRef=3021
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{060FE577-1BDF-4330-ACCA-B6760AB07191}_is1
 Default=False
 FileKey1=%AppData%\ClamSentinel|*.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\ClamSentinel|*.txt
-FileKey3=%ProgramFiles%\ClamSentinel|*.txt
+FileKey2=%ProgramFiles%\ClamSentinel|*.txt
 
 [ClamWin *]
 LangSecRef=3021
@@ -4852,8 +4656,7 @@ Detect2=HKLM\Software\ClamWin
 Default=False
 FileKey1=%AppData%\.clamwin\log|*.*|RECURSE
 FileKey2=%CommonAppData%\.clamwin\log|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\ClamWin\bin|*.txt
-FileKey4=%ProgramFiles%\ClamWin\bin|*.txt
+FileKey3=%ProgramFiles%\ClamWin\bin|*.txt
 
 [ClamWin Portable Failed Updates *]
 LangSecRef=3024
@@ -4871,8 +4674,7 @@ RegKey1=HKCU\Software\IvoSoft\ClassicStartMenu\MRU
 LangSecRef=3024
 DetectFile=%ProgramFiles%\CleanGenius 3\Update
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\CleanGenius 3\Update|update.log
-FileKey2=%ProgramFiles%\CleanGenius 3\Update|update.log
+FileKey1=%ProgramFiles%\CleanGenius 3\Update|update.log
 
 [CleanMyPC Registry Cleaner *]
 LangSecRef=3024
@@ -4904,7 +4706,6 @@ LangSecRef=3024
 DetectFile=%CommonAppData%\ClickFree\FullImagingBackup
 Default=False
 FileKey1=%CommonAppData%\ClickFree\FullImagingBackup|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\ClickFree\FullImagingBackup|*.log
 
 [ClipX *]
 LangSecRef=3024
@@ -4916,8 +4717,7 @@ FileKey1=%LocalAppData%\ClipX\Storage|*.*
 LangSecRef=3024
 DetectFile=%ProgramFiles%\CloneSpy
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\CloneSpy|CloneSpy.log
-FileKey2=%ProgramFiles%\CloneSpy|CloneSpy.log
+FileKey1=%ProgramFiles%\CloneSpy|CloneSpy.log
 
 [Cloud Experience Host *]
 DetectOS=10.0|
@@ -5048,8 +4848,7 @@ FileKey6=%SystemDrive%\Qoobox\Test*|*.*|REMOVESELF
 LangSecRef=3022
 Detect=HKCU\Software\ComcastToolbar
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ComcastToolbar\Cache|*.*
-FileKey2=%ProgramFiles%\ComcastToolbar\Cache|*.*
+FileKey1=%ProgramFiles%\ComcastToolbar\Cache|*.*
 
 [ComicRack *]
 LangSecRef=3021
@@ -5093,11 +4892,7 @@ FileKey4=%CommonAppData%\Comodo\CisDumps|*.*
 FileKey5=%CommonAppData%\Comodo\Firewall Pro|cislogs.sdb
 FileKey6=%CommonAppData%\Comodo\Installer|*.*
 FileKey7=%LocalAppData%\COMODO|*.tmp
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\COMODO\COMODO Internet Security|*.tmp
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Comodo Downloader|*.*
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Comodo\CisDumps|*.*
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\Comodo\Installer|*.*
-FileKey12=%ProgramFiles%\COMODO\COMODO Internet Security|*.tmp;CRASH.DMP;cmdagent.zip
+FileKey8=%ProgramFiles%\COMODO\COMODO Internet Security|*.tmp;CRASH.DMP;cmdagent.zip
 
 [Comodo CertSentry *]
 LangSecRef=3022
@@ -5110,8 +4905,7 @@ LangSecRef=3021
 Detect=HKLM\Software\GeekBuddyRSP
 DetectFile=%ProgramFiles%\Comodo\GeekBuddy
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Comodo\GeekBuddy\logs|*.*|RECURSE
-FileKey2=%ProgramFiles%\Comodo\GeekBuddy\logs|*.*|RECURSE
+FileKey1=%ProgramFiles%\Comodo\GeekBuddy\logs|*.*|RECURSE
 
 [Company of Heroes *]
 Section=Games
@@ -5139,13 +4933,9 @@ FileKey2=%CommonAppData%\Conceiva\Mezzmo\CER|*.zip
 FileKey3=%LocalAppData%\Conceiva\Logs|*.*|REMOVESELF
 FileKey4=%LocalAppData%\Conceiva\Mezzmo|DebugCERwrite.txt
 FileKey5=%LocalAppData%\Conceiva\Mezzmo\Temporary_*_Files|*.*|REMOVESELF
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo|*.txt
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo\Third\MKVToolNix|*.txt
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\Conceiva\Mezzmo\Third\OGMDemuxer\doc|*.*|REMOVESELF
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Conceiva\Mezzmo\CER|*.zip
-FileKey10=%ProgramFiles%\Conceiva\Mezzmo|*.txt
-FileKey11=%ProgramFiles%\Conceiva\Mezzmo\Third\MKVToolNix|*.txt
-FileKey12=%ProgramFiles%\Conceiva\Mezzmo\Third\OGMDemuxer\doc|*.*|REMOVESELF
+FileKey6=%ProgramFiles%\Conceiva\Mezzmo|*.txt
+FileKey7=%ProgramFiles%\Conceiva\Mezzmo\Third\MKVToolNix|*.txt
+FileKey8=%ProgramFiles%\Conceiva\Mezzmo\Third\OGMDemuxer\doc|*.*|REMOVESELF
 RegKey1=HKCU\Software\Conceiva\Mezzmo\General|LastWatchFolder
 
 [Conduit *]
@@ -5162,9 +4952,8 @@ LangSecRef=3022
 Detect=HKLM\Software\Connectify
 Default=False
 FileKey1=%CommonAppData%\Connectify\cache|*.time;*.cache;*.runtime
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Connectify\cache|*.time;*.cache;*.runtime
-FileKey3=%ProgramFiles%\Connectify\Installer|*.*|REMOVESELF
-FileKey4=%ProgramFiles%\Connectify\Portal|*.*|REMOVESELF
+FileKey2=%ProgramFiles%\Connectify\Installer|*.*|REMOVESELF
+FileKey3=%ProgramFiles%\Connectify\Portal|*.*|REMOVESELF
 
 [Connectivity Store *]
 DetectOS=10.0|
@@ -5184,8 +4973,7 @@ FileKey8=%LocalAppData%\Packages\Microsoft.ConnectivityStore_*\TempState|*.*|REC
 Section=Games
 DetectFile=%ProgramFiles%\NetDragon\Conquer Online 2.0\AutoPatch
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\NetDragon\Conquer Online 2.0\AutoPatch|Update.log
-FileKey2=%ProgramFiles%\NetDragon\Conquer Online 2.0\AutoPatch|Update.log
+FileKey1=%ProgramFiles%\NetDragon\Conquer Online 2.0\AutoPatch|Update.log
 
 [Contact Support *]
 DetectOS=10.0|
@@ -5317,8 +5105,6 @@ DetectFile2=%CommonAppData%\WindSolutions\CopyTrans*
 Default=False
 FileKey1=%CommonAppData%\WindSolutions|*.txt|RECURSE
 FileKey2=%CommonAppData%\WindSolutions\CopyTrans*\Logs|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\WindSolutions|*.txt|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\WindSolutions\CopyTrans*\Logs|*.*|RECURSE
 
 [Core Temp *]
 LangSecRef=3024
@@ -5428,7 +5214,6 @@ LangSecRef=3024
 Detect=HKLM\Software\Sunbelt Software\CounterSpy
 Default=False
 FileKey1=%CommonAppData%\Sunbelt Software\CounterSpy\Logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Sunbelt Software\CounterSpy\Logs|*.*
 
 [Crayon Physics Deluxe *]
 Section=Games
@@ -5436,21 +5221,16 @@ Detect=HKCU\Software\Valve\Steam\Apps\26900
 Default=False
 FileKey1=%AppData%\Crayon Physics Deluxe|log.txt
 FileKey2=%AppData%\Crayon Physics Deluxe\data\recordings\temp|current_recording.tmp
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\crayon physics deluxe|log.txt
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\crayon physics deluxe\cache|*.*
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\crayon physics deluxe\data\editor|*.tmp
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\crayon physics deluxe\data\recordings\temp|*.tmp
-FileKey7=%ProgramFiles%\Steam\steamapps\common\crayon physics deluxe|log.txt
-FileKey8=%ProgramFiles%\Steam\steamapps\common\crayon physics deluxe\cache|*.*
-FileKey9=%ProgramFiles%\Steam\steamapps\common\crayon physics deluxe\data\editor|*.tmp
-FileKey10=%ProgramFiles%\Steam\steamapps\common\crayon physics deluxe\data\recordings\temp|*.tmp
+FileKey3=%ProgramFiles%\Steam\steamapps\common\crayon physics deluxe|log.txt
+FileKey4=%ProgramFiles%\Steam\steamapps\common\crayon physics deluxe\cache|*.*
+FileKey5=%ProgramFiles%\Steam\steamapps\common\crayon physics deluxe\data\editor|*.tmp
+FileKey6=%ProgramFiles%\Steam\steamapps\common\crayon physics deluxe\data\recordings\temp|*.tmp
 
 [Creative Installation Information *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Creative Installation Information
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Creative Installation Information|*.log|RECURSE
-FileKey2=%ProgramFiles%\Creative Installation Information|*.log|RECURSE
+FileKey1=%ProgramFiles%\Creative Installation Information|*.log|RECURSE
 
 [Creative Live! Central 3 *]
 LangSecRef=3023
@@ -5472,8 +5252,6 @@ Detect3=HKLM\Software\CREATIVE TECH\Sound Blaster Z-Series Control Panel
 Default=False
 FileKey1=%CommonAppData%\Creative\Software Update\Cache|*.*|RECURSE
 FileKey2=%CommonAppData%\Creative\Software Update\Log|*.*
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Creative\Software Update\Cache|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Creative\Software Update\Log|*.*
 
 [Crypt of the NecroDancer *]
 Section=Games
@@ -5492,17 +5270,15 @@ RegKey1=HKCU\Software\CrypTool2.0|recentFileList
 Section=Games
 Detect=HKLM\Software\Crytek\Crysis 3
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Origin Games\Crysis 3\LogBackups|*.*
-FileKey2=%ProgramFiles%\Origin Games\Crysis 3\LogBackups|*.*
-FileKey3=%UserProfile%\Saved Games\Crysis 3|*.Log.txt
+FileKey1=%ProgramFiles%\Origin Games\Crysis 3\LogBackups|*.*
+FileKey2=%UserProfile%\Saved Games\Crysis 3|*.Log.txt
 
 [CrystalDiskInfo *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\CrystalDiskInfo\Smart
 Default=False
 Warning=This will delete all saved SMART data for history/graph function.
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\CrystalDiskInfo\Smart|*.*|RECURSE
-FileKey2=%ProgramFiles%\CrystalDiskInfo\Smart|*.*|RECURSE
+FileKey1=%ProgramFiles%\CrystalDiskInfo\Smart|*.*|RECURSE
 
 [Curse Client *]
 Section=Games
@@ -5594,8 +5370,6 @@ Detect=HKCU\Software\CyberLink
 Default=False
 FileKey1=%CommonAppData%\CyberLink\Boomerang\*|*.xml;*.dmp
 FileKey2=%CommonAppData%\CyberLink\PowerDVD*\Boomerang\*|*.xml;*.dmp
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\CyberLink\Boomerang\*|*.xml;*.dmp
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\CyberLink\PowerDVD*\Boomerang\*|*.xml;*.dmp
 
 [CyberLink Downloader *]
 LangSecRef=3023
@@ -5610,8 +5384,6 @@ Detect=HKCU\Software\CyberLink
 Default=False
 FileKey1=%CommonAppData%\install_backup|*.*|REMOVESELF
 FileKey2=%CommonAppData%\install_clap|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\install_backup|*.*|REMOVESELF
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\install_clap|*.*|REMOVESELF
 
 [CyberLink Media Cache *]
 LangSecRef=3023
@@ -5829,18 +5601,15 @@ RegKey2=HKCU\Software\DAMN\DAMN NFO Viewer\Recently Viewed Files
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\251170
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Damned|*.log|RECURSE
-FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Damned|*.log|RECURSE
+FileKey1=%ProgramFiles%\Steam\SteamApps\Common\Damned|*.log|RECURSE
 
 [Dangerous Waters *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\1600
 DetectFile=%ProgramFiles%\Sonalysts Combat Simulations\Dangerous Waters
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Sonalysts Combat Simulations\Dangerous Waters|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Dangerous Waters|*.log
-FileKey3=%ProgramFiles%\Sonalysts Combat Simulations\Dangerous Waters|*.log
-FileKey4=%ProgramFiles%\Steam\SteamApps\Common\Dangerous Waters|*.log
+FileKey1=%ProgramFiles%\Sonalysts Combat Simulations\Dangerous Waters|*.log
+FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Dangerous Waters|*.log
 
 [DARK *]
 Section=Games
@@ -5853,15 +5622,13 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\267790
 Default=False
 FileKey1=%AppData%\DarkBlood ServiceST|*.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Dark Blood\logs|*.*|RECURSE
-FileKey3=%ProgramFiles%\Steam\SteamApps\Common\Dark Blood\logs|*.*|RECURSE
+FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Dark Blood\logs|*.*|RECURSE
 
 [Darkspore *]
 Section=Games
 DetectFile=%ProgramFiles%\Origin Games\Darkspore
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Origin Games\Darkspore|*.log|RECURSE
-FileKey2=%ProgramFiles%\Origin Games\Darkspore|*.log|RECURSE
+FileKey1=%ProgramFiles%\Origin Games\Darkspore|*.log|RECURSE
 
 [Dashlane *]
 LangSecRef=3022
@@ -5873,8 +5640,7 @@ FileKey1=%AppData%\Dashlane\*\background_cache|*.*|RECURSE
 LangSecRef=3021
 DetectFile=%ProgramFiles%\DataTron7
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\DataTron7|*.GID;*.BAK
-FileKey2=%ProgramFiles%\DataTron7|*.GID;*.BAK
+FileKey1=%ProgramFiles%\DataTron7|*.GID;*.BAK
 
 [David FX Basic *]
 LangSecRef=3024
@@ -5910,8 +5676,7 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\24200
 Default=False
 FileKey1=%Documents%\My Games\DC Universe Online\Logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\DC Universe Online|.downloadInfo.txt;.downloadStats.txt
-FileKey3=%ProgramFiles%\Steam\SteamApps\Common\DC Universe Online|.downloadInfo.txt;.downloadStats.txt
+FileKey2=%ProgramFiles%\Steam\SteamApps\Common\DC Universe Online|.downloadInfo.txt;.downloadStats.txt
 
 [Dead Island *]
 Section=Games
@@ -5923,9 +5688,8 @@ FileKey1=%Documents%\DeadIsland\out\logs|*.*
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\203810
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\dear esther\dearesther|*.tmp
-FileKey2=%ProgramFiles%\Steam\Steamapps\common\dear esther\dearesther|*.tmp
-FileKey3=%ProgramFiles%\Steam\Steamapps\common\dear esther\dearesther\resource|*.icns
+FileKey1=%ProgramFiles%\Steam\Steamapps\common\dear esther\dearesther|*.tmp
+FileKey2=%ProgramFiles%\Steam\Steamapps\common\dear esther\dearesther\resource|*.icns
 
 [Death to Spies: Moment of Truth *]
 Section=Games
@@ -5944,7 +5708,6 @@ LangSecRef=3021
 Detect=HKCU\Software\Debenu
 Default=False
 FileKey1=%CommonAppData%\Debenu\PDF Tools\Reports\App Log|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Debenu\PDF Tools\Reports\App Log|*.*
 RegKey1=HKCU\Software\Debenu\Debenu PDF Maximus 2\MaximusViewerRecentDocs
 RegKey2=HKCU\Software\Debenu\Debenu PDF Maximus 2\MaximusViewerRecentFolders
 
@@ -5958,16 +5721,14 @@ FileKey1=%AppData%\DeepBurner|DeepBurner.log
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\18500
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\defensegridtheawakening\Shaders\Generated|*.cache
-FileKey2=%ProgramFiles%\Steam\steamapps\common\defensegridtheawakening\Shaders\Generated|*.cache
+FileKey1=%ProgramFiles%\Steam\steamapps\common\defensegridtheawakening\Shaders\Generated|*.cache
 
 [Defraggler *]
 LangSecRef=3024
 Detect=HKCU\Software\Piriform\Defraggler
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Defraggler|*.dmp;*statistics*;*.log;Defraggler*.txt
-FileKey2=%ProgramFiles%\Defraggler|*.dmp;*statistics*;*.log;Defraggler*.txt
-FileKey3=%UserProfile%|Defraggler*.txt
+FileKey1=%ProgramFiles%\Defraggler|*.dmp;*statistics*;*.log;Defraggler*.txt
+FileKey2=%UserProfile%|Defraggler*.txt
 
 [Delfix *]
 LangSecRef=3024
@@ -6016,16 +5777,13 @@ FileKey11=%CommonAppData%\PCDr\*\Cache\DriverScan|*.*
 FileKey12=%CommonAppData%\PCDr\*\Logs|*.log
 FileKey13=%LocalAppData%\Dell\*\Log|*.*
 FileKey14=%LocalAppData%\SupportSoft\DellSupportCenter\*\state\logs|*.*
-FileKey15=%LocalAppData%\VirtualStore\Program Files*\Dell*|*.log|RECURSE
-FileKey16=%LocalAppData%\VirtualStore\ProgramData\Dell\*\Log|*.*
-FileKey17=%ProgramFiles%\Dell*|*.log|RECURSE
+FileKey15=%ProgramFiles%\Dell*|*.log|RECURSE
 
 [Dell PC Doctor Dumps *]
 LangSecRef=3024
 DetectFile=%CommonAppData%\PCDr
 Default=False
 FileKey1=%CommonAppData%\PCDr|*.dmp|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\PCDr|*.dmp|RECURSE
 
 [Dependency Walker *]
 LangSecRef=3025
@@ -6046,9 +5804,7 @@ Detect=HKLM\Software\Desura
 DetectFile=%ProgramFiles%\Desura
 Default=False
 FileKey1=%CommonAppData%\Desura\DesuraApp\Cache|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Desura\Cache\games|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Desura\DesuraApp\Cache|*.*|RECURSE
-FileKey4=%ProgramFiles%\Desura\Cache\games|*.*|RECURSE
+FileKey2=%ProgramFiles%\Desura\Cache\games|*.*|RECURSE
 
 [Desura Game Installation Tools *]
 Section=Games
@@ -6057,7 +5813,6 @@ DetectFile=%ProgramFiles%\Desura
 Default=False
 Warning=Don't use this if you have limited bandwidth as they will be re-downloaded on next game installation.
 FileKey1=%CommonAppData%\Desura\DesuraApp\tools|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Desura\DesuraApp\tools|*.*|RECURSE
 ExcludeKey1=PATH|%CommonAppData%\Desura\DesuraApp\tools\installcheck\|*.*
 
 [Desura Logs *]
@@ -6067,18 +5822,14 @@ DetectFile=%ProgramFiles%\Desura
 Default=False
 FileKey1=%CommonAppData%\Desura\DesuraApp|update_log.txt
 FileKey2=%CommonAppData%\Desura\DesuraApp\dumps|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Desura|*.log
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Desura\DesuraApp|update_log.txt
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Desura\DesuraApp\dumps|*.*
-FileKey6=%ProgramFiles%\Desura|*.log
+FileKey3=%ProgramFiles%\Desura|*.log
 
 [Desura Update Backups *]
 Section=Games
 Detect=HKLM\Software\Desura
 DetectFile=%ProgramFiles%\Desura
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Desura|*.exe_old
-FileKey2=%ProgramFiles%\Desura|*.exe_old
+FileKey1=%ProgramFiles%\Desura|*.exe_old
 
 [Desura Web Cache *]
 Section=Games
@@ -6086,7 +5837,6 @@ Detect=HKLM\Software\Desura
 DetectFile=%ProgramFiles%\Desura
 Default=False
 FileKey1=%CommonAppData%\Desura\DesuraApp|webcore_cache.sqlite
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Desura\DesuraApp|webcore_cache.sqlite
 
 [Deus Ex *]
 Section=Games
@@ -6146,25 +5896,21 @@ FileKey1=%AppData%\Dexpot|*.log
 Section=Games
 Detect=HKCU\Software\Blizzard Entertainment\Diablo II
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Diablo II|bnupdate.log;BnetLog.txt;D*.txt
-FileKey2=%ProgramFiles%\Diablo II|bnupdate.log;BnetLog.txt;D*.txt
-FileKey3=%SystemDrive%\Diablo II|bnupdate.log;BnetLog.txt;D*.txt
+FileKey1=%ProgramFiles%\Diablo II|bnupdate.log;BnetLog.txt;D*.txt
+FileKey2=%SystemDrive%\Diablo II|bnupdate.log;BnetLog.txt;D*.txt
 
 [Diablo III *]
 Section=Games
 Detect=HKCU\Software\Blizzard Entertainment\D3
 Default=False
 FileKey1=%CommonAppData%\Battle.net\Setup\diablo3_engb\Log|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Diablo III*\Logs|*.*
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Battle.net\Setup\diablo3_engb\Log|*.*
-FileKey4=%ProgramFiles%\Diablo III*\Logs|*.*
+FileKey2=%ProgramFiles%\Diablo III*\Logs|*.*
 
 [Digi Net Mobile *]
 LangSecRef=3021
 DetectFile=%CommonAppData%\Digi Net Mobile
 Default=False
 FileKey1=%CommonAppData%\Digi Net Mobile\log|*.log;*.txt
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Digi Net Mobile\log|*.log;*.txt
 
 [Digital Janitor *]
 LangSecRef=3024
@@ -6254,8 +6000,7 @@ Detect=HKCU\Software\DivX
 Default=False
 FileKey1=%AppData%\DivX|Font Cache.|RECURSE
 FileKey2=%CommonAppData%\DivX|*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\DivX|*.log|RECURSE
-FileKey4=%Video%\DivX Movies|*.*|RECURSE
+FileKey3=%Video%\DivX Movies|*.*|RECURSE
 RegKey1=HKCU\Software\DivX\Settings\Converter|lastBrowseDir
 RegKey2=HKCU\Software\DivX\Settings\Converter|outputDir
 RegKey3=HKCU\Software\DivX\Settings\Player\PlayerState|LastOpenFileLocation
@@ -6316,8 +6061,7 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\219740
 Default=False
 FileKey1=%Documents%\Klei\DoNotStarve|log.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\dont_starve\bin|log.txt
-FileKey3=%ProgramFiles%\Steam\steamapps\common\dont_starve\bin|log.txt
+FileKey2=%ProgramFiles%\Steam\steamapps\common\dont_starve\bin|log.txt
 
 [Dooble Downloads *]
 LangSecRef=3022
@@ -6398,7 +6142,6 @@ Detect2=HKLM\Software\BioWare\Dragon Age
 Default=False
 FileKey1=%CommonAppData%\BioWare\Dragon Age\DA Updater\Logs|*.*
 FileKey2=%Documents%\BioWare\Dragon Age\Logs|*.*
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\BioWare\Dragon Age\DA Updater\Logs|*.*
 
 [Dreadnought *]
 Section=Games
@@ -6410,32 +6153,27 @@ FileKey1=%LocalAppData%\DreadGame\Saved\Logs|*.log
 LangSecRef=3021
 Detect=HKLM\Software\Runtime Software\DIXML
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Runtime Software\DriveImage XML|log.txt
-FileKey2=%ProgramFiles%\Runtime Software\DriveImage XML|log.txt
+FileKey1=%ProgramFiles%\Runtime Software\DriveImage XML|log.txt
 
 [Driver Cleaner.NET *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\DriverCleanerDotNET\DriverCleanerDotNET.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\DriverCleanerDotNET\Backup|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\DriverCleanerDotNET\Log|*.*
-FileKey3=%ProgramFiles%\DriverCleanerDotNET\Backup|*.*|RECURSE
-FileKey4=%ProgramFiles%\DriverCleanerDotNET\Log|*.*
+FileKey1=%ProgramFiles%\DriverCleanerDotNET\Backup|*.*|RECURSE
+FileKey2=%ProgramFiles%\DriverCleanerDotNET\Log|*.*
 
 [Driver Fusion *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Driver Fusion\Logs
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Driver Fusion\Logs|*.*|RECURSE
-FileKey2=%ProgramFiles%\Driver Fusion\Logs|*.*|RECURSE
+FileKey1=%ProgramFiles%\Driver Fusion\Logs|*.*|RECURSE
 
 [Driver Fusion Backups *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Driver Fusion\Backup
 Default=False
 Warning=This will delete your driver backups.
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Driver Fusion\Backup|*.*|RECURSE
-FileKey2=%ProgramFiles%\Driver Fusion\Backup|*.*|RECURSE
+FileKey1=%ProgramFiles%\Driver Fusion\Backup|*.*|RECURSE
 
 [Driver Installation Files *]
 LangSecRef=3025
@@ -6486,7 +6224,6 @@ DetectFile=%ProgramFiles%\Driver-Soft\DriverGenius
 Default=False
 FileKey1=%CommonAppData%\DriverGenius|*.log
 FileKey2=%LocalAppData%\DriverGenius|ScanLog.log
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\DriverGenius|*.log
 
 [DriverMax *]
 LangSecRef=3024
@@ -6576,7 +6313,6 @@ LangSecRef=3022
 Detect=HKCU\Software\Hagel\DU Meter
 Default=False
 FileKey1=%CommonAppData%\Hagel Technologies\DU Meter|*.csv
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Hagel Technologies\DU Meter|*.csv
 
 [DuckieTV *]
 LangSecRef=3023
@@ -6588,8 +6324,7 @@ FileKey1=%AppData%\DuckieTV|*.log;*.txt
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\225140
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\Duke Nukem 3D\bin|stderr.txt;stdout.txt
-FileKey2=%ProgramFiles%\Steam\SteamApps\common\Duke Nukem 3D\bin|stderr.txt;stdout.txt
+FileKey1=%ProgramFiles%\Steam\SteamApps\common\Duke Nukem 3D\bin|stderr.txt;stdout.txt
 
 [DUMo *]
 LangSecRef=3024
@@ -6629,19 +6364,16 @@ FileKey2=%Documents%|Duplicate Cleaner log.txt
 LangSecRef=3024
 Detect=HKLM\Software\DVBDream
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\dvbdream|*.log;*.bak;*levellog*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\dvbdream\Logs|*.*
-FileKey3=%ProgramFiles%\dvbdream|*.log;*.bak;*levellog*|RECURSE
-FileKey4=%ProgramFiles%\dvbdream\Logs|*.*
-FileKey5=%SystemDrive%\dvbdream|*.log;*.bak;*levellog*|RECURSE
-FileKey6=%SystemDrive%\dvbdream\Logs|*.*
+FileKey1=%ProgramFiles%\dvbdream|*.log;*.bak;*levellog*|RECURSE
+FileKey2=%ProgramFiles%\dvbdream\Logs|*.*
+FileKey3=%SystemDrive%\dvbdream|*.log;*.bak;*levellog*|RECURSE
+FileKey4=%SystemDrive%\dvbdream\Logs|*.*
 
 [DVBViewer *]
 LangSecRef=3023
 Detect=HKLM\Software\CM&V\DVBViewer
 Default=False
 FileKey1=%CommonAppData%\CMUV\DVBViewer*|*.bak;*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\CMUV\DVBViewer*|*.bak;*.log
 
 [DVBViewer Setup Files *]
 LangSecRef=3023
@@ -6664,13 +6396,10 @@ Default=False
 FileKey1=%AppData%\DVD-Cloner*|*.log
 FileKey2=%CommonAppData%\DVD-Cloner*|*.log
 FileKey3=%Documents%|Smart.log;Smart_result.log
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\DVD-Cloner Platinum\*\readcache|*.*
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\DVD-Cloner*|*.log|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\DVD-Cloner*|*.log
-FileKey7=%ProgramFiles%\DVD-Cloner Platinum\*\readcache|*.*
-FileKey8=%ProgramFiles%\DVD-Cloner*|*.log|RECURSE
-FileKey9=%SystemDrive%|dtdlog.txt
-FileKey10=%WinDir%\system32|dvdtest10024.dat
+FileKey4=%ProgramFiles%\DVD-Cloner Platinum\*\readcache|*.*
+FileKey5=%ProgramFiles%\DVD-Cloner*|*.log|RECURSE
+FileKey6=%SystemDrive%|dtdlog.txt
+FileKey7=%WinDir%\system32|dvdtest10024.dat
 
 [DVD-Ranger *]
 LangSecRef=3021
@@ -6680,9 +6409,7 @@ FileKey1=%CommonAppData%\DVDRanger\DDF626ADdvdcss|*.*
 FileKey2=%CommonAppData%\DVDRanger\Logs|*.*
 FileKey3=%Documents%\DVDRanger\Screenshots|*.*|RECURSE
 FileKey4=%Documents%\DVDRanger\Temp|*.*|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\DVDRanger\DDF626ADdvdcss|*.*
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\DVDRanger\Logs|*.*
-FileKey7=%SystemDrive%\DVDRanger|*.*|REMOVESELF
+FileKey5=%SystemDrive%\DVDRanger|*.*|REMOVESELF
 
 [DVD Flick *]
 LangSecRef=3023
@@ -6696,7 +6423,6 @@ Detect=HKCU\Software\DVD Shrink
 Default=False
 Warning=Each time you use this you'll have to agree to the DVD Shrink license.
 FileKey1=%CommonAppData%\DVD Shrink|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\DVD Shrink|*.*
 
 [dvdcss *]
 LangSecRef=3023
@@ -6747,8 +6473,7 @@ FileKey1=%AppData%\DVDVideoSoft\Backup|*.*|RECURSE
 LangSecRef=3023
 Detect=HKCU\Software\DVDx
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\DVDx|*.tmp
-FileKey2=%ProgramFiles%\DVDx|*.tmp
+FileKey1=%ProgramFiles%\DVDx|*.tmp
 RegKey1=HKCU\Software\DVDx\LastDir
 RegKey2=HKCU\Software\DVDx\LastOutput
 
@@ -6776,7 +6501,6 @@ LangSecRef=3022
 Detect=HKCU\Software\Dyn\Dyn Updater
 Default=False
 FileKey1=%CommonAppData%\Dyn\Updater|*.log;*.msi
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Dyn\Updater|*.log;*.msi
 
 [EA Core *]
 Section=Games
@@ -6786,9 +6510,6 @@ FileKey1=%CommonAppData%\EA Core\Cache|*.*|REMOVESELF
 FileKey2=%CommonAppData%\EA Logs|*.*
 FileKey3=%CommonAppData%\Electronic Arts\EA Core\logs|*.*
 FileKey4=%LocalAppData%\EA Core\Cache|*.*|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\EA Core\Cache|*.*|REMOVESELF
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\EA Logs|*.*
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Electronic Arts\EA Core\logs|*.*
 
 [EA Download Manager *]
 Section=Games
@@ -6818,39 +6539,34 @@ FileKey1=%AppData%\Earth Alerts\Messages|*.*|RECURSE
 LangSecRef=3024
 DetectFile=%ProgramFiles%\EaseUS\EaseUS Data Recovery Wizard
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\EaseUS\EaseUS Data Recovery Wizard|*.log
-FileKey2=%ProgramFiles%\EaseUS\EaseUS Data Recovery Wizard|*.log
+FileKey1=%ProgramFiles%\EaseUS\EaseUS Data Recovery Wizard|*.log
 ExcludeKey1=FILE|%ProgramFiles%\EaseUS\EaseUS Data Recovery Wizard\|install.log
 
 [EaseUS MobiSaver *]
 LangSecRef=3021
 Detect=HKLM\Software\EASEUS\EASEUS IPhone Wizard
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\EaseUS\EaseUS MobiSaver\bin|CommDbg.txt;easeusue.log;PR.log
-FileKey2=%ProgramFiles%\EaseUS\EaseUS MobiSaver\bin|CommDbg.txt;easeusue.log;PR.log
-FileKey3=%SystemDrive%\EaseUS MobiSaver Temp Backup|*.*|RECURSE
+FileKey1=%ProgramFiles%\EaseUS\EaseUS MobiSaver\bin|CommDbg.txt;easeusue.log;PR.log
+FileKey2=%SystemDrive%\EaseUS MobiSaver Temp Backup|*.*|RECURSE
 
 [EaseUS MobiSaver for Android *]
 LangSecRef=3021
 Detect=HKLM\Software\EaseUS\Mobisaver for Android
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\EaseUS\EaseUS MobiSaver for Android\bin|CommDbg.txt;Eaolog;easeusue.log;mbs;PR.log
-FileKey2=%ProgramFiles%\EaseUS\EaseUS MobiSaver for Android\bin|CommDbg.txt;Eaolog;easeusue.log;mbs;PR.log
-FileKey3=%SystemDrive%\EaseUS MobiSaver for Android Temp Backup|*.*|RECURSE
+FileKey1=%ProgramFiles%\EaseUS\EaseUS MobiSaver for Android\bin|CommDbg.txt;Eaolog;easeusue.log;mbs;PR.log
+FileKey2=%SystemDrive%\EaseUS MobiSaver for Android Temp Backup|*.*|RECURSE
 
 [EaseUS Partition Master *]
 LangSecRef=3024
 Detect=HKCU\Software\EASEUS\EASEUS Partition Manager
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\EASEUS\EASEUS Partition Master*\bin|*.log
-FileKey2=%ProgramFiles%\EASEUS\EASEUS Partition Master*\bin|*.log|RECURSE
+FileKey1=%ProgramFiles%\EASEUS\EASEUS Partition Master*\bin|*.log|RECURSE
 
 [EaseUS ToDo Backup *]
 LangSecRef=3024
 Detect=HKCU\Software\EaseUS\EaseUS Todo Backup
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\EaseUS\Todo Backup\bin|easeus.log;TbLogsysClient.tblog
-FileKey2=%ProgramFiles%\EaseUS\Todo Backup\bin|easeus.log;TbLogsysClient.tblog
+FileKey1=%ProgramFiles%\EaseUS\Todo Backup\bin|easeus.log;TbLogsysClient.tblog
 
 [East-Tec Eraser *]
 LangSecRef=3024
@@ -6887,10 +6603,8 @@ RegKey2=HKCU\Software\TopoGrafix\EasyGPS\Recent File List
 LangSecRef=3022
 Detect=HKCU\Software\eBay\eBayToolbar
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\eBay\eBay Toolbar*|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\eBay\eBay Toolbar*\eBayhistory|*.*|RECURSE
-FileKey3=%ProgramFiles%\eBay\eBay Toolbar*|*.log
-FileKey4=%ProgramFiles%\eBay\eBay Toolbar*\eBayhistory|*.*|RECURSE
+FileKey1=%ProgramFiles%\eBay\eBay Toolbar*|*.log
+FileKey2=%ProgramFiles%\eBay\eBay Toolbar*\eBayhistory|*.*|RECURSE
 RegKey1=HKCU\Software\eBay\eBayToolbar\History
 RegKey2=HKCU\Software\eBay\eBayToolbar\RecentSearches
 
@@ -6900,7 +6614,6 @@ Detect1=HKCU\Software\eBay\Turbo lister
 Detect2=HKCU\Software\eBay\Turbo lister2
 Default=False
 FileKey1=%CommonAppData%\eBay\Turbo Lister*|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\eBay\Turbo Lister*|*.log|RECURSE
 
 [EC XTRA Timer *]
 LangSecRef=3021
@@ -6914,15 +6627,13 @@ Detect=HKCU\Software\Valve\Steam\Apps\219910
 DetectFile=%LocalAppData%\Daedalic Entertainment\Harvey
 Default=False
 FileKey1=%LocalAppData%\Daedalic Entertainment\Harvey|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\Edna and Harvey Harvey's New Eyes|stderr.txt
-FileKey3=%ProgramFiles%\Steam\Steamapps\common\Edna and Harvey Harvey's New Eyes|stderr.txt
+FileKey2=%ProgramFiles%\Steam\Steamapps\common\Edna and Harvey Harvey's New Eyes|stderr.txt
 
 [Effective File Search *]
 LangSecRef=3024
 Detect=HKCU\Software\SOW\EFS
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\efs|cblist*.dat
-FileKey2=%ProgramFiles%\efs|cblist*.dat
+FileKey1=%ProgramFiles%\efs|cblist*.dat
 
 [Efficient Calendar *]
 LangSecRef=3021
@@ -6934,8 +6645,7 @@ FileKey1=%AppData%\Efficient Calendar\MRUItems|*.*|RECURSE
 LangSecRef=3021
 Detect=HKCU\Software\ElcomSoft\Elcomsoft Wireless Security Auditor
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Elcomsoft Password Recovery\Elcomsoft Wireless Security Auditor|*.log
-FileKey2=%ProgramFiles%\Elcomsoft Password Recovery\Elcomsoft Wireless Security Auditor|*.log
+FileKey1=%ProgramFiles%\Elcomsoft Password Recovery\Elcomsoft Wireless Security Auditor|*.log
 
 [Electric Sheep *]
 LangSecRef=3021
@@ -6986,10 +6696,8 @@ FileKey3=%AppData%\emesene\emesene2\*\*\log|*.*|RECURSE
 LangSecRef=3024
 Detect=HKLM\Software\Emsi Software GmbH\a-squared HiJackFree
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Emsisoft HiJackFree|*.old
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Emsisoft HiJackFree\Logs|*.*
-FileKey3=%ProgramFiles%\Emsisoft HiJackFree|*.old
-FileKey4=%ProgramFiles%\Emsisoft HiJackFree\Logs|*.*
+FileKey1=%ProgramFiles%\Emsisoft HiJackFree|*.old
+FileKey2=%ProgramFiles%\Emsisoft HiJackFree\Logs|*.*
 
 [EndNote X6 *]
 LangSecRef=3021
@@ -6999,12 +6707,8 @@ FileKey1=%AppData%\EndNote|*.log;*.16
 FileKey2=%CommonAppData%\Thomson.ResearchSoft.Installers|*.*|REMOVESELF
 FileKey3=%CommonProgramFiles%\Risxtd|*.LOG;*.txt
 FileKey4=%Documents%\My EndNote Library.Data\Trash|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\EndNote X6\Product-Support\ThirdParty\Apache2|NOTICE
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\EndNote*|*.txt
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Thomson.ResearchSoft.Installers|*.*|REMOVESELF
-FileKey8=%LocalAppData%\VritualStore\Program Files*\Common Files\Risxtd|*.LOG;*.txt
-FileKey9=%ProgramFiles%\EndNote X6\Product-Support\ThirdParty\Apache2|NOTICE
-FileKey10=%ProgramFiles%\EndNote*|*.txt
+FileKey5=%ProgramFiles%\EndNote X6\Product-Support\ThirdParty\Apache2|NOTICE
+FileKey6=%ProgramFiles%\EndNote*|*.txt
 
 [EnhanceMy8 *]
 LangSecRef=3024
@@ -7036,8 +6740,7 @@ FileKey1=%AppData%\Epson\FAX Utility\FAXLOG|*.*
 LangSecRef=3024
 Detect=HKCU\Software\Heidi Computers Ltd\Eraser\5.5
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Eraser|schedlog.txt
-FileKey2=%ProgramFiles%\Eraser*|schedlog.txt
+FileKey1=%ProgramFiles%\Eraser*|schedlog.txt
 
 [ESET *]
 LangSecRef=3021
@@ -7047,20 +6750,14 @@ Warning=You may need to run this in safe mode. You should also disable the ERA s
 FileKey1=%CommonAppData%\ESET\ESET*\Logs|*.*|RECURSE
 FileKey2=%CommonAppData%\ESET\ESET*\Oldfiles|*.*|RECURSE
 FileKey3=%CommonAppData%\ESET\ESET*\Updfiles|*.*|REMOVESELF
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\ESET\ESET*\Logs|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\ESET\ESET*\Oldfiles|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\ESET\ESET*\Updfiles|*.*|REMOVESELF
 
 [ESET Online Scanner *]
 LangSecRef=3024
 Detect=HKLM\Software\ESET\ESET Security
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner|log.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner\Modules\data\updfiles\temp|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\ESET\ESET Online Scanner\Quarantine|*.*
-FileKey4=%ProgramFiles%\ESET\ESET Online Scanner|log.txt
-FileKey5=%ProgramFiles%\ESET\ESET Online Scanner\Modules\data\updfiles\temp|*.*
-FileKey6=%ProgramFiles%\ESET\ESET Online Scanner\Quarantine|*.*
+FileKey1=%ProgramFiles%\ESET\ESET Online Scanner|log.txt
+FileKey2=%ProgramFiles%\ESET\ESET Online Scanner\Modules\data\updfiles\temp|*.*
+FileKey3=%ProgramFiles%\ESET\ESET Online Scanner\Quarantine|*.*
 
 [eSobi *]
 LangSecRef=3022
@@ -7100,7 +6797,6 @@ LangSecRef=3023
 Detect=HKCU\Software\Disney\DIGStream
 Default=False
 FileKey1=%CommonAppData%\DIGStream\ESPNMotion|*.wmv;*.tmp
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\DIGStream\ESPNMotion|*.wmv;*.tmp
 
 [Essential NetTools 3 *]
 LangSecRef=3022
@@ -7137,17 +6833,14 @@ LangSecRef=3021
 Detect=HKCU\Software\EuroSYSTEMS\CoCut Professional 2011
 Default=False
 FileKey1=%AppData%\EUROSYSTEMS\CoCut Professional 2011 15|*.bak
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\EUROSYSTEMS\CoCut Professional 2011|*.log;*.bak;*.tmp
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\EUROSYSTEMS\CoCut Professional 2011\log|*.*
-FileKey4=%ProgramFiles%\EUROSYSTEMS\CoCut Professional 2011|*.log;*.bak;*.tmp
-FileKey5=%ProgramFiles%\EUROSYSTEMS\CoCut Professional 2011\log|*.*
+FileKey2=%ProgramFiles%\EUROSYSTEMS\CoCut Professional 2011|*.log;*.bak;*.tmp
+FileKey3=%ProgramFiles%\EUROSYSTEMS\CoCut Professional 2011\log|*.*
 
 [EuroSYSTEMS SmartCut Pro *]
 LangSecRef=3021
 Detect=HKCU\Software\EuroSYSTEMS
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\EUROSYSTEMS\SmartCut Pro|*.bak;*.tmp
-FileKey2=%ProgramFiles%\EUROSYSTEMS\SmartCut Pro|*.bak;*.tmp
+FileKey1=%ProgramFiles%\EUROSYSTEMS\SmartCut Pro|*.bak;*.tmp
 
 [EVE Online *]
 Section=Games
@@ -7184,11 +6877,9 @@ DetectFile1=%AppData%\Everything
 DetectFile2=%ProgramFiles%\Everything
 Default=False
 FileKey1=%AppData%\Everything|*.csv;*.txt;*.tmp
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Everything|*.txt;*.csv;*.tmp
-FileKey3=%ProgramFiles%\Everything|*.csv;*.txt;*.tmp
+FileKey2=%ProgramFiles%\Everything|*.csv;*.txt;*.tmp
 ExcludeKey1=FILE|%AppData%\Everything\|Filters.csv
-ExcludeKey2=FILE|%LocalAppData%\VirtualStore\Program Files*\Everything\|Filters.csv
-ExcludeKey3=FILE|%ProgramFiles%\Everything\|Filters.csv
+ExcludeKey2=FILE|%ProgramFiles%\Everything\|Filters.csv
 
 [Exif Tag Remover *]
 LangSecRef=3024
@@ -7208,7 +6899,6 @@ LangSecRef=3024
 Detect=HKCU\Software\MKowalski\ExifPro
 Default=False
 FileKey1=%CommonAppData%\MiK\ExifPro|Cache*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\MiK\ExifPro|Cache*
 RegKey1=HKCU\Software\MKowalski\ExifPro\1.0\Browser\View 0|LastPath
 RegKey2=HKCU\Software\MKowalski\ExifPro\1.0\HTMLAlbumGen\RecentDestPaths
 RegKey3=HKCU\Software\MKowalski\ExifPro\1.0\RecentPaths
@@ -7283,8 +6973,7 @@ FileKey1=%LocalAppData%\FalloutShelter|*.log;*.bkp
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\63900
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\Fantasy Wars|gui_log.txt
-FileKey2=%ProgramFiles%\Steam\Steamapps\common\Fantasy Wars|gui_log.txt
+FileKey1=%ProgramFiles%\Steam\Steamapps\common\Fantasy Wars|gui_log.txt
 
 [FAR Manager *]
 LangSecRef=3021
@@ -7360,7 +7049,6 @@ LangSecRef=3024
 Detect=HKCU\Software\MiserWare, Inc.\FatBatt
 Default=False
 FileKey1=%CommonAppData%\MiserWare\FatBatt\logs|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\MiserWare\FatBatt\logs|*.log
 
 [Feedback Hub *]
 DetectOS=10.0|
@@ -7400,8 +7088,6 @@ Default=False
 FileKey1=%AppData%\Fighters\*\Logs|*.log;*log.txt
 FileKey2=%CommonAppData%\Common Toolkit Suite\Tools\Logs|*.log
 FileKey3=%CommonAppData%\Fighters\*\Logs|*.log
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Common Toolkit Suite\Tools\Logs|*.log
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Fighters\*\Logs|*.log
 
 [File Shredder *]
 LangSecRef=3024
@@ -7451,15 +7137,13 @@ FileKey1=%LocalAppData%\Packages\FileManager_*\LocalState|*.jpg
 LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{92789900-80D0-4B61-B742-7897964A69AB}_is1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Metability Software\FileMindQuickFix|*.log|RECURSE
-FileKey2=%ProgramFiles%\Metability Software\FileMindQuickFix|*.log|RECURSE
+FileKey1=%ProgramFiles%\Metability Software\FileMindQuickFix|*.log|RECURSE
 
 [FileZilla *]
 LangSecRef=3022
 Detect=HKLM\Software\FileZilla Client
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\FileZilla FTP Client|*.tmp
-FileKey2=%ProgramFiles%\FileZilla FTP Client|*.tmp
+FileKey1=%ProgramFiles%\FileZilla FTP Client|*.tmp
 
 [FilmOn *]
 LangSecRef=3031
@@ -7476,8 +7160,7 @@ RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 LangSecRef=3023
 Detect=HKLM\Software\Firebird Project
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Firebird\Firebird_2_1|*.log
-FileKey2=%ProgramFiles%\Firebird\Firebird_2_1|*.log
+FileKey1=%ProgramFiles%\Firebird\Firebird_2_1|*.log
 
 [Fishdom H2O *]
 Section=Games
@@ -7501,15 +7184,13 @@ FileKey1=%Video%|fmle*.log
 LangSecRef=3022
 Detect=HKLM\Software\FlashFXP
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\FlashFXP|quick.dat
-FileKey2=%ProgramFiles%\FlashFXP|quick.dat
+FileKey1=%ProgramFiles%\FlashFXP|quick.dat
 
 [FlashGet *]
 LangSecRef=3022
 Detect=HKCU\Software\JetCar
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\FlashGet|Default.bk*;Default.jcd.bak
-FileKey2=%ProgramFiles%\FlashGet|Default.bk*;Default.jcd.bak
+FileKey1=%ProgramFiles%\FlashGet|Default.bk*;Default.jcd.bak
 RegKey1=HKCU\Software\JetCar\JetCar|Recent File List
 
 [FLEXnet *]
@@ -7517,7 +7198,6 @@ LangSecRef=3021
 Detect=HKCU\Software\FlexNet
 Default=False
 FileKey1=%CommonAppData%\FLEXnet|*.data_backup.*;*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\FLEXnet|*.data_backup.*;*.log
 
 [FolderShare *]
 LangSecRef=3022
@@ -7537,8 +7217,7 @@ FileKey3=%WinDir%\ServiceProfiles\LocalService\AppData\Local\FontCache|~*.dat
 LangSecRef=3023
 Detect=HKLM\Software\foobar2000
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\foobar2000|failure.txt
-FileKey2=%ProgramFiles%\foobar2000|failure.txt
+FileKey1=%ProgramFiles%\foobar2000|failure.txt
 
 [Foobar2000 YouTube Source *]
 LangSecRef=3023
@@ -7583,8 +7262,7 @@ FileKey1=%LocalAppData%\FortniteGame\Saved\webcache|*.*|REMOVESELF
 LangSecRef=3021
 DetectFile=%ProgramFiles%\AAForwardObserver\AAForwardObserver.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\AAForwardObserver|FO.log
-FileKey2=%ProgramFiles%\AAForwardObserver|FO.log
+FileKey1=%ProgramFiles%\AAForwardObserver|FO.log
 
 [Foxit PhantomPDF *]
 LangSecRef=3021
@@ -7634,8 +7312,7 @@ RegKey1=HKCU\Software\Foxit Software\Foxit Reader 6.0\Preferences\History\Option
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\61310
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\Fractal\fractal_data|output_log.txt
-FileKey2=%ProgramFiles%\Steam\Steamapps\common\Fractal\fractal_data|output_log.txt
+FileKey1=%ProgramFiles%\Steam\Steamapps\common\Fractal\fractal_data|output_log.txt
 
 [Fre:ac *]
 LangSecRef=3024
@@ -7681,8 +7358,7 @@ LangSecRef=3022
 Detect=HKCU\Software\Freemake\FreemakeVideoDownloader
 Default=False
 FileKey1=%Documents%\Freemake\FreemakeVideoDownloader|fvd.bin
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Freemake|*.txt
-FileKey3=%ProgramFiles%\Freemake|*.txt
+FileKey2=%ProgramFiles%\Freemake|*.txt
 
 [FrostWire *]
 LangSecRef=3022
@@ -7696,16 +7372,14 @@ FileKey3=%Documents%\FrostWire\Incomplete|*.*|RECURSE
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\98200
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\Frozen Synapse|*.log
-FileKey2=%ProgramFiles%\Steam\Steamapps\common\Frozen Synapse|*.log
+FileKey1=%ProgramFiles%\Steam\Steamapps\common\Frozen Synapse|*.log
 
 [FTL: Faster Than Light *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\212680
 DetectFile=%Documents%\My Games\FasterThanLight
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\FTL Faster Than Light\crashlogs|*.*
-FileKey2=%ProgramFiles%\Steam\steamapps\common\FTL Faster Than Light\crashlogs|*.*
+FileKey1=%ProgramFiles%\Steam\steamapps\common\FTL Faster Than Light\crashlogs|*.*
 
 [Full Bore *]
 Section=Games
@@ -7717,8 +7391,7 @@ FileKey1=%Documents%\Full Bore|log.txt
 Section=Games
 DetectFile=%ProgramFiles%\Full Tilt Poker.net
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Full Tilt Poker.net\Cache|*.*
-FileKey2=%ProgramFiles%\Full Tilt Poker.net\Cache|*.*
+FileKey1=%ProgramFiles%\Full Tilt Poker.net\Cache|*.*
 
 [G-Data *]
 LangSecRef=3023
@@ -7726,10 +7399,7 @@ Detect=HKCU\Software\G Data
 Default=False
 FileKey1=%CommonAppData%\G Data\AVK\Log|*.*|RECURSE
 FileKey2=%CommonProgramFiles%\G Data\AVKScanP\G Data|*.log;*old
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Common Files\G Data\AVKScanP\G Data|*.log;*old
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\G Data\AntiVirus\AVK\UpdatePGM|*.log
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\G Data\AVK\Log|*.*|RECURSE
-FileKey6=%ProgramFiles%\G Data\AntiVirus\AVK\UpdatePGM|*.log
+FileKey3=%ProgramFiles%\G Data\AntiVirus\AVK\UpdatePGM|*.log
 
 [Gadu-Gadu *]
 LangSecRef=3022
@@ -7750,15 +7420,12 @@ Detect=HKCU\Software\GOG.com\Galaxy
 Default=False
 FileKey1=%CommonAppData%\GOG.com\Galaxy\logs|*.log
 FileKey2=%CommonAppData%\GOG.com\Galaxy\temp\desktop-galaxy-updater|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\ProgramData*\GOG.com\Galaxy\logs|*.log
-FileKey4=%LocalAppData%\VirtualStore\ProgramData*\GOG.com\Galaxy\temp\desktop-galaxy-updater|*.*|REMOVESELF
 
 [Galaxy Cache *]
 Section=Games
 Detect=HKCU\Software\GOG.com\Galaxy
 Default=False
 FileKey1=%CommonAppData%\GOG.com\Galaxy\webcache|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\ProgramData*\GOG.com\Galaxy\webcache|*.*|REMOVESELF
 
 [Game Bar *]
 DetectOS=10.0|
@@ -7827,8 +7494,7 @@ DetectFile=%LocalAppData%\Microsoft\GFWLive
 Default=False
 FileKey1=%CommonAppData%\Microsoft\GFWLive\Install\Logs|*.log
 FileKey2=%LocalAppData%\Microsoft\GFWLive|*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Microsoft\GFWLive\Install\Logs|*.log
-FileKey4=%ProgramFiles%\Microsoft Games for Windows - LIVE\Client|dotNetFx40_Client_setup.exe
+FileKey3=%ProgramFiles%\Microsoft Games for Windows - LIVE\Client|dotNetFx40_Client_setup.exe
 
 [Games for Windows Live Installers *]
 Section=Games
@@ -7845,15 +7511,13 @@ Detect3=HKCR\GSM_gsms
 Default=False
 FileKey1=%AppData%\GameSave Manager*\*Cache*|*.*
 FileKey2=%AppData%\GameSave Manager*\TaskLogs|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\GameSave Manager*\settings|*.log;ScanResults.txt|RECURSE
-FileKey4=%ProgramFiles%\GameSave Manager*\settings|*.log;ScanResults.txt|RECURSE
+FileKey3=%ProgramFiles%\GameSave Manager*\settings|*.log;ScanResults.txt|RECURSE
 
 [Gardens Inc. 2: The Road to Fame *]
 Section=Games
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{BBB8E5A9-EE43-491D-9A2D-84172C3C9384}_is1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\*\Gardens Inc. 2*|*.html;*.nfo;*.txt|RECURSE
-FileKey2=%ProgramFiles%\*\Gardens Inc. 2*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
+FileKey1=%ProgramFiles%\*\Gardens Inc. 2*|*.ico;*.html;*msi;*.nfo;*.txt;*.url|RECURSE
 
 [Gardenscapes *]
 Section=Games
@@ -7873,13 +7537,6 @@ FileKey4=%CommonAppData%\GarenaMessenger\cache\emoticon|*.*
 FileKey5=%CommonAppData%\GarenaMessenger\cache\screencapture|*.*
 FileKey6=%CommonAppData%\GarenaMessenger\garena.game.plugins|*.tmp
 FileKey7=%CommonAppData%\GarenaMessenger\update*|*.*|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger|im.log;im.log.*
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\cache\clan|*.*|RECURSE
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\cache\customAvatar\buddy|*.*
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\cache\emoticon|*.*
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\cache\screencapture|*.*
-FileKey13=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\garena.game.plugins|*.tmp
-FileKey14=%LocalAppData%\VirtualStore\ProgramData\GarenaMessenger\update*|*.*|RECURSE
 
 [Garmin Express *]
 LangSecRef=3024
@@ -7952,9 +7609,6 @@ Default=False
 FileKey1=%CommonAppData%\Geek Squad\MRI|EventLog.gsl|RECURSE
 FileKey2=%CommonAppData%\Geek Squad\MRI\Automation Reports|*.*|REMOVESELF
 FileKey3=%CommonAppData%\Geek Squad\MRI\Downloads|*.*|REMOVESELF
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Geek Squad\MRI|EventLog.gsl|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Geek Squad\MRI\Automation Reports|*.*|REMOVESELF
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Geek Squad\MRI\Downloads|*.*|REMOVESELF
 
 [Genie-Soft *]
 LangSecRef=3024
@@ -8065,8 +7719,7 @@ FileKey1=%Documents%\AutomaticSolution Software\GhostMouse\conf\temp|*.tmp
 LangSecRef=3021
 Detect=HKCU\Software\GIANTCompany\AntiSpyware
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\GIANT Company Software\GIANT AntiSpyware|errors.log;cleaner.log;tracksEraser.log
-FileKey2=%ProgramFiles%\GIANT Company Software\GIANT AntiSpyware|errors.log;cleaner.log;tracksEraser.log
+FileKey1=%ProgramFiles%\GIANT Company Software\GIANT AntiSpyware|errors.log;cleaner.log;tracksEraser.log
 
 [Gigantic *]
 Section=Games
@@ -8094,9 +7747,8 @@ LangSecRef=3021
 DetectFile=%ProgramFiles%\Ginger
 Default=False
 FileKey1=%Documents%\Add-in Express|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ginger|*.log;*.tmp|RECURSE
-FileKey3=%ProgramFiles%\Ginger|*.log;*.tmp|RECURSE
-FileKey4=%SystemDrive%|GingerSetup.log
+FileKey2=%ProgramFiles%\Ginger|*.log;*.tmp|RECURSE
+FileKey3=%SystemDrive%|GingerSetup.log
 
 [GitHub *]
 LangSecRef=3022
@@ -8147,8 +7799,7 @@ RegKey1=HKCU\Software\GSettings\org\gnucash\history
 LangSecRef=3022
 Detect=HKCU\Software\Go!Zilla
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Go!Zilla|golog.htm;download.log;leech.hst
-FileKey2=%ProgramFiles%\Go!Zilla|golog.htm;download.log;leech.hst
+FileKey1=%ProgramFiles%\Go!Zilla|golog.htm;download.log;leech.hst
 
 [Goalscape *]
 LangSecRef=3021
@@ -8195,8 +7846,7 @@ DetectFile=%ProgramFiles%\Google\Drive\googledrivesync.exe
 Default=False
 FileKey1=%LocalAppData%\Google\Drive|*.log
 FileKey2=%LocalAppData%\Google\Drive\CrashReports|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Google\Drive|*.log
-FileKey4=%ProgramFiles%\Google\Drive|*.log
+FileKey3=%ProgramFiles%\Google\Drive|*.log
 
 [Google Earth *]
 LangSecRef=3021
@@ -8205,10 +7855,9 @@ Detect2=HKCU\Software\Google\Google Earth Pro
 Detect3=HKLM\Software\Google\Google Earth Plus
 Detect4=HKLM\Software\Google\Google Earth Pro
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Google\GoogleEarth\client|*.log
-FileKey2=%LocalLowAppData%\Google\GoogleEarth|*.tmp;*.log|RECURSE
-FileKey3=%LocalLowAppData%\Google\GoogleEarth\Cache|*.*|RECURSE
-FileKey4=%ProgramFiles%\Google\GoogleEarth\client|*.log
+FileKey1=%LocalLowAppData%\Google\GoogleEarth|*.tmp;*.log|RECURSE
+FileKey2=%LocalLowAppData%\Google\GoogleEarth\Cache|*.*|RECURSE
+FileKey3=%ProgramFiles%\Google\GoogleEarth\client|*.log
 
 [Google GBScreensaver *]
 LangSecRef=3021
@@ -8232,8 +7881,7 @@ FileKey1=%LocalAppData%\Google\Picasa2Albums\backup|*.*|REMOVESELF
 LangSecRef=3022
 Detect=HKCU\Software\Google\GoogleToolbarNotifier
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Google\GoogleToolbarNotifier|*.tmp|RECURSE
-FileKey2=%ProgramFiles%\Google\GoogleToolbarNotifier|*.tmp|RECURSE
+FileKey1=%ProgramFiles%\Google\GoogleToolbarNotifier|*.tmp|RECURSE
 
 [Google Video Player *]
 LangSecRef=3023
@@ -8245,8 +7893,7 @@ RegKey1=HKCU\Software\Google\Google Video Player\MRUList
 LangSecRef=3023
 DetectFile=%ProgramFiles%\GoPlayer
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\GoPlayer|*.log
-FileKey2=%ProgramFiles%\GoPlayer|*.log
+FileKey1=%ProgramFiles%\GoPlayer|*.log
 
 [Gotham City Impostors *]
 Section=Games
@@ -8271,8 +7918,7 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\41800
 Default=False
 FileKey1=%Documents%\My Games\GratuitousSpaceBattles\debug|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\gratuitous space battles\data\temp|*.*|RECURSE
-FileKey3=%ProgramFiles%\Steam\Steamapps\common\gratuitous space battles\data\temp|*.*|RECURSE
+FileKey2=%ProgramFiles%\Steam\Steamapps\common\gratuitous space battles\data\temp|*.*|RECURSE
 
 [Gravity Guy *]
 Section=Games
@@ -8374,15 +8020,13 @@ FileKey1=%AppData%\gSyncit|gsyncit*.*
 LangSecRef=3024
 DetectFile=%ProgramFiles%\GT Interactive\Driver
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\GT Interactive\Driver|debug.log
-FileKey2=%ProgramFiles%\GT Interactive\Driver|debug.log
+FileKey1=%ProgramFiles%\GT Interactive\Driver|debug.log
 
 [Guild Wars *]
 Section=Games
 DetectFile=%ProgramFiles%\Guild Wars
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Guild Wars|*.tmp
-FileKey2=%ProgramFiles%\Guild Wars|*.tmp
+FileKey1=%ProgramFiles%\Guild Wars|*.tmp
 
 [Gwent - The Witcher Card Game *]
 Section=Games
@@ -8420,8 +8064,7 @@ FileKey2=%LocalAppData%\Packages\Microsoft.HaloSpartanAssault_*\AC\Microsoft\Cry
 LangSecRef=3024
 DetectFile=%ProgramFiles%\HandBrake\Handbrake.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\HandBrake|*.stackdump
-FileKey2=%ProgramFiles%\HandBrake|*.stackdump
+FileKey1=%ProgramFiles%\HandBrake|*.stackdump
 
 [Handle Regshot Reports *]
 LangSecRef=3024
@@ -8448,15 +8091,12 @@ Detect=HKCU\Software\HappyCloud
 Default=False
 FileKey1=%CommonAppData%\HappyCloud|*.log
 FileKey2=%CommonAppData%\HappyCloud\cache|*.*
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\HappyCloud|*.log
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\HappyCloud\cache|*.*
 
 [Hard Drive Inspector *]
 LangSecRef=3024
 DetectFile=%CommonAppData%\AltrixSoft\Hard Drive Inspector
 Default=False
 FileKey1=%CommonAppData%\AltrixSoft\Hard Drive Inspector|log.err
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\AltrixSoft\Hard Drive Inspector|log.err
 
 [Hauppauge WinTV *]
 LangSecRef=3024
@@ -8473,22 +8113,19 @@ FileKey6=%SystemDrive%|hcwDriverInstall.txt
 LangSecRef=3022
 Detect=HKLM\System\CurrentControlSet\services\HDDHealth
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\HDD Health|*.tmp
-FileKey2=%ProgramFiles%\HDD Health|*.tmp
+FileKey1=%ProgramFiles%\HDD Health|*.tmp
 
 [HDD Regenerator *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\HDD Regenerator
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\HDD Regenerator|*.log|RECURSE
-FileKey2=%ProgramFiles%\HDD Regenerator|*.log|RECURSE
+FileKey1=%ProgramFiles%\HDD Regenerator|*.log|RECURSE
 
 [HDD Thermometer *]
 LangSecRef=3024
 Detect=HKCU\Software\RSD Software, Inc.\HDD Thermometer
 Default=False
 FileKey1=%CommonAppData%\HDD Thermometer|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\HDD Thermometer|*.log|RECURSE
 
 [HDDExpert *]
 LangSecRef=3024
@@ -8514,8 +8151,7 @@ FileKey1=%AppData%\Intermedia Software\Helium *\Logs|*.*
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\314470
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Heroes of a Broken Land\hobl_data|output_log.txt
-FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Heroes of a Broken Land\hobl_data|output_log.txt
+FileKey1=%ProgramFiles%\Steam\SteamApps\Common\Heroes of a Broken Land\hobl_data|output_log.txt
 
 [Heroes of Newerth *]
 Section=Games
@@ -8536,18 +8172,14 @@ Detect=HKLM\Software\Hi-Rez Studios
 Default=False
 FileKey1=%CommonAppData%\Hi-Rez Studios\BrowserCacheTribes\Default|*.*|RECURSE
 FileKey2=%CommonAppData%\Hi-Rez Studios\HiPatchService\log|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Hi-Rez Studios\hireztemp|*.*
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Hi-Rez Studios\BrowserCacheTribes\Default|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Hi-Rez Studios\HiPatchService\log|*.*
-FileKey6=%ProgramFiles%\Hi-Rez Studios\hireztemp|*.*
-FileKey7=%SystemDrive%|HiRezUpdateInstallLog.txt
+FileKey3=%ProgramFiles%\Hi-Rez Studios\hireztemp|*.*
+FileKey4=%SystemDrive%|HiRezUpdateInstallLog.txt
 
 [HijackThis Backups *]
 LangSecRef=3024
 Detect=HKLM\Software\TrendMicro\HijackThis
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Trend Micro\HijackThis\backups|*.*
-FileKey2=%ProgramFiles%\Trend Micro\HijackThis\backups|*.*
+FileKey1=%ProgramFiles%\Trend Micro\HijackThis\backups|*.*
 
 [HitmanPro *]
 LangSecRef=3024
@@ -8557,30 +8189,23 @@ Detect3=HKCU\Software\HitMan Pro 3
 Detect4=HKLM\Software\HitmanPro
 Default=False
 FileKey1=%CommonAppData%\HitmanPro\Logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Hitman Pro*\downloads|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Hitman Pro*\logs|*.htm
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Hitman Pro*\updates|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\HitmanPro\Logs|*.*
-FileKey6=%ProgramFiles%\Hitman Pro*\downloads|*.*
-FileKey7=%ProgramFiles%\Hitman Pro*\logs|*.htm
-FileKey8=%ProgramFiles%\Hitman Pro*\updates|*.*
+FileKey2=%ProgramFiles%\Hitman Pro*\downloads|*.*
+FileKey3=%ProgramFiles%\Hitman Pro*\logs|*.htm
+FileKey4=%ProgramFiles%\Hitman Pro*\updates|*.*
 
 [Holiday Express *]
 Section=Games
 Detect1=HKLM\Software\GameHouse\Holiday Express
 Detect2=HKLM\Software\HipSoft\Holiday Express
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\GameHouse Games Collection\Holiday Express|*.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Holiday Express|*html;*.txt
-FileKey3=%ProgramFiles%\GameHouse Games Collection\Holiday Express|*.txt
-FileKey4=%ProgramFiles%\Holiday Express|*html;*.txt
+FileKey1=%ProgramFiles%\GameHouse Games Collection\Holiday Express|*.txt
+FileKey2=%ProgramFiles%\Holiday Express|*html;*.txt
 
 [HomeCinema CyberLink *]
 LangSecRef=3023
 DetectFile=%ProgramFiles%\HomeCinema
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\HomeCinema\PowerProducer\Template\Cyberlink\frame|*tmp
-FileKey2=%ProgramFiles%\HomeCinema\PowerProducer\Template\Cyberlink\frame|*tmp
+FileKey1=%ProgramFiles%\HomeCinema\PowerProducer\Template\Cyberlink\frame|*tmp
 
 [Honeyview Bookmarks *]
 LangSecRef=3023
@@ -8661,10 +8286,8 @@ FileKey2=%LocalLowAppData%\abelhadigital.com\HostsServer\Logs|*.log
 LangSecRef=3022
 Detect=HKCU\Software\Hotbar
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Hotbar\*\dynamic|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Hotbar\*\static|*.*
-FileKey3=%ProgramFiles%\Hotbar\*\dynamic|*.*|RECURSE
-FileKey4=%ProgramFiles%\Hotbar\*\static|*.*
+FileKey1=%ProgramFiles%\Hotbar\*\dynamic|*.*|RECURSE
+FileKey2=%ProgramFiles%\Hotbar\*\static|*.*
 RegKey1=HKCU\Software\Hotbar\hotbar\ImagesHistory
 
 [Hotline Miami *]
@@ -8678,16 +8301,14 @@ LangSecRef=3021
 Detect=HKLM\Software\HotspotShield
 DetectFile=%ProgramFiles%\Hotspot Shield\bin\HSSCP.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Hotspot Shield\log|*.log
-FileKey2=%LocalLowAppData%\Hotspot_Shield\Logs|*.*|RECURSE
-FileKey3=%ProgramFiles%\Hotspot Shield\log|*.log
+FileKey1=%LocalLowAppData%\Hotspot_Shield\Logs|*.*|RECURSE
+FileKey2=%ProgramFiles%\Hotspot Shield\log|*.log
 
 [Hover Desk *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\HoverDesk
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\HoverDesk\User|hdcmdrec.txt
-FileKey2=%ProgramFiles%\HoverDesk\User|hdcmdrec.txt
+FileKey1=%ProgramFiles%\HoverDesk\User|hdcmdrec.txt
 
 [HP Drive Key Boot Utility *]
 LangSecRef=3024
@@ -8709,11 +8330,8 @@ DetectFile=%CommonAppData%\HP
 Default=False
 FileKey1=%CommonAppData%\HP\Installer\Temp|*.*
 FileKey2=%CommonAppData%\HP\Temp|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\HP\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\HP\Installer\Temp|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\HP\Temp|*.*
-FileKey6=%ProgramFiles%\HP\Temp|*.*|RECURSE
-FileKey7=%WinDir%|*.dat.temp
+FileKey3=%ProgramFiles%\HP\Temp|*.*|RECURSE
+FileKey4=%WinDir%|*.dat.temp
 
 [HP Installation Files *]
 LangSecRef=3024
@@ -8738,11 +8356,8 @@ FileKey3=%CommonAppData%|hpzinstall.log
 FileKey4=%CommonAppData%\Hewlett-Packard|*.log*.*;*Log.txt|RECURSE
 FileKey5=%CommonAppData%\Hewlett-Packard\HP*\Log*|*.*|RECURSE
 FileKey6=%LocalAppData%\TouchSmartData\Log|*.*
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\HPQ\Shared\Sierra Wireless|*.log|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData|hpzinstall.log
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Hewlett-Packard\HP*\Logs|*.*|RECURSE
-FileKey10=%ProgramFiles%\HPQ\Shared\Sierra Wireless|*.log|RECURSE
-FileKey11=%SystemDrive%\hp\bin\logs|*.log
+FileKey7=%ProgramFiles%\HPQ\Shared\Sierra Wireless|*.log|RECURSE
+FileKey8=%SystemDrive%\hp\bin\logs|*.log
 
 [HP MediaSmart Photo *]
 LangSecRef=3023
@@ -8793,8 +8408,7 @@ FileKey1=%AppData%\HpUpdate|*.*
 LangSecRef=3021
 DetectFile=%ProgramFiles%\HTC Home
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\HTC Home\log|*.*|RECURSE
-FileKey2=%ProgramFiles%\HTC Home\log|*.*|RECURSE
+FileKey1=%ProgramFiles%\HTC Home\log|*.*|RECURSE
 
 [HTC Logs *]
 LangSecRef=3022
@@ -8815,15 +8429,13 @@ Default=False
 Warning=This will remove CHM position, preferences, favorites information.
 FileKey1=%AppData%\Microsoft\HTML Help|hh.dat;hhcolreg.dat;*.chw
 FileKey2=%CommonAppData%\Microsoft\HTML Help|hhcolreg.dat
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Microsoft\HTML Help|hhcolreg.dat
-FileKey4=%WinDir%\Application Data\Microsoft\HTML Help|hh.dat
+FileKey3=%WinDir%\Application Data\Microsoft\HTML Help|hh.dat
 
 [Huawei Modem Driver *]
 LangSecRef=3023
 Detect=HKLM\Software\Huawei technologies
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\HUAWEI Modem Driver|*.log
-FileKey2=%ProgramFiles%\HUAWEI Modem Driver|*.log
+FileKey1=%ProgramFiles%\HUAWEI Modem Driver|*.log
 
 [HuluDesktop *]
 LangSecRef=3023
@@ -8903,8 +8515,7 @@ RegKey2=HKCU\Software\MiTeC\Icon Explorer\4.x\wnd_icoexp_Main|ShellTree_StartInF
 LangSecRef=3024
 DetectFile=%ProgramFiles%\IconCoolEditor\IconCooleditor.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\IconCoolEditor|IconFileList.src;Recentlyused.src
-FileKey2=%ProgramFiles%\IconCoolEditor|IconFileList.src;Recentlyused.src
+FileKey1=%ProgramFiles%\IconCoolEditor|IconFileList.src;Recentlyused.src
 
 [Icons from File *]
 LangSecRef=3024
@@ -8916,8 +8527,7 @@ RegKey1=HKCU\Software\Vitaliy Levchenko\Icons from File\Recent
 LangSecRef=3024
 DetectFile=%ProgramFiles%\ID Security Suite\ID Privacy Shield
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ID Security Suite\ID Privacy Shield\logs|*.*|RECURSE
-FileKey2=%ProgramFiles%\ID Security Suite\ID Privacy Shield\logs|*.*|RECURSE
+FileKey1=%ProgramFiles%\ID Security Suite\ID Privacy Shield\logs|*.*|RECURSE
 
 [IDEA *]
 LangSecRef=3021
@@ -8967,8 +8577,7 @@ FileKey1=%AppData%\IDT\NetGUI\Log|*.log
 LangSecRef=3024
 Detect=HKCU\Software\MySoftware\IEToy
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\IE Toy\Data|history;history_ad
-FileKey2=%ProgramFiles%\IE Toy\Data|history;history_ad
+FileKey1=%ProgramFiles%\IE Toy\Data|history;history_ad
 RegKey1=HKCU\Software\MySoftware\IEToy|FRAGS_ad
 RegKey2=HKCU\Software\MySoftware\IEToy|FRAGS_popup
 
@@ -8982,8 +8591,7 @@ RegKey1=HKCU\Software\IE7pro\ClosedTabs
 LangSecRef=3024
 DetectFile=%ProgramFiles%\i-Funbox DevTeam
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\i-Funbox DevTeam|debug.log
-FileKey2=%ProgramFiles%\i-Funbox DevTeam|debug.log
+FileKey1=%ProgramFiles%\i-Funbox DevTeam|debug.log
 
 [Ignition *]
 LangSecRef=3024
@@ -9029,9 +8637,7 @@ Default=False
 Warning=Immunet service must be stopped to remove log files.
 FileKey1=%AppData%\Immunet|*.*|REMOVESELF
 FileKey2=%CommonAppData%\Immunet|*.log
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Immunet|*.log|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Immunet|*.log
-FileKey5=%ProgramFiles%\Immunet|*.log|RECURSE
+FileKey3=%ProgramFiles%\Immunet|*.log|RECURSE
 
 [iMobie *]
 LangSecRef=3024
@@ -9058,8 +8664,7 @@ FileKey2=%AppData%\iMobie\Backup|*.*|RECURSE
 LangSecRef=3023
 Detect=HKCU\Software\ImTOO\iPad Video Converter
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ImTOO\iPad Video Converter|*.log;ERRORLOG.TXT
-FileKey2=%ProgramFiles%\ImTOO\iPad Video Converter|*.log;ERRORLOG.TXT
+FileKey1=%ProgramFiles%\ImTOO\iPad Video Converter|*.log;ERRORLOG.TXT
 
 [ImTOO Video Converter Ultimate *]
 LangSecRef=3023
@@ -9100,7 +8705,6 @@ DetectFile=%AppData%\inFlow Inventory
 Default=False
 FileKey1=%AppData%\inFlow Inventory|log.txt
 FileKey2=%CommonAppData%\inFlow Inventory\Logs|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\inFlow Inventory\Logs|*.*
 
 [InkScape *]
 LangSecRef=3023
@@ -9141,9 +8745,6 @@ Default=False
 FileKey1=%CommonAppData%\VTech\DA|*.log;InnoTab.txt;IntallLog.txt|RECURSE
 FileKey2=%CommonAppData%\VTech\DA\InnoTab\ConsoleLog|*.*
 FileKey3=%CommonAppData%\VTech\DA\InnoTab\Games\tmp|*.*|REMOVESELF
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\VTech\DA|*.log;InnoTab.txt;IntallLog.txt|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\VTech\DA\InnoTab\ConsoleLog|*.*
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\VTech\DA\InnoTab\Games\tmp|*.*|REMOVESELF
 
 [Inpaint *]
 LangSecRef=3021
@@ -9162,10 +8763,9 @@ FileKey1=%LocalAppData%\MetaGeek,_LLC|ConnectionErrorLog;MetaGeek-OUI.backup
 LangSecRef=3024
 Detect=HKCU\Software\InstallShield
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\InstallShield Installation Information|*.log|RECURSE
-FileKey2=%ProgramFiles%|_ISTMP1.DIR
-FileKey3=%ProgramFiles%\InstallShield Installation Information|*.log|RECURSE
-FileKey4=%SystemDrive%|_ISTMP*.DIR
+FileKey1=%ProgramFiles%|_ISTMP1.DIR
+FileKey2=%ProgramFiles%\InstallShield Installation Information|*.log|RECURSE
+FileKey3=%SystemDrive%|_ISTMP*.DIR
 RegKey1=HKCU\Software\InstallShield\16.0\Professional\Recent File List
 RegKey2=HKCU\Software\InstallShield\17.0\Professional\Recent File List
 RegKey3=HKCU\Software\InstallShield\18.0\Professional\Recent File List
@@ -9215,7 +8815,6 @@ LangSecRef=3024
 DetectFile=%CommonAppData%\Intel\iCLS Client
 Default=False
 FileKey1=%CommonAppData%\Intel\iCLS Client|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Intel\iCLS Client|*.log
 
 [Intel Installation Logs *]
 LangSecRef=3024
@@ -9223,13 +8822,12 @@ Detect1=HKCU\Software\Intel
 Detect2=HKLM\Software\Intel
 Default=False
 FileKey1=%CommonAppData%\intel|*.log|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Intel\InfInst|*.*|REMOVESELF
-FileKey3=%ProgramFiles%\Intel\InfInst|*.*|REMOVESELF
-FileKey4=%SystemDrive%\Intel\Logs|*.*|REMOVESELF
-FileKey5=%UserProfile%\Intel\Logs|*.*|REMOVESELF
-FileKey6=%WinDir%\debug\intel\logs|*.*|REMOVESELF
-FileKey7=%WinDir%\System32\config\systemprofile\Intel\Logs|*.*|REMOVESELF
-FileKey8=%WinDir%\SysWOW64\config\systemprofile\Intel\Logs|*.*|REMOVESELF
+FileKey2=%ProgramFiles%\Intel\InfInst|*.*|REMOVESELF
+FileKey3=%SystemDrive%\Intel\Logs|*.*|REMOVESELF
+FileKey4=%UserProfile%\Intel\Logs|*.*|REMOVESELF
+FileKey5=%WinDir%\debug\intel\logs|*.*|REMOVESELF
+FileKey6=%WinDir%\System32\config\systemprofile\Intel\Logs|*.*|REMOVESELF
+FileKey7=%WinDir%\SysWOW64\config\systemprofile\Intel\Logs|*.*|REMOVESELF
 
 [Intel Rapid Storage Technology *]
 LangSecRef=3021
@@ -9247,8 +8845,7 @@ FileKey1=%WinDir%\Inf\Intel Storage Counters|*.tmp|RECURSE
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Inter-Tel
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Inter-Tel|*.log|RECURSE
-FileKey2=%ProgramFiles%\Inter-Tel|*.log|RECURSE
+FileKey1=%ProgramFiles%\Inter-Tel|*.log|RECURSE
 
 [Internet Business Promoter *]
 LangSecRef=3022
@@ -9388,14 +8985,12 @@ DetectFile=%LocalAppData%\Intuit\Intuit Data Protect
 Default=False
 FileKey1=%CommonAppData%\Intuit\Intuit Data Protect|*.log
 FileKey2=%LocalAppData%\Intuit\Intuit Data Protect|*.log
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Intuit\Intuit Data Protect|*.log
 
 [Intuit Entitlement Client *]
 LangSecRef=3021
 DetectFile=%CommonAppData%\Intuit\Entitlement Client
 Default=False
 FileKey1=%CommonAppData%\Intuit\Entitlement Client\*|IntuitEntitlementLog*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Intuit\Entitlement Client\*|IntuitEntitlementLog*.*
 
 [Intuit PTI *]
 LangSecRef=3021
@@ -9415,15 +9010,7 @@ FileKey5=%CommonAppData%\Intuit\Common\QuickBaseClient\*\Logs|*.*
 FileKey6=%CommonAppData%\Intuit\Common\Update Service\*\Logs|*.*
 FileKey7=%CommonAppData%\Intuit\TurboTax\MSI\*\Logs|*.*
 FileKey8=%CommonProgramFiles%\Intuit\Internet Client|Msdun13.exe
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\Common Files\Intuit\Internet Client|Msdun13.exe
-FileKey10=%LocalAppData%\VirtualStore\Program Files*\TurboTax*|*.txt
-FileKey11=%LocalAppData%\VirtualStore\ProgramData|*.bc
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\Intuit*|*.log|RECURSE
-FileKey13=%LocalAppData%\VirtualStore\ProgramData\Intuit\Common\Metrix\*\Logs|*.*
-FileKey14=%LocalAppData%\VirtualStore\ProgramData\Intuit\Common\QuickBaseClient\*\Logs|*.*
-FileKey15=%LocalAppData%\VirtualStore\ProgramData\Intuit\Common\Update Service\*\Logs|*.*
-FileKey16=%LocalAppData%\VirtualStore\ProgramData\Intuit\TurboTax\MSI\*\Logs|*.*
-FileKey17=%ProgramFiles%\TurboTax*|*.txt
+FileKey9=%ProgramFiles%\TurboTax*|*.txt
 
 [IObit Advanced SystemCare *]
 LangSecRef=3024
@@ -9436,24 +9023,18 @@ FileKey3=%AppData%\IObit\Advanced SystemCare *\EmptyFolder|*.*|RECURSE
 FileKey4=%AppData%\IObit\Advanced SystemCare *\Log|*.*|RECURSE
 FileKey5=%CommonAppData%\IObit\Advanced SystemCare *\Log|*.*|REMOVESELF
 FileKey6=%CommonAppData%\IObit\ASCDownloader|*.log
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\IObit\Advanced SystemCare *|*.log;*.txt|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\IObit\Advanced SystemCare *\*.cab_Temp|*.*|REMOVESELF
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\IObit\Advanced SystemCare *\ASCServiceLog|*.*|RECURSE
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\IObit\Advanced SystemCare *\Log|*.*|RECURSE
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\IObit\ASCDownloader|*.log
-FileKey12=%ProgramFiles%\IObit\Advanced SystemCare *|*.log;*.txt|RECURSE
-FileKey13=%ProgramFiles%\IObit\Advanced SystemCare *\*.cab_Temp|*.*|REMOVESELF
-FileKey14=%ProgramFiles%\IObit\Advanced SystemCare *\ASCServiceLog|*.*|RECURSE
-FileKey15=%SystemDrive%\Users\Default\AppData\Roaming\IObit\Advanced SystemCare *|*.log
-FileKey16=%WinDir%\System32\config\systemprofile\AppData\Roaming\IObit\Advanced SystemCare *|*.log
-FileKey17=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\IObit\Advanced SystemCare *|*.log
+FileKey7=%ProgramFiles%\IObit\Advanced SystemCare *|*.log;*.txt|RECURSE
+FileKey8=%ProgramFiles%\IObit\Advanced SystemCare *\*.cab_Temp|*.*|REMOVESELF
+FileKey9=%ProgramFiles%\IObit\Advanced SystemCare *\ASCServiceLog|*.*|RECURSE
+FileKey10=%SystemDrive%\Users\Default\AppData\Roaming\IObit\Advanced SystemCare *|*.log
+FileKey11=%WinDir%\System32\config\systemprofile\AppData\Roaming\IObit\Advanced SystemCare *|*.log
+FileKey12=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\IObit\Advanced SystemCare *|*.log
 
 [IObit Advanced SystemCare Antivirus Backups *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\IObit\Advanced SystemCare Ultimate
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\IObit\Advanced SystemCare Ultimate\Antivirus\BackupRec|*.*|RECURSE
-FileKey2=%ProgramFiles%\IObit\Advanced SystemCare Ultimate\Antivirus\BackupRec|*.*|RECURSE
+FileKey1=%ProgramFiles%\IObit\Advanced SystemCare Ultimate\Antivirus\BackupRec|*.*|RECURSE
 
 [IObit Driver Booster *]
 LangSecRef=3024
@@ -9467,13 +9048,9 @@ LangSecRef=3024
 DetectFile=%ProgramFiles%\IObit\Game Booster 3
 Default=False
 FileKey1=%CommonAppData%\IObit\Game Booster 3|Defrags.ini
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3|*.log
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3\FPS|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\IObit\Game Booster 3\Update|Update.tmp
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\IObit\Game Booster 3|Defrags.ini
-FileKey6=%ProgramFiles%\IObit\Game Booster 3|*.log
-FileKey7=%ProgramFiles%\IObit\Game Booster 3\FPS|*.*|RECURSE
-FileKey8=%ProgramFiles%\IObit\Game Booster 3\Update|Update.tmp
+FileKey2=%ProgramFiles%\IObit\Game Booster 3|*.log
+FileKey3=%ProgramFiles%\IObit\Game Booster 3\FPS|*.*|RECURSE
+FileKey4=%ProgramFiles%\IObit\Game Booster 3\Update|Update.tmp
 
 [IObit KB Downloader *]
 LangSecRef=3024
@@ -9485,26 +9062,22 @@ FileKey1=%CommonAppData%\IObit\KBDownloader|*.*|RECURSE
 LangSecRef=3024
 DetectFile=%ProgramFiles%\IObit\LiveUpdate
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\IObit\LiveUpdate|*.log|RECURSE
-FileKey2=%ProgramFiles%\IObit\LiveUpdate|*.log|RECURSE
+FileKey1=%ProgramFiles%\IObit\LiveUpdate|*.log|RECURSE
 
 [IObit Uninstaller *]
 LangSecRef=3024
 DetectFile=%AppData%\IObit\IObit Uninstaller
 Default=False
 FileKey1=%AppData%\IObit\IObit Uninstaller\*Log|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\IObit\iObit Uninstaller|*.log|RECURSE
-FileKey3=%ProgramFiles%\IObit\iObit Uninstaller|*.log|RECURSE
+FileKey2=%ProgramFiles%\IObit\iObit Uninstaller|*.log|RECURSE
 
 [iPod-Cloner *]
 LangSecRef=3023
 Detect=HKCU\Software\iPod-Cloner
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\iPod-Cloner|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\iPod-Cloner\ReadCache|*.*
-FileKey3=%ProgramFiles%\iPod-Cloner|*.log
-FileKey4=%ProgramFiles%\iPod-Cloner\ReadCache|*.*
-FileKey5=%SystemDrive%|dtdlog.txt
+FileKey1=%ProgramFiles%\iPod-Cloner|*.log
+FileKey2=%ProgramFiles%\iPod-Cloner\ReadCache|*.*
+FileKey3=%SystemDrive%|dtdlog.txt
 
 [iResizer *]
 LangSecRef=3021
@@ -9520,9 +9093,6 @@ FileKey1=%CommonProgramFiles%\iSkysoft\iSkysoft Helper Compact|ProductUpdateList
 FileKey2=%CommonProgramFiles%\iSkysoft\iSkysoft Helper Compact\DATADICT|*.*|RECURSE
 FileKey3=%CommonProgramFiles%\iSkysoft\iSkysoft Helper Compact\log|*.*|RECURSE
 FileKey4=%CommonProgramFiles%\iSkysoft\iSkysoft Helper Compact\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Common Files\iSkysoft\iSkysoft Helper Compact|ProductUpdateLists.xml;ISHelper.exe_temp;ISHelperSetup.exe_temp
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Common Files\iSkysoft\iSkysoft Helper Compact\log|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Common Files\iSkysoft\iSkysoft Helper Compact\Temp|*.*|RECURSE
 RegKey1=HKLM\Software\iSkysoft\iSkysoft Helper Compact
 RegKey2=HKLM\Software\Wow6432Node\iSkysoft\iSkysoft Helper Compact
 
@@ -9533,12 +9103,8 @@ Detect2=HKLM\Software\iSkysoft\iSkysoft Video Converter Ultimate
 Default=False
 FileKey1=%CommonAppData%\iSkysoft Video Converter*|*.dat.bak
 FileKey2=%CommonAppData%\iSkysoft Video Converter*\Temp*Dir|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\iSkysoft\Video Converter*\Log|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\iSkysoft\Video Converter*\TempThumbDir|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\iSkysoft Video Converter*|*.dat.bak
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\iSkysoft Video Converter*\Temp*Dir|*.*|RECURSE
-FileKey7=%ProgramFiles%\iSkysoft\Video Converter*\Log|*.*|RECURSE
-FileKey8=%ProgramFiles%\iSkysoft\Video Converter*\TempThumbDir|*.*|RECURSE
+FileKey3=%ProgramFiles%\iSkysoft\Video Converter*\Log|*.*|RECURSE
+FileKey4=%ProgramFiles%\iSkysoft\Video Converter*\TempThumbDir|*.*|RECURSE
 
 [iSpy *]
 LangSecRef=3021
@@ -9551,8 +9117,7 @@ FileKey2=%LocalAppData%\iSpy\WebServerRoot\Media|*.*|RECURSE
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Utils\iSysCleaner\iSysCleaner.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Utils\iSysCleaner\traces|*.*
-FileKey2=%ProgramFiles%\Utils\iSysCleaner\traces|*.*
+FileKey1=%ProgramFiles%\Utils\iSysCleaner\traces|*.*
 
 [iTunes *]
 LangSecRef=3023
@@ -9563,12 +9128,11 @@ FileKey2=%AppData%\Apple Computer\iTunes\Cookies|Cookies.binarycookies
 FileKey3=%AppData%\Apple Computer\Logs|*.*|RECURSE
 FileKey4=%CommonAppData%\Apple Computer\iTunes\iPhone Temporary Files|*.*|RECURSE
 FileKey5=%LocalAppData%\Apple Computer\iTunes|Cache.db
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Apple Computer\iTunes\iPhone Temporary Files|*.*|RECURSE
-FileKey7=%Music%\iTunes|*.tmp|RECURSE
-FileKey8=%Music%\iTunes\Album Artwork\Cache|*.*|RECURSE
-FileKey9=%UserProfile%\Apple Computer\logs|*.log
-FileKey10=%WinDir%\System32\config\systemprofile\AppData\Roaming\Apple Computer\Logs|*.*|RECURSE
-FileKey11=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\Apple Computer\Logs|*.*|RECURSE
+FileKey6=%Music%\iTunes|*.tmp|RECURSE
+FileKey7=%Music%\iTunes\Album Artwork\Cache|*.*|RECURSE
+FileKey8=%UserProfile%\Apple Computer\logs|*.log
+FileKey9=%WinDir%\System32\config\systemprofile\AppData\Roaming\Apple Computer\Logs|*.*|RECURSE
+FileKey10=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\Apple Computer\Logs|*.*|RECURSE
 
 [iTunes Previous Libraries *]
 LangSecRef=3023
@@ -9580,8 +9144,7 @@ FileKey1=%Music%\iTunes\Previous iTunes Libraries|*.*|RECURSE
 LangSecRef=3023
 DetectFile=%ProgramFiles%\iWisoft Free Video Converter
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\iWisoft Free Video Converter|VideoConverter.log
-FileKey2=%ProgramFiles%\iWisoft Free Video Converter|VideoConverter.log
+FileKey1=%ProgramFiles%\iWisoft Free Video Converter|VideoConverter.log
 
 [iXL *]
 LangSecRef=3021
@@ -9599,19 +9162,15 @@ FileKey1=%AppData%\iZotope\iZotope RX 2 Session Data|*.*|RECURSE
 LangSecRef=3022
 Detect=HKCU\Software\Jabbear
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Jabbear|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Jabbear\avatars|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Jabbear\cachedir|*.*|RECURSE
-FileKey4=%ProgramFiles%\Jabbear|*.log|RECURSE
-FileKey5=%ProgramFiles%\Jabbear\avatars|*.*|RECURSE
-FileKey6=%ProgramFiles%\Jabbear\cachedir|*.*|RECURSE
+FileKey1=%ProgramFiles%\Jabbear|*.log|RECURSE
+FileKey2=%ProgramFiles%\Jabbear\avatars|*.*|RECURSE
+FileKey3=%ProgramFiles%\Jabbear\cachedir|*.*|RECURSE
 
 [Jabbear Chat History *]
 LangSecRef=3022
 Detect=HKCU\Software\Jabbear
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Jabbear\Users|*.dat;*.html|RECURSE
-FileKey2=%ProgramFiles%\Jabbear\Users|*.dat;*.html|RECURSE
+FileKey1=%ProgramFiles%\Jabbear\Users|*.dat;*.html|RECURSE
 
 [Jagex Cache *]
 Section=Games
@@ -9644,12 +9203,9 @@ FileKey1=%AppData%\Flood Light Games\WMC3|*.log
 LangSecRef=3025
 DetectFile=%ProgramFiles%\jAnrufmonitor
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\jAnrufmonitor\data|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\jAnrufmonitor\lib\cache|classloader.cache.log
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\jAnrufmonitor\logs|*.*
-FileKey4=%ProgramFiles%\jAnrufmonitor\data|*.log
-FileKey5=%ProgramFiles%\jAnrufmonitor\lib\cache|classloader.cache.log
-FileKey6=%ProgramFiles%\jAnrufmonitor\logs|*.*
+FileKey1=%ProgramFiles%\jAnrufmonitor\data|*.log
+FileKey2=%ProgramFiles%\jAnrufmonitor\lib\cache|classloader.cache.log
+FileKey3=%ProgramFiles%\jAnrufmonitor\logs|*.*
 
 [Jasc Animation Shop *]
 LangSecRef=3023
@@ -9666,14 +9222,12 @@ Default=False
 FileKey1=%AppData%\Sun\Java\Deployment\SystemCache|*.*|RECURSE
 FileKey2=%CommonAppData%\Oracle\Java\.oracle_jre_usage|*.*
 FileKey3=%LocalAppData%\Sun\Java\Deployment\*Cache|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Java\jre*|*PATCH.ERR
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Java\jre*\lib\security|*.bak
-FileKey6=%LocalLowAppData%\Sun\Java\Deployment\SystemCache|*.*|RECURSE
-FileKey7=%ProgramFiles%\Java\jre*|*PATCH.ERR
-FileKey8=%ProgramFiles%\Java\jre*\lib\security|*.bak
-FileKey9=%SystemDrive%\Users\*\.oracle_jre_usage|*.*|REMOVESELF
-FileKey10=%WinDir%\System32\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\Cache|*.*|RECURSE
-FileKey11=%WinDir%\SysWOW64\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\Cache|*.*|RECURSE
+FileKey4=%LocalLowAppData%\Sun\Java\Deployment\SystemCache|*.*|RECURSE
+FileKey5=%ProgramFiles%\Java\jre*|*PATCH.ERR
+FileKey6=%ProgramFiles%\Java\jre*\lib\security|*.bak
+FileKey7=%SystemDrive%\Users\*\.oracle_jre_usage|*.*|REMOVESELF
+FileKey8=%WinDir%\System32\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\Cache|*.*|RECURSE
+FileKey9=%WinDir%\SysWOW64\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\Cache|*.*|RECURSE
 
 [Java Setup Files *]
 LangSecRef=3022
@@ -9691,55 +9245,41 @@ LangSecRef=3022
 DetectFile1=%ProgramFiles%\JavaRa 2.0\JavaRa.exe
 DetectFile2=%ProgramFiles%\JavaRa\JavaRa.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\JavaRa 2.0|*.log|RECURSE
-FileKey2=%ProgramFiles%\JavaRa 2.0|*.log|RECURSE
-FileKey3=%SystemDrive%|JavaRa.log
+FileKey1=%ProgramFiles%\JavaRa 2.0|*.log|RECURSE
+FileKey2=%SystemDrive%|JavaRa.log
 
 [JDownloader *]
 LangSecRef=3022
 Detect=HKLM\Software\JDownloader
 DetectFile=%ProgramFiles%\JDownloader
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\JDownloader*|*.log;updateLog.txt;*.lck;*.log.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\JDownloader*\.junique|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\JDownloader*\captchas|*.*
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\JDownloader*\container|*.*
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\JDownloader*\downloads|*.*
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\JDownloader*\tmp\linksave|*.*
-FileKey7=%ProgramFiles%\JDownloader*|*.log;updateLog.txt;*.lck;*.log.*|RECURSE
-FileKey8=%ProgramFiles%\JDownloader*\.junique|*.*
-FileKey9=%ProgramFiles%\JDownloader*\captchas|*.*
-FileKey10=%ProgramFiles%\JDownloader*\container|*.*
-FileKey11=%ProgramFiles%\JDownloader*\downloads|*.*
-FileKey12=%ProgramFiles%\JDownloader*\tmp\linksave|*.*
-FileKey13=%UserProfile%\.jd_home|JDownloader.log
-FileKey14=%UserProfile%\.jd_home\logs|*.0
+FileKey1=%ProgramFiles%\JDownloader*|*.log;updateLog.txt;*.lck;*.log.*|RECURSE
+FileKey2=%ProgramFiles%\JDownloader*\.junique|*.*
+FileKey3=%ProgramFiles%\JDownloader*\captchas|*.*
+FileKey4=%ProgramFiles%\JDownloader*\container|*.*
+FileKey5=%ProgramFiles%\JDownloader*\downloads|*.*
+FileKey6=%ProgramFiles%\JDownloader*\tmp\linksave|*.*
+FileKey7=%UserProfile%\.jd_home|JDownloader.log
+FileKey8=%UserProfile%\.jd_home\logs|*.0
 
 [JDownloader Backups *]
 LangSecRef=3022
 Detect=HKLM\Software\JDownloader
 DetectFile=%ProgramFiles%\JDownloader
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\JDownloader*\backup|*.*
-FileKey2=%ProgramFiles%\JDownloader*\backup|*.*
+FileKey1=%ProgramFiles%\JDownloader*\backup|*.*
 
 [JDownloader2 *]
 LangSecRef=3022
 Detect=HKLM\Software\Classes\JDownloader2
 DetectFile=%ProgramFiles%\JDownloader 2
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*|JDownloader.log;Updater_*-*-*.log;SessionInstallLog.json.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*\captchas|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*\cfg|CaptchaDialogDimensions_*.json
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*\logs|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*\tmp|*.*|RECURSE
-FileKey6=%ProgramFiles%\JDownloader*2*|JDownloader.log;Updater_*-*-*.log;SessionInstallLog.json.*|RECURSE
-FileKey7=%ProgramFiles%\JDownloader*2*\captchas|*.*|RECURSE
-FileKey8=%ProgramFiles%\JDownloader*2*\cfg|CaptchaDialogDimensions_*.json
-FileKey9=%ProgramFiles%\JDownloader*2*\logs|*.*|RECURSE
-FileKey10=%ProgramFiles%\JDownloader*2*\tmp|*.*|RECURSE
-ExcludeKey1=PATH|%LocalAppData%\VirtualStore\Program Files*\JDownloader*2*\cfg\|subconf_*.ejs
-ExcludeKey2=PATH|%ProgramFiles%\JDownloader*2*\cfg\|subconf_*.ejs
+FileKey1=%ProgramFiles%\JDownloader*2*|JDownloader.log;Updater_*-*-*.log;SessionInstallLog.json.*|RECURSE
+FileKey2=%ProgramFiles%\JDownloader*2*\captchas|*.*|RECURSE
+FileKey3=%ProgramFiles%\JDownloader*2*\cfg|CaptchaDialogDimensions_*.json
+FileKey4=%ProgramFiles%\JDownloader*2*\logs|*.*|RECURSE
+FileKey5=%ProgramFiles%\JDownloader*2*\tmp|*.*|RECURSE
+ExcludeKey1=PATH|%ProgramFiles%\JDownloader*2*\cfg\|subconf_*.ejs
 
 [jEdit *]
 LangSecRef=3021
@@ -9759,23 +9299,20 @@ LangSecRef=3024
 DetectFile=%ProgramFiles%\BlueSprig\JetClean\JetClean.exe
 Default=False
 FileKey1=%AppData%\BlueSprig\JetClean\Log|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\BlueSprig\JetClean\Update|*.*|REMOVESELF
-FileKey3=%ProgramFiles%\BlueSprig\JetClean\Update|*.*|REMOVESELF
+FileKey2=%ProgramFiles%\BlueSprig\JetClean\Update|*.*|REMOVESELF
 
 [JetDrive *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\JetDrive
 Default=False
 FileKey1=%LocalAppData%\Abelssoft\JetDrive|JetDrive.reports.xml
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\JetDrive|JetDrive.log
-FileKey3=%ProgramFiles%\JetDrive|JetDrive.log
+FileKey2=%ProgramFiles%\JetDrive|JetDrive.log
 
 [Jetico Personal Firewall *]
 LangSecRef=3022
 Detect=HKLM\Software\Jetico\Personal Firewall
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Jetico\Jetico Personal Firewall|firewall*.log
-FileKey2=%ProgramFiles%\Jetico\Jetico Personal Firewall|firewall*.log
+FileKey1=%ProgramFiles%\Jetico\Jetico Personal Firewall|firewall*.log
 
 [Jing *]
 LangSecRef=3024
@@ -9845,17 +9382,15 @@ RegKey1=HKLM\Software\Juniper Networks\Default
 LangSecRef=3024
 DetectFile=%ProgramFiles%\jv16 PowerTools X\jv16PT.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\jv16 PowerTools X|StartupOptimizer*.log
-FileKey2=%ProgramFiles%\jv16 PowerTools X|StartupOptimizer*.log
+FileKey1=%ProgramFiles%\jv16 PowerTools X|StartupOptimizer*.log
 
 [K-Lite Codec Pack *]
 LangSecRef=3023
 Detect=HKLM\Software\KLCodecPack
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\K-Lite*|*.log;*.txt|RECURSE
-FileKey2=%ProgramFiles%\K-Lite*|*.log;*.txt|RECURSE
-FileKey3=%SystemDrive%|*klcp_itp_*.tmp;*klcp_iph_*.tmp
-FileKey4=%UserProfile%\Desktop|klcp_codec_log.txt
+FileKey1=%ProgramFiles%\K-Lite*|*.log;*.txt|RECURSE
+FileKey2=%SystemDrive%|*klcp_itp_*.tmp;*klcp_iph_*.tmp
+FileKey3=%UserProfile%\Desktop|klcp_codec_log.txt
 RegKey1=HKCU\Software\Gabest\vsfilter\DefTextPathes|Path0
 RegKey2=HKCU\Software\Gabest\vsfilter\DefTextPathes|Path1
 RegKey3=HKCU\Software\Gabest\vsfilter\DefTextPathes|Path2
@@ -9881,10 +9416,7 @@ FileKey1=%CommonAppData%\Kaspersky Lab|*.dmp;*.dmp.stat;*.log
 FileKey2=%CommonAppData%\Kaspersky Lab\*\Bases\Cache|*.*|RECURSE
 FileKey3=%CommonAppData%\Kaspersky Lab\*\Data\Updater\Temporary Files|*.*|RECURSE
 FileKey4=%CommonAppData%\Kaspersky Lab\*\Temp|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Kaspersky Lab\*\Bases\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Kaspersky Lab\*\Data\Updater\Temporary Files|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Kaspersky Lab\*\Temp|*.*
-FileKey8=%ProgramFiles%\Kaspersky Lab\NetworkAgent\~dumps|*.*
+FileKey5=%ProgramFiles%\Kaspersky Lab\NetworkAgent\~dumps|*.*
 
 [Kaspersky Now *]
 LangSecRef=3031
@@ -9982,8 +9514,6 @@ FileKey3=%CommonAppData%\Kodak\Inkjet Logging|*.*|RECURSE
 FileKey4=%LocalAppData%|LaunchHomeCenter.log
 FileKey5=%LocalAppData%\Kodak\Diagnostics|UploadLog.xml
 FileKey6=%LocalAppData%\Kodak\Inkjet Logging|Status Monitor Log.*
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Kodak\Diagnostics|*.*
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Kodak\Inkjet Logging|*.*|RECURSE
 
 [Kodi *]
 LangSecRef=3023
@@ -10022,9 +9552,6 @@ Default=False
 FileKey1=%CommonAppData%\GFI Software\LanGuard 10|newfileslog.*
 FileKey2=%CommonAppData%\GFI Software\LanGuard 10\*Logs|*.*|RECURSE
 FileKey3=%CommonAppData%\GFI Software\LanGuard 10\Cache|*.*|REMOVESELF
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10|newfileslog.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10\*Logs|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\GFI Software\LanGuard 10\Cache|*.*|REMOVESELF
 
 [Launchy *]
 LangSecRef=3021
@@ -10057,18 +9584,12 @@ FileKey2=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\data7\*|*.*
 FileKey3=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\http*|*.*
 FileKey4=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\prepared|*.*
 FileKey5=%CommonAppData%\Leapfrog\LeapFrog Connect\DownloadCache|*.*
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\cookies|*.*
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\data7\*|*.*
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\http*|*.*
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\cache\*\prepared|*.*
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Leapfrog\LeapFrog Connect\DownloadCache|*.*
 
 [LeapFTP *]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\LeapFTP
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\LeapFTP|stats.dat
-FileKey2=%ProgramFiles%\LeapFTP|stats.dat
+FileKey1=%ProgramFiles%\LeapFTP|stats.dat
 
 [Learn2 Player *]
 LangSecRef=3023
@@ -10123,17 +9644,14 @@ FileKey2=%CommonAppData%\Lenovo\SystemUpdate\sessionSE\system\SSClientCommon|*.x
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Leviev Sales Information Portal
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\JMS|JMSErrors.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Leviev Sales Information Portal|JMSErrors.txt
-FileKey3=%ProgramFiles%\JMS|JMSErrors.txt
-FileKey4=%ProgramFiles%\Leviev Sales Information Portal|JMSErrors.txt
+FileKey1=%ProgramFiles%\JMS|JMSErrors.txt
+FileKey2=%ProgramFiles%\Leviev Sales Information Portal|JMSErrors.txt
 
 [Lexmark Logs *]
 LangSecRef=3021
 DetectFile=%CommonAppData%\gn_logs
 Default=False
 FileKey1=%CommonAppData%\gn_logs\*|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\gn_logs\*|*.*
 
 [Lexmark Photo Editor *]
 LangSecRef=3021
@@ -10151,13 +9669,8 @@ FileKey3=%CommonAppData%\Lexware\elster\Log|*.*|REMOVESELF
 FileKey4=%CommonAppData%\Lexware\logs|*.*|REMOVESELF
 FileKey5=%CommonProgramFiles%\Lexware|*.log|RECURSE
 FileKey6=%LocalAppData%\Lexware|*.log;*.logx|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Common Files\Lexware|*.log|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\Lexware|*.log|RECURSE
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Lexware|*.log;*.logx|RECURSE
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Lexware\elster\Log|*.*|REMOVESELF
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\Lexware\logs|*.*|REMOVESELF
-FileKey12=%ProgramFiles%\Lexware|*.log|RECURSE
-FileKey13=%SystemDrive%|LxDasi.Log
+FileKey7=%ProgramFiles%\Lexware|*.log|RECURSE
+FileKey8=%SystemDrive%|LxDasi.Log
 
 [LibreOffice *]
 LangSecRef=3021
@@ -10184,7 +9697,6 @@ LangSecRef=3023
 Detect=HKCU\Software\LightScribe
 Default=False
 FileKey1=%CommonAppData%\LightScribe\log|*.xml
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\LightScribe\log|*.xml
 
 [LightShot *]
 LangSecRef=3022
@@ -10217,8 +9729,7 @@ LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Listary_is1
 Default=False
 FileKey1=%AppData%\Listary\CrashRpt|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Listary|*.log
-FileKey3=%ProgramFiles%\Listary|*.log
+FileKey2=%ProgramFiles%\Listary|*.log
 
 [Loadout *]
 Section=Games
@@ -10297,8 +9808,7 @@ Detect1=HKCU\Software\Logitech\DesktopMessenger
 Detect2=HKLM\Software\Logitech\DesktopMessenger
 Detect3=HKLM\Software\Logitech\Logitech Desktop Messenger
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Logitech\Desktop Messenger|*.log;*.bak
-FileKey2=%ProgramFiles%\Logitech\Desktop Messenger|*.log;*.bak
+FileKey1=%ProgramFiles%\Logitech\Desktop Messenger|*.log;*.bak
 
 [Logitech Harmony Remote Cache *]
 LangSecRef=3021
@@ -10318,9 +9828,7 @@ FileKey4=%CommonAppData%\LogiShrd|*.log|RECURSE
 FileKey5=%CommonAppData%\Logishrd\unifying|EngineLog.*;*.txt
 FileKey6=%CommonAppData%\Logitech\KHAL\Battery|*.log
 FileKey7=%CommonProgramFiles%\logishrd|*.log|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\LogiShrd|*.log|RECURSE
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Logishrd\unifying|EngineLog.*
-FileKey10=%WinDir%\System32|lvcoinst.log
+FileKey8=%WinDir%\System32|lvcoinst.log
 
 [LogMeIn Hamachi *]
 LangSecRef=3022
@@ -10346,8 +9854,7 @@ LangSecRef=3022
 DetectFile=%ProgramFiles%\Lost Photos
 Default=False
 FileKey1=%LocalAppData%\Lost_Photos\*|ResultSearchFile.info
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Lost Photos\Logs|*.*
-FileKey3=%ProgramFiles%\Lost Photos\Logs|*.*
+FileKey2=%ProgramFiles%\Lost Photos\Logs|*.*
 
 [Lotus Notes *]
 LangSecRef=3021
@@ -10362,8 +9869,7 @@ Default=False
 FileKey1=%AppData%\lunascape\Lunascape6\ApplicationData|rebar.bmp
 FileKey2=%AppData%\lunascape\Lunascape6\ApplicationData\icons|*.*|RECURSE
 FileKey3=%AppData%\lunascape\Lunascape6\ApplicationData\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Lunascape\Lunascape6\applicationdata|rebar.bmp
-FileKey5=%ProgramFiles%\Lunascape\Lunascape6\applicationdata|rebar.bmp
+FileKey4=%ProgramFiles%\Lunascape\Lunascape6\applicationdata|rebar.bmp
 
 [Lunascape6 Backups *]
 LangSecRef=3022
@@ -10377,8 +9883,7 @@ Detect=HKLM\Software\Lunascape Corporation
 Default=False
 Warning=Lunascape will show you a warning on next start up.
 FileKey1=%AppData%\lunascape\Lunascape6\ApplicationData|history.ld2
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Lunascape\Lunascape6\applicationdata|history.ld2
-FileKey3=%ProgramFiles%\Lunascape\Lunascape6\applicationdata|history.ld2
+FileKey2=%ProgramFiles%\Lunascape\Lunascape6\applicationdata|history.ld2
 
 [Lupinho.Net Hardlink *]
 LangSecRef=3023
@@ -10390,8 +9895,7 @@ FileKey1=%LocalAppData%\Lupinho.Net|*.log|RECURSE
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Lynx - web browser
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Lynx - web browser\tmp|*.*
-FileKey2=%ProgramFiles%\Lynx - web browser\tmp|*.*
+FileKey1=%ProgramFiles%\Lynx - web browser\tmp|*.*
 
 [Lyrik *]
 LangSecRef=3023
@@ -10444,8 +9948,7 @@ RegKey2=HKCU\Software\Macromedia\Shockwave 9\movies
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\42910
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\magicka|errorReport*.txt
-FileKey2=%ProgramFiles%\Steam\steamapps\common\magicka|errorReport*.txt
+FileKey1=%ProgramFiles%\Steam\steamapps\common\magicka|errorReport*.txt
 
 [MAGIX Installation Manager *]
 LangSecRef=3023
@@ -10453,8 +9956,6 @@ Detect=HKCU\Software\Magix\MAGIX Installation manager
 Default=False
 FileKey1=%CommonAppData%\MAGIX\*|*.log;*.reg
 FileKey2=%CommonAppData%\MAGIX\*\download|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\MAGIX\*|*.log;*.reg
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\MAGIX\*\download|*.*|RECURSE
 
 [MAGIX Video Easy TERRATEC Edition *]
 LangSecRef=3023
@@ -10502,8 +10003,7 @@ Detect=HKLM\System\CurrentControlSet\Services\MbaeSvc
 DetectFile=%CommonAppData%\Malwarebytes Anti-Exploit
 Default=False
 FileKey1=%CommonAppData%\Malwarebytes Anti-Exploit|*.log;mbae-default.log.bak;mbae-protector.xpe.bak
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Malwarebytes Anti-Exploit|*.log;mbae-default.log.bak;mbae-protector.xpe.bak
-FileKey3=%ProgramFiles%\Malwarebytes Anti-Exploit|mbae-uninstall.log;changelog.txt
+FileKey2=%ProgramFiles%\Malwarebytes Anti-Exploit|mbae-uninstall.log;changelog.txt
 
 [Malwarebytes Anti-Malware *]
 LangSecRef=3024
@@ -10517,15 +10017,12 @@ FileKey3=%CommonAppData%\Malwarebytes\Malwarebytes*Anti-Malware\Logs|*.*
 FileKey4=%CommonAppData%\Malwarebytes\MBAMService|*.log;*.bak;*.regtrans-ms;*.TM.blf;*-ntuser.dat;*.LOG1;*.LOG2;*-UsrClass.dat
 FileKey5=%CommonAppData%\Malwarebytes\MBAMService\logs|*.*
 FileKey6=%CommonAppData%\Malwarebytes\MBAMService\ScanResults|*.*
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Malwarebytes\Malwarebytes*Anti-Malware|mbam-setup.exe
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Malwarebytes\Malwarebytes*Anti-Malware\Logs|*.*
 
 [ManiaPlanet *]
 Section=Games
 DetectFile=%CommonAppData%\ManiaPlanet
 Default=False
 FileKey1=%CommonAppData%\ManiaPlanet\Cache|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\ManiaPlanet\Cache|*.*
 
 [ManyCam *]
 LangSecRef=3023
@@ -10554,17 +10051,14 @@ FileKey8=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\TempState|*.*|RECURSE
 Section=Games
 DetectFile=%ProgramFiles%\Groove Games\Marine Sharpshooter 3
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Groove Games\Marine Sharpshooter 3|*.dmp;*.mdmp|RECURSE
-FileKey2=%ProgramFiles%\Groove Games\Marine Sharpshooter 3|*.dmp;*.mdmp|RECURSE
+FileKey1=%ProgramFiles%\Groove Games\Marine Sharpshooter 3|*.dmp;*.mdmp|RECURSE
 
 [Mass Downloader *]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Mass Downloader
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Mass Downloader|*.bak;massdown.dat;history.dat|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Mass Downloader\Index|*.*|RECURSE
-FileKey3=%ProgramFiles%\Mass Downloader|*.bak;massdown.dat;history.dat|RECURSE
-FileKey4=%ProgramFiles%\Mass Downloader\Index|*.*|RECURSE
+FileKey1=%ProgramFiles%\Mass Downloader|*.bak;massdown.dat;history.dat|RECURSE
+FileKey2=%ProgramFiles%\Mass Downloader\Index|*.*|RECURSE
 
 [Mass Effect *]
 Section=Games
@@ -10604,16 +10098,14 @@ Default=False
 FileKey1=%Documents%\Maxprog\iCash\Database Logs|*.*|REMOVESELF
 FileKey2=%Documents%\Maxprog\iCash\Error Logs|*.*|REMOVESELF
 FileKey3=%Documents%\Maxprog\iCash\XML Dumps|*.*|REMOVESELF
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\iCash\vlogs|*.*|REMOVESELF
-FileKey5=%ProgramFiles%\iCash\vlogs|*.*|REMOVESELF
+FileKey4=%ProgramFiles%\iCash\vlogs|*.*|REMOVESELF
 
 [Maxthon Browser *]
 LangSecRef=3022
 Detect1=HKCU\Software\Maxthon
 Detect2=HKCU\Software\Maxthon2
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Maxthon*\Temp|*.*
-FileKey2=%ProgramFiles%\Maxthon*\Temp|*.*
+FileKey1=%ProgramFiles%\Maxthon*\Temp|*.*
 
 [Maxthon Browser 3 Backups *]
 LangSecRef=3022
@@ -10658,28 +10150,12 @@ FileKey12=%CommonAppData%\McAfee\Update|*.*|RECURSE
 FileKey13=%CommonAppData%\McAfee\VirusScan\Data|*.log;*.old
 FileKey14=%CommonAppData%\McAfee\VirusScan\Logs|*.*|RECURSE
 FileKey15=%CommonAppData%\Network Associates\Common Framework\AgentEvents|*.*
-FileKey16=%LocalAppData%\VirtualStore\ProgramData\McAfee\AMCore\datreputation\Logs|*.*|RECURSE
-FileKey17=%LocalAppData%\VirtualStore\ProgramData\McAfee\Common Framework\AgentEvents|*.*
-FileKey18=%LocalAppData%\VirtualStore\ProgramData\McAfee\CSP\ETW|*.bak
-FileKey19=%LocalAppData%\VirtualStore\ProgramData\McAfee\Jcm|*.tmp
-FileKey20=%LocalAppData%\VirtualStore\ProgramData\McAfee\MCLOGS|*.bak;*.log|RECURSE
-FileKey21=%LocalAppData%\VirtualStore\ProgramData\McAfee\MHN|*.bak
-FileKey22=%LocalAppData%\VirtualStore\ProgramData\McAfee\modulecoreservice.exe|*.txt
-FileKey23=%LocalAppData%\VirtualStore\ProgramData\McAfee\MPF|*.tmp
-FileKey24=%LocalAppData%\VirtualStore\ProgramData\McAfee\MPF\data|*.*|RECURSE
-FileKey25=%LocalAppData%\VirtualStore\ProgramData\McAfee\MSC\Logs|*.log
-FileKey26=%LocalAppData%\VirtualStore\ProgramData\McAfee\SiteAdvisor|*.txt|RECURSE
-FileKey27=%LocalAppData%\VirtualStore\ProgramData\McAfee\Update|*.*|RECURSE
-FileKey28=%LocalAppData%\VirtualStore\ProgramData\McAfee\VirusScan\Data|*.log;*.old
-FileKey29=%LocalAppData%\VirtualStore\ProgramData\McAfee\VirusScan\Logs|*.*|RECURSE
-FileKey30=%LocalAppData%\VirtualStore\ProgramData\Network Associates\Common Framework\AgentEvents|*.*
 
 [McPixel *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\220860
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\mcpixel|log.txt
-FileKey2=%ProgramFiles%\Steam\Steamapps\common\mcpixel|log.txt
+FileKey1=%ProgramFiles%\Steam\Steamapps\common\mcpixel|log.txt
 
 [Media Center 18 *]
 LangSecRef=3023
@@ -10692,8 +10168,7 @@ FileKey2=%Documents%\J River\Media Center 18\Library|*.*|RECURSE
 LangSecRef=3023
 Detect=HKCU\Software\J. River\Music Exchange\1.0\Media Jukebox
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\J River\Media Jukebox\Data|*.jmd
-FileKey2=%ProgramFiles%\J River\Media Jukebox\Data|*.jmd
+FileKey1=%ProgramFiles%\J River\Media Jukebox\Data|*.jmd
 
 [Media Play Ready Client *]
 LangSecRef=3031
@@ -10910,10 +10385,8 @@ RegKey1=HKCU\Software\Microsoft\Expression\Web Designer\FindMRU
 Section=Games
 Detect=HKLM\Software\Microsoft\Microsoft Games\Flight Simulator\10.0
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Microsoft Games\Microsoft Flight Simulator X|*.log;*.rtf;*.html;*.URL
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Microsoft Games\Microsoft Flight Simulator X\Modules|*.log
-FileKey3=%ProgramFiles%\Microsoft Games\Microsoft Flight Simulator X|*.log;*.rtf;*.html;*.URL
-FileKey4=%ProgramFiles%\Microsoft Games\Microsoft Flight Simulator X\Modules|*.log
+FileKey1=%ProgramFiles%\Microsoft Games\Microsoft Flight Simulator X|*.log;*.rtf;*.html;*.URL
+FileKey2=%ProgramFiles%\Microsoft Games\Microsoft Flight Simulator X\Modules|*.log
 ExcludeKey1=PATH|%ProgramFiles%\Microsoft Games\Microsoft Flight Simulator X\|*kiosk.rtf;*readme.rtf;*Readme.htm
 
 [Microsoft Message Analyzer *]
@@ -10969,9 +10442,6 @@ FileKey1=%CommonAppData%\Microsoft\Microsoft Antimalware\LocalCopy|*.*|RECURSE
 FileKey2=%CommonAppData%\Microsoft\Microsoft Antimalware\Network Inspection System\Support|NisLog.txt.bak
 FileKey3=%CommonAppData%\Microsoft\Microsoft Antimalware\Scans\History\Service|*.log|RECURSE
 FileKey4=%CommonAppData%\Microsoft\Microsoft Security Client\Support|MSSecurityClient*.log
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft Antimalware\LocalCopy|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft Antimalware\Scans\History\Service|*.log|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft Security Client\Support|MSSecurityClient*.log
 
 [Microsoft Silverlight *]
 LangSecRef=3023
@@ -10995,7 +10465,6 @@ LangSecRef=3024
 Detect=HKCU\Software\Microsoft\Microsoft Standalone System Sweeper Tool
 Default=False
 FileKey1=%CommonAppData%\Microsoft\Microsoft Standalone System Sweeper Tool\Support|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft Standalone System Sweeper Tool\Support|*.log
 
 [Microsoft Ultimate Word Games *]
 Section=Games
@@ -11045,9 +10514,7 @@ Detect=HKCU\Software\MiKTeX.org\MiKTeX
 Default=False
 FileKey1=%CommonAppData%\MiKTeX\*\miktex\log|*.log
 FileKey2=%LocalAppData%\MiKTeX\*\miktex\log|*.log
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\MiKTeX\miktex\config|*.log
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\MiKTeX\*\miktex\log|*.log
-FileKey5=%ProgramFiles%\MiKTeX\miktex\config|*.log
+FileKey3=%ProgramFiles%\MiKTeX\miktex\config|*.log
 
 [Minecraft *]
 Section=Games
@@ -11076,8 +10543,7 @@ LangSecRef=3022
 Detect=HKCU\Software\mIRC
 Default=False
 FileKey1=%AppData%\mIRC\Logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\mIRC\logs|*.*
-FileKey3=%ProgramFiles%\mIRC\logs|*.*
+FileKey2=%ProgramFiles%\mIRC\logs|*.*
 
 [Mirkes.De Tiny Hexer *]
 LangSecRef=3021
@@ -11121,11 +10587,9 @@ FileKey1=%LocalAppData%\Mixxx|*.log
 LangSecRef=3024
 DetectFile=%ProgramFiles%\SkanerOnline
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\SkanerOnline\Raporty|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\SkanerOnline\tmp|*.*
-FileKey3=%ProgramFiles%\SkanerOnline\Raporty|*.*
-FileKey4=%ProgramFiles%\SkanerOnline\tmp|*.*
-FileKey5=%SystemDrive%|*.cpp.log
+FileKey1=%ProgramFiles%\SkanerOnline\Raporty|*.*
+FileKey2=%ProgramFiles%\SkanerOnline\tmp|*.*
+FileKey3=%SystemDrive%|*.cpp.log
 
 [MMOUI Minion *]
 Section=Games
@@ -11145,7 +10609,6 @@ LangSecRef=3021
 DetectFile=%CommonAppData%\MobileBrServ
 Default=False
 FileKey1=%CommonAppData%\MobileBrServ\log|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\MobileBrServ\log|*.*|REMOVESELF
 
 [Mojo *]
 LangSecRef=3022
@@ -11181,17 +10644,14 @@ LangSecRef=3023
 Detect=HKCU\Software\Morpheus
 Default=False
 Warning=This will clear your shared folder and databases.
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Morpheus\DB|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Morpheus\My Shared Folder|*.*|RECURSE
-FileKey3=%ProgramFiles%\Morpheus\DB|*.*|RECURSE
-FileKey4=%ProgramFiles%\Morpheus\My Shared Folder|*.*|RECURSE
+FileKey1=%ProgramFiles%\Morpheus\DB|*.*|RECURSE
+FileKey2=%ProgramFiles%\Morpheus\My Shared Folder|*.*|RECURSE
 
 [Motherboard Monitor 5 *]
 LangSecRef=3023
 Detect=HKCU\Software\Alexander van Kaam\MBM 5
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Motherboard Monitor 5\Log|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Motherboard Monitor 5\Log|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\Motherboard Monitor 5\Log|*.*|REMOVESELF
 
 [Motorola Device Manager *]
 LangSecRef=3024
@@ -11210,19 +10670,15 @@ Detect6=HKLM\Software\Mount&Blade Warband
 Detect7=HKLM\Software\Mount&Blade With Fire and Sword
 Detect8=HKLM\Software\Mount&Blade: Warband - Napoleonic Wars
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Mount&Blade*|rgl_log.txt|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Napoleonic Wars|rgl_log.txt|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Mount&Blade*|rgl_log.txt|RECURSE
-FileKey4=%ProgramFiles%\Mount&Blade*|rgl_log.txt|RECURSE
-FileKey5=%ProgramFiles%\Napoleonic Wars|rgl_log.txt|RECURSE
-FileKey6=%ProgramFiles%\Steam\steamapps\common\Mount&Blade*|rgl_log.txt|RECURSE
+FileKey1=%ProgramFiles%\Mount&Blade*|rgl_log.txt|RECURSE
+FileKey2=%ProgramFiles%\Napoleonic Wars|rgl_log.txt|RECURSE
+FileKey3=%ProgramFiles%\Steam\steamapps\common\Mount&Blade*|rgl_log.txt|RECURSE
 
 [Mousotron *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Mousotron
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Mousotron|*.log
-FileKey2=%ProgramFiles%\Mousotron|*.log
+FileKey1=%ProgramFiles%\Mousotron|*.log
 
 [Movavi Video Converter *]
 LangSecRef=3023
@@ -11265,8 +10721,7 @@ RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 LangSecRef=3023
 Detect=HKCU\Software\VB and VBA Program Settings\MP3GainAnalysis
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\MP3Gain|*.log
-FileKey2=%ProgramFiles%\MP3Gain|*.log
+FileKey1=%ProgramFiles%\MP3Gain|*.log
 RegKey1=HKCU\Software\VB and VBA Program Settings\MP3GainAnalysis\StartUp|AddFilesPath
 RegKey2=HKCU\Software\VB and VBA Program Settings\MP3GainAnalysis\StartUp|AddFolderPath
 RegKey3=HKCU\Software\VB and VBA Program Settings\MP3GainAnalysis\StartUp|ChangeLog
@@ -11311,13 +10766,8 @@ FileKey2=%CommonAppData%\Microsoft\Microsoft antimalware\scans\history\results\Q
 FileKey3=%CommonAppData%\Microsoft\Microsoft antimalware\scans\history\results\resource|*.*|REMOVESELF
 FileKey4=%CommonAppData%\Microsoft\Microsoft antimalware\scans\history\results\System|*.*|REMOVESELF
 FileKey5=%CommonAppData%\Microsoft\Microsoft antimalware\support|*.log;*.txt
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft antimalware\network inspection system\Support|*.log;*.txt
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft antimalware\scans\history\results\Quick|*.*|REMOVESELF
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft antimalware\scans\history\results\resource|*.*|REMOVESELF
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft antimalware\scans\history\results\System|*.*|REMOVESELF
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Microsoft antimalware\support|*.log
-FileKey11=%SystemDrive%\Documents and Settings\NetworkService*\Temp|MpCmdRun.log
-FileKey12=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Temp|MpCmdRun.log
+FileKey6=%SystemDrive%\Documents and Settings\NetworkService*\Temp|MpCmdRun.log
+FileKey7=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Temp|MpCmdRun.log
 
 [MS Backup *]
 LangSecRef=3025
@@ -11379,8 +10829,7 @@ RegKey1=HKCU\Software\Kodak\Imaging\Recent File List
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Conferencing
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\NetMeeting|CallLog.dat
-FileKey2=%ProgramFiles%\NetMeeting|CallLog.dat
+FileKey1=%ProgramFiles%\NetMeeting|CallLog.dat
 RegKey1=HKCU\Software\Microsoft\Conferencing\UI\CallMRU
 
 [MS Notepad *]
@@ -11491,8 +10940,7 @@ LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Microsoft Robocopy GUI
 Default=False
 FileKey1=%AppData%\Microsoft Robocopy GUI\Logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Microsoft\Microsoft Robocopy GUI\Logs|*.*
-FileKey3=%ProgramFiles%\Microsoft\Microsoft Robocopy GUI\Logs|*.*
+FileKey2=%ProgramFiles%\Microsoft\Microsoft Robocopy GUI\Logs|*.*
 
 [MS Search *]
 LangSecRef=3025
@@ -11502,11 +10950,7 @@ FileKey1=%CommonAppData%\Microsoft\Search\Data\Applications\Windows|Windows.edb
 FileKey2=%CommonAppData%\Microsoft\Search\Data\Applications\Windows\GatherLogs\SystemIndex|*.*|RECURSE
 FileKey3=%CommonAppData%\Microsoft\Search\Data\Applications\Windows\Projects\SystemIndex\PropMap|*.*|RECURSE
 FileKey4=%CommonAppData%\Microsoft\Search\Data\Applications\Windows\Projects\SystemIndex\SecStore|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Search\Data\Applications\Windows|Windows.edb
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Search\Data\Applications\Windows\GatherLogs\SystemIndex|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Search\Data\Applications\Windows\Projects\SystemIndex\PropMap|*.*|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Search\Data\Applications\Windows\Projects\SystemIndex\SecStore|*.*|RECURSE
-FileKey9=%UserProfile%\Searches|*.search-ms
+FileKey5=%UserProfile%\Searches|*.search-ms
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Search\JumplistData
 RegKey2=HKLM\Software\Microsoft\Windows Search\VolumeInfoCache
 
@@ -11521,10 +10965,8 @@ LangSecRef=3021
 Detect1=HKCU\Software\Microsoft\Microsoft SQL Server
 Detect2=HKLM\Software\Microsoft\Microsoft SQL Server
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Microsoft SQL Server\*\MSSQL\Log|*ERRORLOG*;*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Microsoft SQL Server\*\Setup Bootstrap\LOG|*.*|RECURSE
-FileKey3=%ProgramFiles%\Microsoft SQL Server\*\MSSQL\Log|*ERRORLOG*;*.*|RECURSE
-FileKey4=%ProgramFiles%\Microsoft SQL Server\*\Setup Bootstrap\LOG|*.*|RECURSE
+FileKey1=%ProgramFiles%\Microsoft SQL Server\*\MSSQL\Log|*ERRORLOG*;*.*|RECURSE
+FileKey2=%ProgramFiles%\Microsoft SQL Server\*\Setup Bootstrap\LOG|*.*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Microsoft SQL Server\80\Tools\Shell\FileMRUList
 RegKey2=HKCU\Software\Microsoft\Microsoft SQL Server\80\Tools\Shell\ProjectMRUList
 RegKey3=HKCU\Software\Microsoft\Microsoft SQL Server\90\Tools\Shell\FileMRUList
@@ -11722,8 +11164,7 @@ Detect=HKCU\Software\Microsoft\VisualStudio
 Default=False
 FileKey1=%LocalAppData%\Microsoft\VisualStudio\SettingsLogs|*.*|RECURSE
 FileKey2=%LocalAppData%\PerfWatson|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Microsoft Visual Studio *\*\Logs|*.*|RECURSE
-FileKey4=%ProgramFiles%\Microsoft Visual Studio *\*\Logs|*.*|RECURSE
+FileKey3=%ProgramFiles%\Microsoft Visual Studio *\*\Logs|*.*|RECURSE
 
 [MS Visual Studio Backups *]
 LangSecRef=3021
@@ -11984,19 +11425,15 @@ RegKey1=HKCU\Software\Microsoft\XML Notepad\Recent File List
 LangSecRef=3024
 Detect=HKCU\Software\MSI
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\MSI Afterburner|HardwareMonitoring.hml
-FileKey2=%ProgramFiles%\MSI Afterburner|HardwareMonitoring.hml
+FileKey1=%ProgramFiles%\MSI Afterburner|HardwareMonitoring.hml
 
 [MTA San Andreas 1.3 *]
 Section=Games
 DetectFile=%ProgramFiles%\MTA San Andreas 1.3\Multi Theft Auto.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\MTA San Andreas 1.3\MTA\logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\MTA San Andreas 1.3\server\mods\deathmatch\backups|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\MTA San Andreas 1.3\server\mods\deathmatch\logs|*.*
-FileKey4=%ProgramFiles%\MTA San Andreas 1.3\MTA\logs|*.*
-FileKey5=%ProgramFiles%\MTA San Andreas 1.3\server\mods\deathmatch\backups|*.*
-FileKey6=%ProgramFiles%\MTA San Andreas 1.3\server\mods\deathmatch\logs|*.*
+FileKey1=%ProgramFiles%\MTA San Andreas 1.3\MTA\logs|*.*
+FileKey2=%ProgramFiles%\MTA San Andreas 1.3\server\mods\deathmatch\backups|*.*
+FileKey3=%ProgramFiles%\MTA San Andreas 1.3\server\mods\deathmatch\logs|*.*
 
 [Multi-Edit 2008 *]
 LangSecRef=3024
@@ -12038,8 +11475,7 @@ FileKey1=%AppData%\MultiBit\log|*.*
 LangSecRef=3024
 Detect=HKLM\Software\abelhadigital.com\MultiHasher
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\MultiHasher|*.txt;*.zip|RECURSE
-FileKey2=%ProgramFiles%\MultiHasher|*.txt;*.zip|RECURSE
+FileKey1=%ProgramFiles%\MultiHasher|*.txt;*.zip|RECURSE
 
 [MultiViewInpaint *]
 LangSecRef=3021
@@ -12078,10 +11514,8 @@ LangSecRef=3023
 Detect=HKLM\Software\MUSICMATCH\MUSICMATCH Jukebox
 Default=False
 FileKey1=%LocalAppData%\Musicmatch\Jukebox\Cache|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\MUSICMATCH\MUSICMATCH Jukebox|*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\MUSICMATCH\Musicmatch Jukebox\MMRadio\Cache|*.*|RECURSE
-FileKey4=%ProgramFiles%\MUSICMATCH\MUSICMATCH Jukebox|*.log|RECURSE
-FileKey5=%ProgramFiles%\MUSICMATCH\Musicmatch Jukebox\MMRadio\Cache|*.*|RECURSE
+FileKey2=%ProgramFiles%\MUSICMATCH\MUSICMATCH Jukebox|*.log|RECURSE
+FileKey3=%ProgramFiles%\MUSICMATCH\Musicmatch Jukebox\MMRadio\Cache|*.*|RECURSE
 
 [MusicNet *]
 LangSecRef=3023
@@ -12100,12 +11534,9 @@ FileKey2=%LocalAppData%\My Family Tree\Temp|*.*|RECURSE
 Section=Games
 Detect=HKLM\Software\My Horse and Me 2
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Atari\Mein Pferd und ich*\System|++ Finish log.txt;++ Start log.txt;*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Atari\My Horse and Me|++ Finish log.txt;++ Start log.txt;*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Atari\W!Games\My Horse and Me|++ Finish log.txt;++ Start log.txt;*.log|RECURSE
-FileKey4=%ProgramFiles%\Atari\Mein Pferd und ich*\System|++ Finish log.txt;++ Start log.txt;*.log|RECURSE
-FileKey5=%ProgramFiles%\Atari\My Horse and Me|++ Finish log.txt;++ Start log.txt;*.log|RECURSE
-FileKey6=%ProgramFiles%\Atari\W!Games\My Horse and Me|++ Finish log.txt;++ Start log.txt;*.log|RECURSE
+FileKey1=%ProgramFiles%\Atari\Mein Pferd und ich*\System|++ Finish log.txt;++ Start log.txt;*.log|RECURSE
+FileKey2=%ProgramFiles%\Atari\My Horse and Me|++ Finish log.txt;++ Start log.txt;*.log|RECURSE
+FileKey3=%ProgramFiles%\Atari\W!Games\My Horse and Me|++ Finish log.txt;++ Start log.txt;*.log|RECURSE
 
 [My Movies Collection *]
 LangSecRef=3023
@@ -12114,9 +11545,6 @@ Default=False
 FileKey1=%CommonAppData%\My Movies|vcredist*.*;installerlog.txt;log.txt
 FileKey2=%CommonAppData%\My Movies\File Storage\Temp|*.*|RECURSE
 FileKey3=%CommonAppData%\My Movies\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\My Movies|installerlog.txt;log.txt
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\My Movies\File Storage\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\My Movies\Temp|*.*|RECURSE
 
 [My Office *]
 DetectOS=10.0|
@@ -12135,8 +11563,7 @@ FileKey7=%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\LocalState\Cache
 Section=Games
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\MyRidingStables
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\My Riding Stables*|*.txt;*.url
-FileKey2=%ProgramFiles%\My Riding Stables*|*.txt;*.url
+FileKey1=%ProgramFiles%\My Riding Stables*|*.txt;*.url
 
 [My Singing Monsters *]
 Section=Games
@@ -12144,10 +11571,8 @@ Detect1=HKLM\Software\Big Fish Games\Persistence\Install\F7664T1L1
 Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\My Singing Monsters1.1
 DetectFile=%ProgramFiles%\My Singing Monsters
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\*\My Singing Monsters|*.log;*.txt|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\My Singing Monsters|*.log;*.txt|RECURSE
-FileKey3=%ProgramFiles%\*\My Singing Monsters|dotnetfx35setup.exe;*.html;*.PNG;vcredist_x86.exe;*.log;*.txt|RECURSE
-FileKey4=%ProgramFiles%\My Singing Monsters|dotnetfx35setup.exe;vcredist_x86.exe;*.log;*.txt|RECURSE
+FileKey1=%ProgramFiles%\*\My Singing Monsters|dotnetfx35setup.exe;*.html;*.PNG;vcredist_x86.exe;*.log;*.txt|RECURSE
+FileKey2=%ProgramFiles%\My Singing Monsters|dotnetfx35setup.exe;vcredist_x86.exe;*.log;*.txt|RECURSE
 
 [MyCraft *]
 Section=Games
@@ -12159,10 +11584,8 @@ FileKey1=%UserProfile%\Desktop\MyCraft|MyCraft Log.*
 LangSecRef=3021
 Detect=HKCU\Software\MyDefrag
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\MyDefrag *|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\MyDefrag *\LOGs|*.*
-FileKey3=%ProgramFiles%\MyDefrag *|*.log
-FileKey4=%ProgramFiles%\MyDefrag *\LOGs|*.*
+FileKey1=%ProgramFiles%\MyDefrag *|*.log
+FileKey2=%ProgramFiles%\MyDefrag *\LOGs|*.*
 
 [MyPhoneExplorer *]
 LangSecRef=3024
@@ -12215,8 +11638,7 @@ LangSecRef=3024
 DetectFile=%ProgramFiles%\EgisTec\mywinlocker 3
 Default=False
 FileKey1=%LocalAppData%|mywinlockerinstaller.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\EgisTec\MyWinLocker 3\log|*.*
-FileKey3=%ProgramFiles%\EgisTec\MyWinLocker 3\log|*.*
+FileKey2=%ProgramFiles%\EgisTec\MyWinLocker 3\log|*.*
 
 [Nancy Drew: The Secret of Shadow Ranch *]
 Section=Games
@@ -12274,7 +11696,6 @@ FileKey8=%AppData%\Nero\Nero*\Nero3D|*.log
 FileKey9=%CommonAppData%\Nero\PeakFiles|*.tmp
 FileKey10=%LocalAppData%\Nero\Nero *\Nero Vision\Cache|*.*
 FileKey11=%LocalAppData%\Nero\Nero *\Nero Vision\Cache\GraphicObjectCache|*.*
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\Nero\PeakFiles|*.tmp
 RegKey1=HKCU\Software\ahead\Nero PhotoSnap\Recent File List
 RegKey2=HKCU\Software\Ahead\NeroSearch\NeroSavedSearches\SavedSearches
 RegKey3=HKCU\Software\ahead\NeroVision\2.0\RecentFiles
@@ -12354,12 +11775,9 @@ RegKey74=HKCU\Software\Nero\Nero8\Nero - Burning Rom\Recent File List
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Net Vampire
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Net Vampire\Data\Jobs|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Net Vampire\Data\Sites|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Net Vampire\Data\State|*.*|RECURSE
-FileKey4=%ProgramFiles%\Net Vampire\Data\Jobs|*.*|RECURSE
-FileKey5=%ProgramFiles%\Net Vampire\Data\Sites|*.*|RECURSE
-FileKey6=%ProgramFiles%\Net Vampire\Data\State|*.*|RECURSE
+FileKey1=%ProgramFiles%\Net Vampire\Data\Jobs|*.*|RECURSE
+FileKey2=%ProgramFiles%\Net Vampire\Data\Sites|*.*|RECURSE
+FileKey3=%ProgramFiles%\Net Vampire\Data\State|*.*|RECURSE
 
 [Net2Printer RDP *]
 LangSecRef=3021
@@ -12371,8 +11789,7 @@ FileKey1=%AppData%\Net2Printer RDP Client|*.*
 LangSecRef=3022
 DetectFile=%ProgramFiles%\NetAnts
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\NetAnts|netants.job;history.txt
-FileKey2=%ProgramFiles%\NetAnts|netants.job;history.txt
+FileKey1=%ProgramFiles%\NetAnts|netants.job;history.txt
 
 [NetBeans IDE *]
 LangSecRef=3021
@@ -12456,8 +11873,7 @@ Section=Games
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\New Yankee 3 - In Santas ServiceFinal
 Default=False
 FileKey1=%AppData%\AlawarEntertainment|*_log.html|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\New Yankee 3 - In Santas Service|*.nfo
-FileKey3=%ProgramFiles%\New Yankee 3 - In Santas Service|*.nfo
+FileKey2=%ProgramFiles%\New Yankee 3 - In Santas Service|*.nfo
 
 [News *]
 LangSecRef=3031
@@ -12489,12 +11905,9 @@ FileKey1=%AppData%\Newsleecher\Backups|*.*
 LangSecRef=3022
 DetectFile=%ProgramFiles%\neXBC\neXBC.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\neXBC|messages.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\neXBC\Logs\Hosted|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\neXBC\Logs\Joined|*.*
-FileKey4=%ProgramFiles%\neXBC|messages.txt
-FileKey5=%ProgramFiles%\neXBC\Logs\Hosted|*.*
-FileKey6=%ProgramFiles%\neXBC\Logs\Joined|*.*
+FileKey1=%ProgramFiles%\neXBC|messages.txt
+FileKey2=%ProgramFiles%\neXBC\Logs\Hosted|*.*
+FileKey3=%ProgramFiles%\neXBC\Logs\Joined|*.*
 
 [Nextup TextAloud *]
 LangSecRef=3021
@@ -12557,10 +11970,8 @@ LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\NirSoft RegScanner
 DetectFile=%ProgramFiles%\Nirsoft\regscanner.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\NirSoft|report.html
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\NirSoft\x64|report.html
-FileKey3=%ProgramFiles%\NirSoft|report.html
-FileKey4=%ProgramFiles%\NirSoft\x64|report.html
+FileKey1=%ProgramFiles%\NirSoft|report.html
+FileKey2=%ProgramFiles%\NirSoft\x64|report.html
 
 [Nitro PDF Reader *]
 LangSecRef=3024
@@ -12580,8 +11991,7 @@ FileKey1=%AppData%\.nitrous\backups|*.*|REMOVESELF
 LangSecRef=3024
 DetectFile=%ProgramFiles%\nLite
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\nLite\Presets|*.*
-FileKey2=%ProgramFiles%\nLite\Presets|*.*
+FileKey1=%ProgramFiles%\nLite\Presets|*.*
 
 [No-IP DUC *]
 LangSecRef=3022
@@ -12607,9 +12017,6 @@ Warning=This will remove Nokia phone firmwares, applications and other files sto
 FileKey1=%CommonAppData%\Nokia\Nokia Service Layer\A|*.*|REMOVESELF
 FileKey2=%CommonProgramFiles%\Nokia\Service Layer\A|*.*|REMOVESELF
 FileKey3=%LocalAppData%\Nokia\NSU3\NOSSU2|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Common Files\Nokia\Service Layer\A|*.*|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Nokia\Nokia Service Layer\A|*.*|REMOVESELF
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Nokia\Nokia Suite\NOSSU2|*.*|RECURSE
 ExcludeKey1=FILE|%LocalAppData%\Nokia\NSU3\NOSSU2\|usergroups.cfg
 ExcludeKey2=PATH|%LocalAppData%\Nokia\NSU3\NOSSU2\Flash\|*.*
 
@@ -12618,7 +12025,6 @@ LangSecRef=3021
 DetectFile=%CommonAppData%\NokiaInstallerCache
 Default=False
 FileKey1=%CommonAppData%\NokiaInstallerCache\PackageCache|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\NokiaInstallerCache\PackageCache|*.*|RECURSE
 
 [Norton *]
 LangSecRef=3024
@@ -12627,8 +12033,6 @@ Default=False
 FileKey1=%CommonAppData%\Norton|*.log;*.txt
 FileKey2=%CommonAppData%\Norton\LocalDumps|*.dmp
 FileKey3=%CommonAppData%\NortonInstaller\Logs|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Norton\LocalDumps|*.dmp
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\NortonInstaller\Logs|*.*|RECURSE
 
 [Norton Power Eraser *]
 LangSecRef=3024
@@ -12637,8 +12041,7 @@ Default=False
 Warning=This removes all files of Norton Power Eraser. This tool should be re-downloaded from Symantec after each run.
 FileKey1=%CommonAppData%\Norton\NPE|*.*|REMOVESELF
 FileKey2=%LocalAppData%\NPE|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Norton\NPE|*.*|REMOVESELF
-FileKey4=%UserProfile%\Desktop|NPE.exe
+FileKey3=%UserProfile%\Desktop|NPE.exe
 
 [Norton Utilities 15 *]
 LangSecRef=3021
@@ -12708,8 +12111,7 @@ FileKey4=%WinDir%\System32\config|COMPONENTS.bak;SYSTEM.bak;DEFAULT.bak;SAM.bak;
 LangSecRef=3024
 DetectFile=%ProgramFiles%\New Tech Infosystems\NTI Backup Now 5
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\New Tech Infosystems\NTI Backup Now 5\logs|*.*
-FileKey2=%ProgramFiles%\New Tech Infosystems\NTI Backup Now 5\logs|*.*
+FileKey1=%ProgramFiles%\New Tech Infosystems\NTI Backup Now 5\logs|*.*
 
 [Nuance Dragon Natually Speaking 12 *]
 LangSecRef=3021
@@ -12793,16 +12195,8 @@ FileKey10=%LocalAppData%\NVIDIA Corporation|*.log;*.bak;*.old|RECURSE
 FileKey11=%LocalAppData%\NVIDIA Corporation\*\CefCache|Cookies;Cookies-journal;QuotaManager;QuotaManager-journal
 FileKey12=%LocalAppData%\NVIDIA Corporation\*\CefCache\*Cache|*.*|RECURSE
 FileKey13=%LocalAppData%\NVIDIA\NvBackend|*.log;*.bak
-FileKey14=%LocalAppData%\VirtualStore\Program Files*\NVIDIA Corporation\NetworkAccessManager\Apache Group\Apache2\logs|*.*
-FileKey15=%LocalAppData%\VirtualStore\ProgramData\NVIDIA|*.log;*.log_backup1;Resource.old;*.bak|RECURSE
-FileKey16=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation|*.log;*bak;*log.*;*.old;*.stat|RECURSE
-FileKey17=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\Downloader|*.*|RECURSE
-FileKey18=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\GeForce Experience\Update|*.*|RECURSE
-FileKey19=%LocalAppData%\VirtualStore\ProgramData\NVIDIA Corporation\NetService|*.*|RECURSE
-FileKey20=%LocalAppData%\VirtualStore\ProgramData\NVIDIA\NvBackend\Updatus\DownloadManager|*.*
-FileKey21=%LocalAppData%\VirtualStore\ProgramData\NVIDIA\Updatus\DownloadManager|*.*
-FileKey22=%ProgramFiles%\NVIDIA Corporation\NetworkAccessManager\Apache Group\Apache2\logs|*.*
-FileKey23=%SystemDrive%\NvidiaLogging\GFExperience|GridClientLog.log*|RECURSE
+FileKey14=%ProgramFiles%\NVIDIA Corporation\NetworkAccessManager\Apache Group\Apache2\logs|*.*
+FileKey15=%SystemDrive%\NvidiaLogging\GFExperience|GridClientLog.log*|RECURSE
 
 [O&O Defrag *]
 LangSecRef=3024
@@ -12907,16 +12301,14 @@ FileKey2=%LocalAppData%\oneteam\profiles\*\cache|*.*|RECURSE
 LangSecRef=3021
 Detect=HKLM\Software\Tall Emu\Online Armor
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Tall Emu\Online Armor\Logs|*.*
-FileKey2=%ProgramFiles%\Tall Emu\Online Armor\Logs|*.*
+FileKey1=%ProgramFiles%\Tall Emu\Online Armor\Logs|*.*
 
 [Ontrack EasyRecovery *]
 LangSecRef=3024
 Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{668CC71A-C2AD-4D56-866D-CF300BD1D5BE}_is1
 Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{AE695CA4-8847-4462-98CC-023874D29E72}_is1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Kroll Ontrack\Ontrack EasyRecovery*|*erent_log.txt;*erpro_log.txt
-FileKey2=%ProgramFiles%\Kroll Ontrack\Ontrack EasyRecovery*|*erent_log.txt;*erpro_log.txt
+FileKey1=%ProgramFiles%\Kroll Ontrack\Ontrack EasyRecovery*|*erent_log.txt;*erpro_log.txt
 
 [Ookla Speed Test *]
 LangSecRef=3031
@@ -12941,10 +12333,8 @@ FileKey1=%AppData%\OpalCalc_prefs|lastSession.txt
 LangSecRef=3023
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Blu-ray to DVD Pro_is1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Blu-ray to DVD*|*.log;*.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Blu-ray to DVD*\ReadCache|*.*
-FileKey3=%ProgramFiles%\Blu-ray to DVD*|*.log;*.txt
-FileKey4=%ProgramFiles%\Blu-ray to DVD*\ReadCache|*.*
+FileKey1=%ProgramFiles%\Blu-ray to DVD*|*.log;*.txt
+FileKey2=%ProgramFiles%\Blu-ray to DVD*\ReadCache|*.*
 
 [Open Blu-ray/DVD Ripper *]
 LangSecRef=3023
@@ -12971,22 +12361,19 @@ FileKey1=%AppData%\OpenDNS Updater|*.txt
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Openfire
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Openfire\Logs|*.*
-FileKey2=%ProgramFiles%\Openfire\Logs|*.*
+FileKey1=%ProgramFiles%\Openfire\Logs|*.*
 
 [OpenMG *]
 LangSecRef=3023
 DetectFile=%CommonAppData%\Sony Corporation\OpenMG
 Default=False
 FileKey1=%CommonAppData%\Sony Corporation\OpenMG|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Sony Corporation\OpenMG|*.log
 
 [OpenMG CD Backups *]
 LangSecRef=3023
 DetectFile=%CommonAppData%\Sony Corporation\OpenMG
 Default=False
 FileKey1=%CommonAppData%\Sony Corporation\OpenMG\CD Walkman\Temp|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Sony Corporation\OpenMG\CD Walkman\Temp|*.*|REMOVESELF
 
 [OpenMG Jukebox *]
 LangSecRef=3023
@@ -13023,8 +12410,7 @@ FileKey1=%Documents%\OpenRA\Logs|*.*
 LangSecRef=3024
 DetectFile=%ProgramFiles%\OpenVPN
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\OpenVPN\Log|*.*
-FileKey2=%ProgramFiles%\OpenVPN\Log|*.*
+FileKey1=%ProgramFiles%\OpenVPN\Log|*.*
 
 [Opera *]
 LangSecRef=3027
@@ -13044,10 +12430,8 @@ RegKey1=HKCU\Software\Opera Software|Last CommandLine v2
 LangSecRef=3027
 DetectFile=%ProgramFiles%\Opera 9\Opera.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Opera 9\profile|cookies4.dat;vlink4.dat;global.dat
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Opera 9\profile\cache*|*.*
-FileKey3=%ProgramFiles%\Opera 9\profile|cookies4.dat;vlink4.dat;global.dat
-FileKey4=%ProgramFiles%\Opera 9\profile\cache*|*.*
+FileKey1=%ProgramFiles%\Opera 9\profile|cookies4.dat;vlink4.dat;global.dat
+FileKey2=%ProgramFiles%\Opera 9\profile\cache*|*.*
 
 [Optimizer Pro *]
 LangSecRef=3024
@@ -13091,10 +12475,7 @@ FileKey2=%CommonAppData%\Origin\Logs|*.*
 FileKey3=%CommonAppData%\Origin\Telemetry|*.*
 FileKey4=%LocalAppData%\Origin\Origin\cache|*.*|RECURSE
 FileKey5=%LocalAppData%\Origin\Web Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Origin\*Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Origin\Logs|*.*
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Origin\Telemetry|*.*
-FileKey9=%SystemDrive%|shared.log
+FileKey6=%SystemDrive%|shared.log
 
 [Origin Installers *]
 Section=Games
@@ -13114,8 +12495,7 @@ Section=Games
 Detect=HKCU\Software\Osu!
 Default=False
 FileKey1=%LocalAppData%\osu!\logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Osu!|debug-import.txt
-FileKey3=%ProgramFiles%\Osu!|debug-import.txt
+FileKey2=%ProgramFiles%\Osu!|debug-import.txt
 
 [Outlast *]
 Section=Games
@@ -13154,25 +12534,21 @@ LangSecRef=3021
 Detect=HKLM\Software\Agnitum\Outpost Firewall
 Default=False
 FileKey1=%CommonAppData%\Agnitum\Security Suite\Feedback\Logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Agnitum\Outpost Firewall Pro\log|*.*
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Agnitum\Security Suite\Feedback\Logs|*.*
-FileKey4=%ProgramFiles%\Agnitum\Outpost Firewall Pro\log|*.*
+FileKey2=%ProgramFiles%\Agnitum\Outpost Firewall Pro\log|*.*
 
 [Outpost Security Suite *]
 LangSecRef=3021
 Detect=HKLM\Software\Agnitum\Security Suite
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Agnitum\Outpost Security Suite Pro\log|*.log
-FileKey2=%ProgramFiles%\Agnitum\Outpost Security Suite Pro\log|*.log
+FileKey1=%ProgramFiles%\Agnitum\Outpost Security Suite Pro\log|*.log
 
 [Overwatch *]
 Section=Games
 DetectFile=%Documents%\Overwatch
 Default=False
 FileKey1=%Documents%\Overwatch\Logs|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Overwatch\WebBrowserProxy\cache\browser|*.*
-FileKey3=%ProgramFiles%\Overwatch\WebBrowserProxy\cache\browser|*.*
-FileKey4=%ProgramFiles%\Overwatch\WebBrowserProxy\logs\browser|*.*
+FileKey2=%ProgramFiles%\Overwatch\WebBrowserProxy\cache\browser|*.*
+FileKey3=%ProgramFiles%\Overwatch\WebBrowserProxy\logs\browser|*.*
 
 [OVH HubiC *]
 LangSecRef=3021
@@ -13184,14 +12560,10 @@ FileKey1=%LocalAppData%\OVH\hubiC-browser\cache\data7|*.*|RECURSE
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Oxygen XML Editor 14
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Oxygen XML Editor 14|*.properties;*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Oxygen XML Editor 14\.install4j|*.log
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Oxygen XML Editor 14\dicts|*.txt;*.html
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Oxygen XML Editor 14\lib|*.txt|RECURSE
-FileKey5=%ProgramFiles%\Oxygen XML Editor 14|*.properties;*.log
-FileKey6=%ProgramFiles%\Oxygen XML Editor 14\.install4j|*.log
-FileKey7=%ProgramFiles%\Oxygen XML Editor 14\dicts|*.txt;*.html
-FileKey8=%ProgramFiles%\Oxygen XML Editor 14\lib|*.txt|RECURSE
+FileKey1=%ProgramFiles%\Oxygen XML Editor 14|*.properties;*.log
+FileKey2=%ProgramFiles%\Oxygen XML Editor 14\.install4j|*.log
+FileKey3=%ProgramFiles%\Oxygen XML Editor 14\dicts|*.txt;*.html
+FileKey4=%ProgramFiles%\Oxygen XML Editor 14\lib|*.txt|RECURSE
 ExcludeKey1=FILE|%ProgramFiles%\Oxygen XML Editor 14\.install4j\|files.log
 
 [Pacific Storm *]
@@ -13199,10 +12571,8 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\11250
 DetectFile=%ProgramFiles%\Buka\Pacific Storm
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Buka\Pacific Storm|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Pacific Storm*|*.log|RECURSE
-FileKey3=%ProgramFiles%\Buka\Pacific Storm|*.log|RECURSE
-FileKey4=%ProgramFiles%\Steam\SteamApps\Common\Pacific Storm*|*.log|RECURSE
+FileKey1=%ProgramFiles%\Buka\Pacific Storm|*.log|RECURSE
+FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Pacific Storm*|*.log|RECURSE
 
 [Paint 3D *]
 DetectOS=10.0|
@@ -13268,14 +12638,12 @@ Detect=HKCU\Software\Pando Networks\PMB
 Default=False
 FileKey1=%CommonAppData%\PMB Files|*.TOK;*.log
 FileKey2=%LocalAppData%\PMB Files\*|*.CT1;*.CT2;*.dat;*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\PMB Files|*.TOK;*.log
 
 [Paragon Hard Disk Manager 12 Suite *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Paragon Software\Hard Disk Manager 12 Suite
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Paragon Software\Hard Disk Manager 12 Suite|*.log
-FileKey2=%ProgramFiles%\Paragon Software\Hard Disk Manager 12 Suite|*.log
+FileKey1=%ProgramFiles%\Paragon Software\Hard Disk Manager 12 Suite|*.log
 
 [Paragon Hard Disk Manager 14 Suite *]
 LangSecRef=3024
@@ -13293,22 +12661,9 @@ FileKey9=%CommonAppData%\redistpart|*.log
 FileKey10=%CommonAppData%\vmadjust|*.log
 FileKey11=%CommonAppData%\vmcreate|*.log
 FileKey12=%CommonAppData%\wipe|*.log
-FileKey13=%LocalAppData%\VirtualStore\Program Files*\Paragon Software\Hard Disk Manager 14 Suite\*|BioNtLog.txt;cdb.log;fdisk.txt;pwlog.txt;stubact.log
-FileKey14=%LocalAppData%\VirtualStore\Program Files*\Paragon Software\Hard Disk Manager 14 Suite\*\symmpi*|*.txt
-FileKey15=%LocalAppData%\VirtualStore\ProgramData\clonehdd|*.log
-FileKey16=%LocalAppData%\VirtualStore\ProgramData\createpart|*.log
-FileKey17=%LocalAppData%\VirtualStore\ProgramData\deletepart|*.log
-FileKey18=%LocalAppData%\VirtualStore\ProgramData\explauncher|*.log
-FileKey19=%LocalAppData%\VirtualStore\ProgramData\ftw|*.log
-FileKey20=%LocalAppData%\VirtualStore\ProgramData\launcher|*.log
-FileKey21=%LocalAppData%\VirtualStore\ProgramData\logsaver|*.log
-FileKey22=%LocalAppData%\VirtualStore\ProgramData\migrateos|*.log
-FileKey23=%LocalAppData%\VirtualStore\ProgramData\redistpart|*.log
-FileKey24=%LocalAppData%\VirtualStore\ProgramData\vmadjust|*.log
-FileKey25=%LocalAppData%\VirtualStore\ProgramData\vmcreate|*.log
-FileKey26=%ProgramFiles%\Paragon Software\Hard Disk Manager 14 Suite\*|BioNtLog.txt;cdb.log;fdisk.txt;pwlog.txt;stubact.log
-FileKey27=%ProgramFiles%\Paragon Software\Hard Disk Manager 14 Suite\*\symmpi*|*.txt
-FileKey28=%SystemDrive%\Documents and Settings\LocalService|objsrv.log
+FileKey13=%ProgramFiles%\Paragon Software\Hard Disk Manager 14 Suite\*|BioNtLog.txt;cdb.log;fdisk.txt;pwlog.txt;stubact.log
+FileKey14=%ProgramFiles%\Paragon Software\Hard Disk Manager 14 Suite\*\symmpi*|*.txt
+FileKey15=%SystemDrive%\Documents and Settings\LocalService|objsrv.log
 
 [Paragon Partition Manager 2014 *]
 LangSecRef=3024
@@ -13322,24 +12677,14 @@ FileKey5=%CommonAppData%\formatpart|*.log
 FileKey6=%CommonAppData%\launcher|*.log
 FileKey7=%CommonAppData%\logsaver|*.log
 FileKey8=%CommonAppData%\redistpart|*.log
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\Paragon Software\*\program|BioNtLog.txt;cdb.log;fdisk.txt;pwlog.txt;stubact.log
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\converthfs|*.log
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\createpart|*.log
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\deletepart|*.log
-FileKey13=%LocalAppData%\VirtualStore\ProgramData\explauncher|*.log
-FileKey14=%LocalAppData%\VirtualStore\ProgramData\formatpart|*.log
-FileKey15=%LocalAppData%\VirtualStore\ProgramData\launcher|*.log
-FileKey16=%LocalAppData%\VirtualStore\ProgramData\logsaver|*.log
-FileKey17=%LocalAppData%\VirtualStore\ProgramData\redistpart|*.log
-FileKey18=%ProgramFiles%\Paragon Software\*\program|BioNtLog.txt;cdb.log;fdisk.txt;pwlog.txt;stubact.log
-FileKey19=%SystemDrive%\Documents and Settings\LocalService|objsrv.log
+FileKey9=%ProgramFiles%\Paragon Software\*\program|BioNtLog.txt;cdb.log;fdisk.txt;pwlog.txt;stubact.log
+FileKey10=%SystemDrive%\Documents and Settings\LocalService|objsrv.log
 
 [Paragon Total Defrag 2010 *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Paragon Software\Total Defrag 2010
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Paragon Software\Total Defrag 2010|*.log;biontlog.txt|RECURSE
-FileKey2=%ProgramFiles%\Paragon Software\Total Defrag 2010|*.log;biontlog.txt|RECURSE
+FileKey1=%ProgramFiles%\Paragon Software\Total Defrag 2010|*.log;biontlog.txt|RECURSE
 
 [Paramount Dynamic *]
 LangSecRef=3023
@@ -13352,8 +12697,7 @@ FileKey1=%LocalAppData%\Microsoft\Feeds|http~c~f~fthemeserver~dmicrosoft~dcom~fd
 Section=Games
 DetectFile=%ProgramFiles%\Desura\Common\paranormal
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Desura\Common\paranormal\UDKGame\Logs|*.*
-FileKey2=%ProgramFiles%\Desura\Common\paranormal\UDKGame\Logs|*.*
+FileKey1=%ProgramFiles%\Desura\Common\paranormal\UDKGame\Logs|*.*
 
 [Paranormal Agency *]
 Section=Games
@@ -13366,7 +12710,6 @@ LangSecRef=3022
 DetectFile=%CommonAppData%\Partner
 Default=False
 FileKey1=%CommonAppData%\Partner|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Partner|*.log
 
 [Patch My PC *]
 LangSecRef=3024
@@ -13380,10 +12723,8 @@ Detect1=HKCU\Software\GrindingGearGames\Path of Exile
 Detect2=HKCU\Software\Valve\Steam\Apps\238960
 Default=False
 FileKey1=%Documents%\My Games\Path of Exile\Minimap|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Grinding Gear Games\Path of Exile\Logs|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Path of Exile\logs|*.*
-FileKey4=%ProgramFiles%\Grinding Gear Games\Path of Exile\Logs|*.*
-FileKey5=%ProgramFiles%\Steam\steamapps\common\Path of Exile\logs|*.*
+FileKey2=%ProgramFiles%\Grinding Gear Games\Path of Exile\Logs|*.*
+FileKey3=%ProgramFiles%\Steam\steamapps\common\Path of Exile\logs|*.*
 
 [PAYDAY 2 *]
 Section=Games
@@ -13396,15 +12737,13 @@ FileKey1=%LocalAppData%\PAYDAY 2|crash.txt;crashlog.txt
 LangSecRef=3024
 DetectFile=%ProgramFiles%\PC-Doctor For Windows
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\PC-Doctor For Windows\Logs|*.*
-FileKey2=%ProgramFiles%\PC-Doctor For Windows\Logs|*.*
+FileKey1=%ProgramFiles%\PC-Doctor For Windows\Logs|*.*
 
 [PC Optimizer Pro *]
 LangSecRef=3024
 DetectFile=%CommonAppData%\PC optimizer pro
 Default=False
 FileKey1=%CommonAppData%\PC Optimizer Pro\Logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\PC Optimizer Pro\Logs|*.*
 
 [PC Tools Performance Toolkit *]
 LangSecRef=3024
@@ -13413,19 +12752,14 @@ Default=False
 FileKey1=%AppData%\PC Tools Performance Toolkit\CleanReports|*.*
 FileKey2=%CommonAppData%\PC Tools\Performance Toolkit\Defrag\Logs|*.*
 FileKey3=%CommonAppData%\PC Tools\Performance Toolkit\Repair\Logs|*.*
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\PC Tools\*\~tmp|*.*
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\PC Tools\*\Log|*.*
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\PC Tools\Performance Toolkit\Defrag\Logs|*.*
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\PC Tools\Performance Toolkit\Repair\Logs|*.*
-FileKey8=%ProgramFiles%\PC Tools\*\~tmp|*.*
-FileKey9=%ProgramFiles%\PC Tools\*\Log|*.*
+FileKey4=%ProgramFiles%\PC Tools\*\~tmp|*.*
+FileKey5=%ProgramFiles%\PC Tools\*\Log|*.*
 
 [PC Tools sMonitor *]
 LangSecRef=3024
 DetectFile=%CommonProgramFiles%\PC Tools\sMonitor
 Default=False
 FileKey1=%CommonProgramFiles%\PC Tools\sMonitor|cputime.xml;logfile.etl
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Common Files\PC Tools\sMonitor|cputime.xml;logfile.etl
 
 [PCFresh Backups *]
 LangSecRef=3024
@@ -13478,8 +12812,7 @@ FileKey1=%AppData%\Zeon\DocuCom\PDF Plus\Log|*.*
 LangSecRef=3021
 DetectFile=%ProgramFiles%\PDF24
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\PDF24|*.log
-FileKey2=%ProgramFiles%\PDF24|*.log
+FileKey1=%ProgramFiles%\PDF24|*.log
 
 [PE Module Explorer *]
 LangSecRef=3024
@@ -13491,9 +12824,8 @@ RegKey1=HKCU\Software\Woozle\PE Module Explorer\Recent Files
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Peerblock
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Peerblock|*.log;History.db;*.bak;cache.p2b
-FileKey2=%ProgramFiles%\Peerblock|*.log;History.db;*.bak;cache.p2b
-FileKey3=%ProgramFiles%\Peerblock\lists|*.list.failed*
+FileKey1=%ProgramFiles%\Peerblock|*.log;History.db;*.bak;cache.p2b
+FileKey2=%ProgramFiles%\Peerblock\lists|*.list.failed*
 
 [PeerNetworking *]
 LangSecRef=3025
@@ -13535,7 +12867,6 @@ LangSecRef=3024
 Detect=HKCU\Software\Raxco\PerfectDisk
 Default=False
 FileKey1=%CommonAppData%\Raxco\PerfectDisk\*|*.log;*.txt;PDBootLog
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Raxco\PerfectDisk\*|*.log;*.txt
 
 [PerfectUpdater *]
 LangSecRef=3024
@@ -13550,21 +12881,16 @@ FileKey3=%AppData%\Raxco\PerfectUpdater\Download|*.*
 LangSecRef=3024
 DetectFile=%ProgramFiles%\PC Starters\Performance Maintainer
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\PC Starters\Performance Maintainer\Backups|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\PC Starters\Performance Maintainer\log*|*.*|RECURSE
-FileKey3=%ProgramFiles%\PC Starters\Performance Maintainer\Backups|*.*|RECURSE
-FileKey4=%ProgramFiles%\PC Starters\Performance Maintainer\log*|*.*|RECURSE
+FileKey1=%ProgramFiles%\PC Starters\Performance Maintainer\Backups|*.*|RECURSE
+FileKey2=%ProgramFiles%\PC Starters\Performance Maintainer\log*|*.*|RECURSE
 
 [Pet Pals: Animal Doctor *]
 Section=Games
 Detect=HKLM\Software\Legacy Interactive\Pet Pals
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Legacy Interactive\Pet Pals Animal Doctor|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Legacy Interactive\Pet Pals Animal Doctor\jre|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Legacy Interactive\Pet Pals Animal Doctor\temp|*.*|REMOVESELF
-FileKey4=%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor|*.log
-FileKey5=%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor\jre|*.*
-FileKey6=%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor\temp|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor|*.log
+FileKey2=%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor\jre|*.*
+FileKey3=%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor\temp|*.*|REMOVESELF
 ExcludeKey1=PATH|%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor\jre\bin\|*.*
 ExcludeKey2=PATH|%ProgramFiles%\Legacy Interactive\Pet Pals Animal Doctor\jre\lib\|*.*
 
@@ -13603,8 +12929,7 @@ RegKey5=HKCU\Software\FutureFog\Phorest\Options|LastUsedFolder
 LangSecRef=3021
 Detect=HKLM\Software\Computer Institute of Japan, Ltd.\Photo Print Calendar from YOKOHAMA Ver.3.00E beta\3.00E beta
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Photo Print Calendar|update.bmp
-FileKey2=%ProgramFiles%\Photo Print Calendar|update.bmp
+FileKey1=%ProgramFiles%\Photo Print Calendar|update.bmp
 
 [Photo Stamp Remover *]
 LangSecRef=3023
@@ -13616,8 +12941,7 @@ RegKey1=HKCU\Software\softorbits\PhotoStampRemover|currentFile
 LangSecRef=3024
 Detect=HKCU\Software\VicMan Software\Photo! Editor
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Photo!\Photo! Editor|*.log
-FileKey2=%ProgramFiles%\Photo!\Photo! Editor|*.log
+FileKey1=%ProgramFiles%\Photo!\Photo! Editor|*.log
 RegKey1=HKCU\Software\VicMan Software\Photo! Editor|LastFolder
 
 [Photodex ProShow Producer *]
@@ -13628,13 +12952,8 @@ FileKey1=%CommonAppData%\Photodex\ProShow|*.log|RECURSE
 FileKey2=%CommonAppData%\Photodex\ProShow\FontCache|*.*|REMOVESELF
 FileKey3=%CommonAppData%\Photodex\ProShow\Styles\Cache|*.*|REMOVESELF
 FileKey4=%CommonAppData%\Photodex\ProShow\Transitions\Cache|*.*|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Photodex\ProShow Producer|*.log|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Photodex\ProShow|*.log|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Photodex\ProShow\FontCache|*.*|REMOVESELF
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Photodex\ProShow\Styles\Cache|*.*|REMOVESELF
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Photodex\ProShow\Transitions\Cache|*.*|REMOVESELF
-FileKey10=%ProgramFiles%\Photodex\ProShow Producer|*.log|RECURSE
-FileKey11=%UserProfile%|proshow-burn.log
+FileKey5=%ProgramFiles%\Photodex\ProShow Producer|*.log|RECURSE
+FileKey6=%UserProfile%|proshow-burn.log
 ExcludeKey1=FILE|%ProgramFiles%\Photodex\ProShow Producer\pxf\images\|xicons.txt
 
 [Photos *]
@@ -13698,15 +13017,13 @@ FileKey1=%AppData%\PhrozenSoft\PVTUploader|phrzvtu.db
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Phyxion.net\Driver Sweeper\Logs
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Phyxion.net\Driver Sweeper\Logs|*.*|RECURSE
-FileKey2=%ProgramFiles%\Phyxion.net\Driver Sweeper\Logs|*.*|RECURSE
+FileKey1=%ProgramFiles%\Phyxion.net\Driver Sweeper\Logs|*.*|RECURSE
 
 [Phyxion.net Driver Sweeper Backups *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Phyxion.net\Driver Sweeper\Backup
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Phyxion.net\Driver Sweeper\Backup|*.*|RECURSE
-FileKey2=%ProgramFiles%\Phyxion.net\Driver Sweeper\Backup|*.*|RECURSE
+FileKey1=%ProgramFiles%\Phyxion.net\Driver Sweeper\Backup|*.*|RECURSE
 
 [Pidgin *]
 LangSecRef=3022
@@ -13733,16 +13050,14 @@ Detect1=HKCU\Software\PKWARE\PKZIP for Windows
 Detect2=HKCU\Software\PKWARE\PKZIP70
 Detect3=HKCU\Software\PKWARE\ZIPReader 0
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\PKWARE\PKZIPW|*.log
-FileKey2=%ProgramFiles%\PKWARE\PKZIPW|*.log
+FileKey1=%ProgramFiles%\PKWARE\PKZIPW|*.log
 
 [Planet Horse *]
 Section=Games
 Detect=HKLM\Software\Big Fish Games\Persistence\Install\F6023T1L1
 DetectFile=%ProgramFiles%\Planet Horse
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Planet Horse|output_log.txt|RECURSE
-FileKey2=%ProgramFiles%\Planet Horse|output_log.txt|RECURSE
+FileKey1=%ProgramFiles%\Planet Horse|output_log.txt|RECURSE
 
 [Planets Under Attack *]
 Section=Games
@@ -13770,14 +13085,9 @@ FileKey1=%LocalAppData%\Plex Media Server\Cache\PhotoTranscoder|*.*|RECURSE
 FileKey2=%LocalAppData%\Plex Media Server\Crash Reports|*.*|RECURSE
 FileKey3=%LocalAppData%\Plex Media Server\Logs|*.*|RECURSE
 FileKey4=%LocalAppData%\Plex Media Server\Updates|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Plex Media Server\Cache\PhotoTranscoder|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Plex Media Server\Crash Reports|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Plex Media Server\Logs|*.*|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\Plex Media Server\Updates|*.*|RECURSE
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\Plex\Plex Media Server|*.txt;*.log|RECURSE
-FileKey10=%ProgramFiles%\Plex\Plex Media Server|*.txt;*.log|RECURSE
-FileKey11=%WinDir%\System32\config\systemprofile\AppData\Local\Plex Media Server\Logs|*.*|RECURSE
-FileKey12=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Plex Media Server\Logs|*.*|RECURSE
+FileKey5=%ProgramFiles%\Plex\Plex Media Server|*.txt;*.log|RECURSE
+FileKey6=%WinDir%\System32\config\systemprofile\AppData\Local\Plex Media Server\Logs|*.*|RECURSE
+FileKey7=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Plex Media Server\Logs|*.*|RECURSE
 
 [Pogo Games *]
 Section=Games
@@ -13789,8 +13099,7 @@ FileKey1=%AppData%\Pogo Games\*\Cache|*.*|REMOVESELF
 LangSecRef=3024
 Detect=HKCU\Software\Pointstone\Total Privacy
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Pointstone\Total Privacy*|*.txt
-FileKey2=%ProgramFiles%\Pointstone\Total Privacy*|*.txt
+FileKey1=%ProgramFiles%\Pointstone\Total Privacy*|*.txt
 
 [Pok3D *]
 LangSecRef=3021
@@ -13869,9 +13178,7 @@ LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 Default=False
 FileKey1=%CommonAppData%\Microsoft\Windows\Power Efficiency Diagnostics|*.xml
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\Power Efficiency Diagnostics|*.xml
 ExcludeKey1=FILE|%CommonAppData%\Microsoft\Windows\Power Efficiency Diagnostics\|energy-report-latest.xml
-ExcludeKey2=FILE|%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\Power Efficiency Diagnostics\|energy-report-latest.xml
 
 [PowerISO *]
 LangSecRef=3024
@@ -13897,7 +13204,6 @@ LangSecRef=3021
 Detect=HKLM\Software\Predator-Usb
 Default=False
 FileKey1=%CommonAppData%\Predator-Usb\PredatorACE\data|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Predator-Usb\PredatorACE\data|*.log
 
 [Presentation Foundation *]
 LangSecRef=3025
@@ -13927,8 +13233,7 @@ Section=Games
 DetectFile=%ProgramFiles%\Ubisoft\Prince of Persia T2T
 Default=False
 FileKey1=%LocalAppData%\Ubisoft\Prince of Persia T2T|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Prince of Persia T2T|*.log
-FileKey3=%ProgramFiles%\Ubisoft\Prince of Persia T2T|*.log
+FileKey2=%ProgramFiles%\Ubisoft\Prince of Persia T2T|*.log
 
 [Print Queue *]
 LangSecRef=3025
@@ -13966,18 +13271,15 @@ LangSecRef=3022
 DetectFile=%AppData%\Titanium\appdata\com.privateinternetaccess.vpn
 Default=False
 FileKey1=%AppData%\Titanium\appdata\com.privateinternetaccess.vpn|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\pia_manager\log|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\pia_manager\tmp|*.*
-FileKey4=%ProgramFiles%\pia_manager\log|*.*
-FileKey5=%ProgramFiles%\pia_manager\tmp|*.*
-FileKey6=%UserProfile%|.pia_manager_crash.log
+FileKey2=%ProgramFiles%\pia_manager\log|*.*
+FileKey3=%ProgramFiles%\pia_manager\tmp|*.*
+FileKey4=%UserProfile%|.pia_manager_crash.log
 
 [Privoxy *]
 LangSecRef=3022
 Detect=HKCU\Software\Privoxy
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Vidalia Bundle\Privoxy|privoxy.log
-FileKey2=%ProgramFiles%\Vidalia Bundle\Privoxy|privoxy.log
+FileKey1=%ProgramFiles%\Vidalia Bundle\Privoxy|privoxy.log
 
 [Procaster *]
 LangSecRef=3023
@@ -13997,8 +13299,7 @@ LangSecRef=3024
 Detect=HKCU\Software\ProcessLasso
 Default=False
 FileKey1=%AppData%\ProcessLasso|prolasso.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Process Lasso|.logtype5
-FileKey3=%ProgramFiles%\Process Lasso|.logtype5
+FileKey2=%ProgramFiles%\Process Lasso|.logtype5
 
 [ProDiscover *]
 LangSecRef=3024
@@ -14020,16 +13321,14 @@ RegKey5=HKCU\Software\EvolutionComputing\CC3View|WorkingDrawing
 LangSecRef=3023
 DetectFile=%ProgramFiles%\ProgDVB
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ProgDVB\Logs|*.*|RECURSE
-FileKey2=%ProgramFiles%\ProgDVB\Logs|*.*|RECURSE
+FileKey1=%ProgramFiles%\ProgDVB\Logs|*.*|RECURSE
 
 [Project64 *]
 Section=Games
 Detect=HKCU\Software\N64 Emulation
 DetectFile=%ProgramFiles%\Project64 *
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Project64 2.*\Logs|*.*
-FileKey2=%ProgramFiles%\Project64 2.*\Logs|*.*
+FileKey1=%ProgramFiles%\Project64 2.*\Logs|*.*
 RegKey1=HKCU\Software\N64 Emulation\Project64 Version 1.6|RecentFile1
 RegKey2=HKCU\Software\N64 Emulation\Project64 Version 1.6|RecentFile2
 RegKey3=HKCU\Software\N64 Emulation\Project64 Version 1.6|RecentFile3
@@ -14052,8 +13351,7 @@ ExcludeKey1=FILE|%Documents%\Proteus\logs\|rng.txt
 LangSecRef=3023
 Detect=HKCU\Software\PS3 Media Server
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\PS3 Media Server|*log;*.md|RECURSE
-FileKey2=%ProgramFiles%\PS3 Media Server|*log;*.md|RECURSE
+FileKey1=%ProgramFiles%\PS3 Media Server|*log;*.md|RECURSE
 
 [Psi Avatar Cache *]
 LangSecRef=3022
@@ -14094,8 +13392,7 @@ FileKey2=%WinDir%\System32\LogFiles\PunkBuster|*.*
 LangSecRef=3024
 Detect=HKLM\Software\Puran Software\Puran Defrag
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Puran Defrag|PuranDefrag.html
-FileKey2=%ProgramFiles%\Puran Defrag|PuranDefrag.html
+FileKey1=%ProgramFiles%\Puran Defrag|PuranDefrag.html
 
 [Pure Networks *]
 LangSecRef=3022
@@ -14104,9 +13401,6 @@ Default=False
 FileKey1=%CommonAppData%\Pure Networks\Log|*.*
 FileKey2=%CommonAppData%\Pure Networks\Platform|*.bak
 FileKey3=%CommonAppData%\Pure Networks\Platform\minidumps|*.*
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Pure Networks\Log|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Pure Networks\Platform|*.bak
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Pure Networks\Platform\minidumps|*.*
 
 [PureRa *]
 LangSecRef=3024
@@ -14119,7 +13413,6 @@ LangSecRef=3023
 Detect=HKCU\Software\Puritan\File Destroyer Elite
 Default=False
 FileKey1=%CommonAppData%\Puritan\File Destroyer Elite|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Puritan\File Destroyer Elite|*.log|RECURSE
 
 [Push Notifications *]
 DetectOS=10.0|
@@ -14188,7 +13481,6 @@ DetectFile=%Documents%\Tencent Files
 Default=False
 FileKey1=%CommonAppData%\Tencent Files\QQ\Misc|*.*|RECURSE
 FileKey2=%Documents%\Tencent Files|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Tencent Files\QQ\Misc|*.*|RECURSE
 
 [QTTabBar *]
 LangSecRef=3024
@@ -14209,18 +13501,12 @@ FileKey3=%CommonAppData%\Intuit\Quickbooks|*.log;qbsdklog.txt
 FileKey4=%CommonAppData%\Intuit\QuickBooks DB Server Manager|*.log;*.old
 FileKey5=%CommonProgramFiles%\Intuit\Quickbooks\QBUpdate\Log|*.*
 FileKey6=%LocalAppData%\Intuit\QuickBooks\Log|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Intuit\Quickbooks\QBUpdate\Log|*.*
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Common Files\Intuit\Quickbooks\qbupdate\log|*.*
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Intuit\QBWebConnector\log|*.*
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Intuit\Quickbooks|*.log;qbsdklog.txt
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\Intuit\QuickBooks DB Server Manager|*.log;*.old
 
 [QuickDic History *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\QuickDic
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\QuickDic|QuickDic.ini
-FileKey2=%ProgramFiles%\QuickDic|QuickDic.ini
+FileKey1=%ProgramFiles%\QuickDic|QuickDic.ini
 
 [Quicken *]
 LangSecRef=3021
@@ -14237,11 +13523,7 @@ FileKey7=%CommonAppData%\Quicken\Log\installer|*.*|REMOVESELF
 FileKey8=%CommonAppData%\Quicken\SendError|*.log
 FileKey9=%LocalAppData%\Intuit\Common\Authorization\V1\Logs|*.txt
 FileKey10=%LocalAppData%\Quicken\Common\Authorization\V1\Logs|*.txt
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\Intuit\Quicken\Log|*.log
-FileKey12=%LocalAppData%\VirtualStore\ProgramData\Intuit\SendError|*.log
-FileKey13=%LocalAppData%\VirtualStore\ProgramData\Quicken\Log|*.log
-FileKey14=%LocalAppData%\VirtualStore\ProgramData\Quicken\SendError|*.log
-FileKey15=%ProgramFiles%\Quicken\PDFDrv|install.log;InstallPDFConverter.log
+FileKey11=%ProgramFiles%\Quicken\PDFDrv|install.log;InstallPDFConverter.log
 
 [Quicken WillMaker Plus *]
 LangSecRef=3021
@@ -14254,15 +13536,6 @@ LangSecRef=3024
 Detect=HKCU\Software\QuickPar
 Default=False
 FileKey1=%LocalAppData%\QuickPar|*.*
-
-[QuickTime Player *]
-LangSecRef=3023
-Detect=HKLM\Software\Apple Computer, Inc.\QuickTime
-Default=False
-RegKey1=HKCU\Software\Classes\VirtualStore\MACHINE\Software\Apple Computer, Inc.\QuickTime\Favorite Movies
-RegKey2=HKCU\Software\Classes\VirtualStore\MACHINE\Software\Apple Computer, Inc.\QuickTime\Recent Movies
-RegKey3=HKCU\Software\Classes\VirtualStore\MACHINE\Software\WOW6432Node\Apple Computer, Inc.\QuickTime\Favorite Movies
-RegKey4=HKCU\Software\Classes\VirtualStore\MACHINE\Software\WOW6432Node\Apple Computer, Inc.\QuickTime\Recent Movies
 
 [QuizUp *]
 Section=Games
@@ -14339,7 +13612,6 @@ Detect=HKLM\Software\QuickCare
 Default=False
 FileKey1=%CommonAppData%\Support.com|*.tmp|RECURSE
 FileKey2=%LocalAppData%\SupportSoft|*.tmp|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Support.com|*.tmp|RECURSE
 
 [RadeonPro *]
 LangSecRef=3024
@@ -14353,17 +13625,15 @@ FileKey3=%AppData%\RadeonPro\Temp|*.*|RECURSE
 LangSecRef=3021
 Detect=HKCU\Software\Radialix
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Radialix 2|*diz;*.txt;*.url
-FileKey2=%ProgramFiles%\Radialix 2|*diz;*.txt;*.url
-FileKey3=%ProgramFiles%\Radialix 2\Tools\UPX|COPYING;LICENSE
+FileKey1=%ProgramFiles%\Radialix 2|*diz;*.txt;*.url
+FileKey2=%ProgramFiles%\Radialix 2\Tools\UPX|COPYING;LICENSE
 
 [RadioSure *]
 LangSecRef=3023
 Detect=HKCU\Software\RadioSure
 Default=False
 FileKey1=%LocalAppData%\RadioSure\Log|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\RadioSure\Log|*.*
-FileKey3=%ProgramFiles%\RadioSure\Log|*.*
+FileKey2=%ProgramFiles%\RadioSure\Log|*.*
 
 [Rage *]
 Section=Games
@@ -14397,9 +13667,7 @@ Detect3=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Ranch Rush1.0
 DetectFile=%ProgramFiles%\Ranch Rush
 Default=False
 FileKey1=%CommonAppData%\FreshGames\RanchRush\*|*.log;temp_data.ssp
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ranch Rush*|*.html;*.nfo
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\FreshGames\RanchRush\*|*.log;temp_data.ssp
-FileKey4=%ProgramFiles%\Ranch Rush*|*.html;*.nfo
+FileKey2=%ProgramFiles%\Ranch Rush*|*.html;*.nfo
 
 [Razer Software *]
 LangSecRef=3024
@@ -14410,12 +13678,7 @@ FileKey2=%CommonAppData%\Razer\*\Logs|*.*
 FileKey3=%CommonAppData%\Razer\Synapse\Accounts\*\DataSync|SyncDate.txt
 FileKey4=%CommonAppData%\Razer\Synapse\ProductUpdates\Downloads|*.*
 FileKey5=%LocalAppData%\Razer\RzUninstallation\Logs|*.*
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Razer\*|*.log
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Razer\*|DiagnoseReport*.*.txt
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Razer\*\Logs|*.*
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\Razer\Synapse\Accounts\*\DataSync|SyncDate.txt
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\Razer\Synapse\ProductUpdates\Downloads|*.*
-FileKey11=%ProgramFiles%\Razer\*|*.log
+FileKey6=%ProgramFiles%\Razer\*|*.log
 
 [RCrawler *]
 LangSecRef=3024
@@ -14428,8 +13691,7 @@ RegKey2=HKLM\Software\4Developers\RCrawler\Settings|LastSearch
 LangSecRef=3022
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Real Network Monitor
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Real Network Monitor|*.xml
-FileKey2=%ProgramFiles%\Real Network Monitor|*.xml
+FileKey1=%ProgramFiles%\Real Network Monitor|*.xml
 
 [Realms of Arkania: Blade of Destiny *]
 Section=Games
@@ -14453,10 +13715,9 @@ FileKey1=%AppData%\Real\RealPlayer\db|*.*|RECURSE
 LangSecRef=3024
 Detect=HKLM\Software\Realtek
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Realtek*|*.log;*.txt|RECURSE
-FileKey2=%ProgramFiles%\Realtek*|*.*log;*.txt|RECURSE
-FileKey3=%ProgramFiles%\Temp|*.*|REMOVESELF
-FileKey4=%SystemDrive%|RHDSetup.log
+FileKey1=%ProgramFiles%\Realtek*|*.*log;*.txt|RECURSE
+FileKey2=%ProgramFiles%\Temp|*.*|REMOVESELF
+FileKey3=%SystemDrive%|RHDSetup.log
 ExcludeKey1=FILE|%ProgramFiles%\Realtek\*\|InstCtrl.txt
 ExcludeKey2=FILE|%ProgramFiles%\Realtek\*\|setupctrl.txt
 
@@ -14478,9 +13739,8 @@ FileKey1=%AppData%\Advansys\RecollX\log|*.*|RECURSE
 LangSecRef=3024
 Detect=HKCU\Software\Piriform\Recuva
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Recuva|*.log;Recuva_log*.txt
-FileKey2=%ProgramFiles%\Recuva|*.log;Recuva_log*.txt
-FileKey3=%UserProfile%|Recuva_log*.txt
+FileKey1=%ProgramFiles%\Recuva|*.log;Recuva_log*.txt
+FileKey2=%UserProfile%|Recuva_log*.txt
 
 [Reddit To Go! *]
 LangSecRef=3031
@@ -14506,8 +13766,7 @@ LangSecRef=3024
 Detect=HKCU\Software\ChemTable Software\Reg Organizer
 Default=False
 FileKey1=%LocalAppData%\ChemTable Software\Reg Organizer|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Reg Organizer|*.txt
-FileKey3=%ProgramFiles%\Reg Organizer|*.txt
+FileKey2=%ProgramFiles%\Reg Organizer|*.txt
 
 [RegAlyzer *]
 LangSecRef=3024
@@ -14528,7 +13787,6 @@ FileKey1=%AppData%\Systweak\RegClean Pro\Version 6.1|*.log
 LangSecRef=3024
 Detect=HKLM\Software\DCSoft\RegEditX
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\DCSoft\RegEditX\*|RegEditX.sav;RegEditX.bak
 RegKey1=HKLM\Software\4Developers\RCrawler\History
 RegKey2=HKLM\Software\4Developers\RCrawler\Settings|LastSearch
 
@@ -14536,8 +13794,7 @@ RegKey2=HKLM\Software\4Developers\RCrawler\Settings|LastSearch
 LangSecRef=3022
 Detect=HKCU\Software\ReGet Software\ReGetDx
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ReGet Deluxe\history|*.*
-FileKey2=%ProgramFiles%\ReGet Deluxe\history|*.*
+FileKey1=%ProgramFiles%\ReGet Deluxe\history|*.*
 RegKey1=HKCU\Software\ReGet Software\ReGetDx\FtpExplorer\Hist
 RegKey2=HKCU\Software\ReGet Software\ReGetDx\History
 RegKey3=HKCU\Software\ReGet Software\ReGetDx\Search\HistFind
@@ -14554,8 +13811,7 @@ RegKey3=HKCU\Software\Resplendence Sp\Registrar Registry Manager\Settings|LastOp
 LangSecRef=3023
 Detect=HKCU\Software\SuniSoft\IncUpdate\Registry Clean Expert
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Registry Clean Expert|fixlog.ini
-FileKey2=%ProgramFiles%\Registry Clean Expert|fixlog.ini
+FileKey1=%ProgramFiles%\Registry Clean Expert|fixlog.ini
 
 [Registry First Aid *]
 LangSecRef=3024
@@ -14573,22 +13829,19 @@ LangSecRef=3024
 Detect=HKLM\Software\PCTools\Registry Mechanic
 Default=False
 FileKey1=%AppData%\Registry Mechanic\log|*.html
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Registry Mechanic\log*|*.*
-FileKey3=%ProgramFiles%\Registry Mechanic\log*|*.*
+FileKey2=%ProgramFiles%\Registry Mechanic\log*|*.*
 
 [RegistryFix *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\RegistryFix\RegistryFix.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\RegistryFix\logs|*.*
-FileKey2=%ProgramFiles%\RegistryFix\logs|*.*
+FileKey1=%ProgramFiles%\RegistryFix\logs|*.*
 
 [RegServo *]
 LangSecRef=3024
 DetectFile=%CommonAppData%\regservo
 Default=False
 FileKey1=%CommonAppData%\regservo\Logs|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\regservo\Logs|*.*|RECURSE
 
 [RegToBat *]
 LangSecRef=3024
@@ -14600,17 +13853,14 @@ RegKey1=HKLM\Software\BlueLife\RegToBat|LastRegFile
 LangSecRef=3024
 DetectFile=%ProgramFiles%\RegVac Registry Cleaner
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\RegVac Registry Cleaner|*.xml
-FileKey2=%ProgramFiles%\RegVac Registry Cleaner|*.xml
+FileKey1=%ProgramFiles%\RegVac Registry Cleaner|*.xml
 
 [RegWork *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\RegWork
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\RegWork\Logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\RegWork\Tmp|*.*
-FileKey3=%ProgramFiles%\RegWork\Logs|*.*
-FileKey4=%ProgramFiles%\RegWork\Tmp|*.*
+FileKey1=%ProgramFiles%\RegWork\Logs|*.*
+FileKey2=%ProgramFiles%\RegWork\Tmp|*.*
 
 [Reign: Conflict of Nations *]
 Section=Games
@@ -14648,8 +13898,7 @@ FileKey2=%AppData%\Replay Media Catcher 4\History|*.*|REMOVESELF
 FileKey3=%LocalAppData%\Replay Media Catcher 5\History|*.*|REMOVESELF
 FileKey4=%LocalAppData%\Replay Media Catcher 5\Temp|*.*|REMOVESELF
 FileKey5=%LocalAppData%\Replay Media Catcher 5\UrlCache|*.*|REMOVESELF
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Applian Technologies\Replay Media Catcher*|*.html;*.txt;*.rtf
-FileKey7=%ProgramFiles%\Applian Technologies\Replay Media Catcher*|*.html;*.txt;*.rtf
+FileKey6=%ProgramFiles%\Applian Technologies\Replay Media Catcher*|*.html;*.txt;*.rtf
 
 [Resilio Sync *]
 LangSecRef=3024
@@ -14661,8 +13910,7 @@ FileKey1=%AppData%\Resilio Sync|*.journal;*.journal.zip;*.log;*.old;history.dat
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Resource Hacker\ResHacker.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Resource Hacker|ResHacker.ini;reshacker.GID
-FileKey2=%ProgramFiles%\Resource Hacker|ResHacker.ini;reshacker.GID
+FileKey1=%ProgramFiles%\Resource Hacker|ResHacker.ini;reshacker.GID
 
 [Restorator 2007 *]
 LangSecRef=3021
@@ -14679,22 +13927,19 @@ LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{CC48DE1C-8EC2-43BC-9201-29701CD9AE13}_is1
 Default=False
 FileKey1=%CommonAppData%|Restore Point Creator.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Restore Point Creator|*.log;*.txt
-FileKey3=%ProgramFiles%\Restore Point Creator|*.log;*.txt
+FileKey2=%ProgramFiles%\Restore Point Creator|*.log;*.txt
 
 [ResumeMaker *]
 LangSecRef=3021
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{D2E80193-7318-4707-A9DE-49AF663ADA73}
 Default=False
 FileKey1=%CommonAppData%\Individual Software\ResumeMaker\R12|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Individual Software\ResumeMaker\R12|*.log
 
 [Reus *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\222730
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\Reus|errorReport*.txt
-FileKey2=%ProgramFiles%\Steam\SteamApps\common\Reus|errorReport*.txt
+FileKey1=%ProgramFiles%\Steam\SteamApps\common\Reus|errorReport*.txt
 
 [Revenge of the Titans *]
 Section=Games
@@ -14706,9 +13951,8 @@ FileKey1=%UserProfile%\.revenge_of_the_titans_1.80|*.log
 LangSecRef=3024
 DetectFile=%LocalAppData%\VS Revo group
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\VS Revo Group\Revo Uninstaller Pro|*.bak
-FileKey2=%LocalAppData%\VS Revo Group\Revo Uninstaller*\BackupsData|*.*|RECURSE
-FileKey3=%ProgramFiles%\VS Revo Group\Revo Uninstaller Pro|*.bak
+FileKey1=%LocalAppData%\VS Revo Group\Revo Uninstaller*\BackupsData|*.*|RECURSE
+FileKey2=%ProgramFiles%\VS Revo Group\Revo Uninstaller Pro|*.bak
 
 [Ride! *]
 Section=Games
@@ -14716,9 +13960,8 @@ Detect1=HKLM\Software\Big Fish Games\Persistence\Install\F2440T1L1
 Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\BFG-Ride!
 DetectFile=%ProgramFiles%\Ride!
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Ride!|*.log;*.txt|RECURSE
-FileKey2=%ProgramFiles%\Ride!|*.log;*.txt|RECURSE
-FileKey3=%ProgramFiles%\Ride!\DirectX9|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\Ride!|*.log;*.txt|RECURSE
+FileKey2=%ProgramFiles%\Ride!\DirectX9|*.*|REMOVESELF
 
 [Riding Academy 3D *]
 Section=Games
@@ -14730,8 +13973,7 @@ FileKey1=%LocalAppData%\Riding Academy 3D\logs|*.*
 Section=Games
 Detect=HKLM\Software\DTP\Riding Star 3
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Riding Star 3|INSTALL.LOG;log.txt
-FileKey2=%ProgramFiles%\Riding Star 3|INSTALL.LOG;log.txt
+FileKey1=%ProgramFiles%\Riding Star 3|INSTALL.LOG;log.txt
 
 [RIFT *]
 Section=Games
@@ -14739,10 +13981,9 @@ DetectFile=%Documents%\RIFT
 Default=False
 FileKey1=%AppData%\RIFT|*.log
 FileKey2=%Documents%\RIFT|*.log
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\RIFT|*.log
-FileKey4=%ProgramFiles%\RIFT|*.log
-FileKey5=%Public%\Games\RIFT|*.log
-FileKey6=%SystemDrive%\RIFT|*.log
+FileKey3=%ProgramFiles%\RIFT|*.log
+FileKey4=%Public%\Games\RIFT|*.log
+FileKey5=%SystemDrive%\RIFT|*.log
 
 [Rigs of Rods *]
 LangSecRef=3021
@@ -14755,7 +13996,6 @@ LangSecRef=3022
 DetectFile=%CommonAppData%\RingCentral
 Default=False
 FileKey1=%CommonAppData%\RingCentral\LogFiles|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\RingCentral\LogFiles|*.*
 
 [Rise of Nations *]
 Section=Games
@@ -14803,9 +14043,8 @@ FileKey1=%AppData%\RoboBasket3|log.database
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\107800
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\Rochard\Rochard_Data|Output_log.txt
-FileKey2=%LocalLowAppData%\Recoil Games\Rochard|journal.txt
-FileKey3=%ProgramFiles%\Steam\SteamApps\common\Rochard\Rochard_Data|Output_log.txt
+FileKey1=%LocalLowAppData%\Recoil Games\Rochard|journal.txt
+FileKey2=%ProgramFiles%\Steam\SteamApps\common\Rochard\Rochard_Data|Output_log.txt
 
 [Rock of Ages *]
 Section=Games
@@ -14825,8 +14064,7 @@ FileKey1=%Documents%\My Games\Rocket League\TAGame\Logs|*.*
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Shield
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Shield|*.log
-FileKey2=%ProgramFiles%\Shield|*.log
+FileKey1=%ProgramFiles%\Shield|*.log
 
 [Roxio *]
 LangSecRef=3021
@@ -14838,9 +14076,8 @@ FileKey3=%AppData%\Roxio\Dragon\3.x\*Logs|*.log
 FileKey4=%AppData%\Roxio\Dragon\3.x\DiscInfoCache|*.tmp
 FileKey5=%CommonAppData%\Roxio|*.log;cardinfo.*
 FileKey6=%LocalAppData%|rx_audio.Cache;rx_image32.Cache
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Roxio|*.log;cardinfo.*
-FileKey8=%WinDir%\System32\config\systemprofile\AppData\Roaming\Roxio Log Files|*.*|RECURSE
-FileKey9=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\Roxio Log Files|*.*|RECURSE
+FileKey7=%WinDir%\System32\config\systemprofile\AppData\Roaming\Roxio Log Files|*.*|RECURSE
+FileKey8=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\Roxio Log Files|*.*|RECURSE
 
 [Roxio Creator Pro *]
 LangSecRef=3021
@@ -14883,8 +14120,7 @@ FileKey1=%UserProfile%|.swfinfo
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\252490
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Rust|debug_steamclient.txt
-FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Rust|debug_steamclient.txt
+FileKey1=%ProgramFiles%\Steam\SteamApps\Common\Rust|debug_steamclient.txt
 
 [SABnzbd *]
 LangSecRef=3021
@@ -14912,14 +14148,12 @@ LangSecRef=3021
 Detect=HKLM\Software\ACT
 Default=False
 FileKey1=%CommonAppData%\Sage Software, Inc\ACT! by Sage\ActUpdate|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Sage Software, Inc\ACT! by Sage\ActUpdate|*.*|RECURSE
 
 [Sage Simply Accounting *]
 LangSecRef=3021
 Detect=HKLM\Software\Sage Software\Simply Accounting
 Default=False
 FileKey1=%CommonAppData%\Sage Software\Simply Accounting\Download|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Sage Software\Simply Accounting\Download|*.*|RECURSE
 
 [SageThumbs *]
 LangSecRef=3021
@@ -14945,8 +14179,6 @@ FileKey2=%CommonAppData%\Samsung\Device Error Recovery|*.*
 FileKey3=%CommonAppData%\Samsung\Kies|Kiesairmessage.log
 FileKey4=%Documents%\samsung\Kies3\backup|*.dmp|RECURSE
 FileKey5=%Documents%\SelfMV|*.log
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Samsung\Device Error Recovery|*.log
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Samsung\Kies|Kiesairmessage.log
 
 [Samsung Kies Backups *]
 LangSecRef=3023
@@ -14960,10 +14192,8 @@ FileKey1=%Documents%\samsung\Kies*\backup|*.*|RECURSE
 LangSecRef=3021
 Detect=HKLM\Software\Samsung Magician
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Samsung\Samsung Magician|*.log;*.txt|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Samsung\Samsung Magician\Log*|*.*
-FileKey3=%ProgramFiles%\Samsung Magician\Logs|*.*
-FileKey4=%ProgramFiles%\Samsung\Samsung Magician\Log*|*.*
+FileKey1=%ProgramFiles%\Samsung Magician\Logs|*.*
+FileKey2=%ProgramFiles%\Samsung\Samsung Magician\Log*|*.*
 RegKey1=HKCU\Software\Local AppWizard-Generated Applications\SamsungMagician
 
 [Sanctum *]
@@ -14977,8 +14207,7 @@ Section=Games
 Detect=HKLM\Software\Invictus-Games\Santa Ride 2
 DetectFile=%ProgramFiles%\Invictus Games\Santa Ride! 2\SR2.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Invictus Games\Santa Ride! 2|*.log
-FileKey2=%ProgramFiles%\Invictus Games\Santa Ride! 2|*.log
+FileKey1=%ProgramFiles%\Invictus Games\Santa Ride! 2|*.log
 
 [Santa's Rampage *]
 Section=Games
@@ -14998,8 +14227,7 @@ DetectFile=%ProgramFiles%\Sauerbraten\bin\sauerbraten.exe
 Default=False
 FileKey1=%Documents%\My Games\Crash|*.log
 FileKey2=%Documents%\My Games\Sauerbraten|log.txt
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Sauerbraten\packages\base|*.bak|RECURSE
-FileKey4=%ProgramFiles%\Sauerbraten\packages\base|*.bak|RECURSE
+FileKey3=%ProgramFiles%\Sauerbraten\packages\base|*.bak|RECURSE
 
 [SavingsBull *]
 LangSecRef=3022
@@ -15088,8 +14316,7 @@ LangSecRef=3024
 Detect=HKLM\Software\SeaToolsforWindows
 Default=False
 FileKey1=%AppData%\Dexpot|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Seagate\SeaTools for Windows|*.log
-FileKey3=%ProgramFiles%\Seagate\SeaTools for Windows|*.log
+FileKey2=%ProgramFiles%\Seagate\SeaTools for Windows|*.log
 
 [Search History *]
 DetectOS=6.2|
@@ -15105,8 +14332,7 @@ Detect=HKCU\Software\Centered Systems\Second Copy 2000
 DetectFile=%LocalAppData%\Centered Systems\Second Copy
 Default=False
 FileKey1=%LocalAppData%\Centered Systems\Second Copy|log*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\SecCopy|log.rtf;log-old.rtf
-FileKey3=%ProgramFiles%\SecCopy|log.rtf;log-old.rtf
+FileKey2=%ProgramFiles%\SecCopy|log.rtf;log-old.rtf
 RegKey1=HKCU\Software\Centered Systems\Second Copy 2000\MRU
 
 [SecondLife *]
@@ -15148,7 +14374,6 @@ LangSecRef=3022
 DetectFile=%CommonAppData%\Sendori
 Default=False
 FileKey1=%CommonAppData%\Sendori|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Sendori|*.log
 
 [Serious Sam *]
 Section=Games
@@ -15157,16 +14382,11 @@ Detect2=HKCU\Software\Valve\Steam\Apps\41070
 Detect3=HKCU\Software\Valve\Steam\Apps\564310
 DetectFile=%ProgramFiles%\Croteam\Serious Sam *
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Croteam\Serious Sam *|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Croteam\Serious Sam *\Temp|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Serious Sam *|*.log
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Serious Sam *\Log|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Serious Sam *\Temp|*.*
-FileKey6=%ProgramFiles%\Croteam\Serious Sam *|*.log
-FileKey7=%ProgramFiles%\Croteam\Serious Sam *\Temp|*.*
-FileKey8=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam *|*.log
-FileKey9=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam *\Log|*.*|RECURSE
-FileKey10=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam *\Temp|*.*
+FileKey1=%ProgramFiles%\Croteam\Serious Sam *|*.log
+FileKey2=%ProgramFiles%\Croteam\Serious Sam *\Temp|*.*
+FileKey3=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam *|*.log
+FileKey4=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam *\Log|*.*|RECURSE
+FileKey5=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam *\Temp|*.*
 
 [ServeToMe *]
 LangSecRef=3023
@@ -15178,8 +14398,7 @@ FileKey1=%AppData%\ProjectsWithLove\ServeToMe\Fontcache|*.*
 LangSecRef=3024
 Detect=HKLM\Software\Serviio
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Serviio\log|*.*
-FileKey2=%ProgramFiles%\Serviio\log|*.*
+FileKey1=%ProgramFiles%\Serviio\log|*.*
 
 [Session Manager *]
 LangSecRef=3025
@@ -15246,8 +14465,7 @@ FileKey2=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\Microsoft\C
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\20820
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Shatter|log.txt
-FileKey2=%ProgramFiles%\Steam\steamapps\common\Shatter|log.txt
+FileKey1=%ProgramFiles%\Steam\steamapps\common\Shatter|log.txt
 
 [Shattered Horizon *]
 Section=Games
@@ -15287,8 +14505,7 @@ RegKey1=HKCU\Software\Insight Software Solutions\ShortKeys\MRU
 LangSecRef=3024
 Detect=HKCU\Software\Reason
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Reason\Should I Remove It|programdata.dat
-FileKey2=%ProgramFiles%\Reason\Should I Remove It|programdata.dat
+FileKey1=%ProgramFiles%\Reason\Should I Remove It|programdata.dat
 RegKey1=HKCU\Software\Reason\ShouldIRemoveIt\Cache
 
 [Shuffle Party *]
@@ -15317,10 +14534,8 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\15210
 DetectFile=%ProgramFiles%\Ubisoft\SilentHunterIII
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\SilentHunterIII|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\SilentHunterIII|*.log|RECURSE
-FileKey3=%ProgramFiles%\Steam\SteamApps\Common\SilentHunterIII|*.log|RECURSE
-FileKey4=%ProgramFiles%\Ubisoft\SilentHunterIII|*.log|RECURSE
+FileKey1=%ProgramFiles%\Steam\SteamApps\Common\SilentHunterIII|*.log|RECURSE
+FileKey2=%ProgramFiles%\Ubisoft\SilentHunterIII|*.log|RECURSE
 
 [SimCity 4 *]
 Section=Games
@@ -15328,8 +14543,7 @@ Detect=HKLM\Software\Maxis\SimCity 4
 Default=False
 FileKey1=%Documents%\SimCity 4\Exception Reports|*.mdmp;*.txt
 FileKey2=%Documents%\SimCity 4\HTTPCache|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Maxis\SimCity 4 Deluxe\Apps|*.txt
-FileKey4=%ProgramFiles%\Maxis\SimCity 4 Deluxe\Apps|*.txt
+FileKey3=%ProgramFiles%\Maxis\SimCity 4 Deluxe\Apps|*.txt
 
 [SimCity Societies *]
 Section=Games
@@ -15352,9 +14566,8 @@ DetectFile2=%ProgramFiles%\SIMS\RACER
 DetectFile3=%SystemDrive%\SIMS\RACER
 Default=False
 FileKey1=%CommonAppData%\SIMS\RACER|QLOG.txt
-FileKey2=%LocalAppData%\VirtualStore\Program*\SIMS\RACER|QLOG.txt
-FileKey3=%ProgramFiles%\SIMS\RACER|QLOG.txt
-FileKey4=%SystemDrive%\SIMS\RACER|QLOG.txt
+FileKey2=%ProgramFiles%\SIMS\RACER|QLOG.txt
+FileKey3=%SystemDrive%\SIMS\RACER|QLOG.txt
 
 [SiSense *]
 LangSecRef=3021
@@ -15363,8 +14576,6 @@ Default=False
 FileKey1=%AppData%\SiSense\Prism\logs|*.*
 FileKey2=%CommonAppData%\SiSense|*.slog;*.log|RECURSE
 FileKey3=%CommonAppData%\SiSense\Logs|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\SiSense|*.slog;*.log|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\SiSense\Logs|*.*|RECURSE
 
 [SketchUp Make *]
 LangSecRef=3021
@@ -15444,8 +14655,7 @@ FileKey1=%Documents%\My Games\Skyrim\SKSE|*.log
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\202170
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\SleepingDogs|LogBoot.txt;LogShaders.txt
-FileKey2=%ProgramFiles%\Steam\Steamapps\common\SleepingDogs|LogBoot.txt;LogShaders.txt
+FileKey1=%ProgramFiles%\Steam\Steamapps\common\SleepingDogs|LogBoot.txt;LogShaders.txt
 
 [SlimBoat *]
 LangSecRef=3022
@@ -15473,9 +14683,7 @@ Default=False
 FileKey1=%CommonAppData%\SlimWare Utilities Inc\Services\SlimService*\Logs|*.log
 FileKey2=%LocalAppData%\SlimWare Utilities Inc\SlimCleaner*\Cache|*.*|RECURSE
 FileKey3=%LocalAppData%\SlimWare Utilities Inc\SlimCleaner*\Logs|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\SlimCleaner*|*.txt
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\SlimWare Utilities Inc\Services\SlimService*\Logs|*.log
-FileKey6=%ProgramFiles%\SlimCleaner*|*.txt
+FileKey4=%ProgramFiles%\SlimCleaner*|*.txt
 
 [SlimComputer *]
 LangSecRef=3024
@@ -15608,8 +14816,7 @@ RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\271500
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Sniper Art of Victory\logs|*.*
-FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Sniper Art of Victory\logs|*.*
+FileKey1=%ProgramFiles%\Steam\SteamApps\Common\Sniper Art of Victory\logs|*.*
 
 [Sniper: Ghost Warrior *]
 Section=Games
@@ -15621,8 +14828,7 @@ FileKey1=%Documents%\Sniper - Ghost Warrior\out\logs|*.*
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\111100
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\snuggle truck\Snuggle Truck_Data|output_log.txt
-FileKey2=%ProgramFiles%\Steam\steamapps\common\snuggle truck\Snuggle Truck_Data|output_log.txt
+FileKey1=%ProgramFiles%\Steam\steamapps\common\snuggle truck\Snuggle Truck_Data|output_log.txt
 
 [Sobees *]
 LangSecRef=3022
@@ -15672,7 +14878,6 @@ FileKey1=%AppData%\SoftGrid Client|*.tmp|RECURSE
 FileKey2=%AppData%\SoftGrid Client\Icon Cache|*.*
 FileKey3=%CommonAppData%\Microsoft\Application Virtualization Client\SoftGrid Client|*.tmp|RECURSE
 FileKey4=%LocalAppData%\SoftGrid Client|*.tmp|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Application Virtualization Client\SoftGrid Client|*.tmp|RECURSE
 
 [Softonic *]
 LangSecRef=3021
@@ -15795,8 +15000,7 @@ FileKey1=%LocalAppData%\inkle\Sorcery|*.log
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Soulseek\slsk.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Soulseek*|search.cfg
-FileKey2=%ProgramFiles%\Soulseek*|search.cfg
+FileKey1=%ProgramFiles%\Soulseek*|search.cfg
 
 [Soulseek NS *]
 LangSecRef=3022
@@ -15818,8 +15022,7 @@ FileKey1=%LocalAppData%\Soulseek Chat Logs\*|*.log
 LangSecRef=3023
 DetectFile=%ProgramFiles%\Analog Devices\SoundMAX
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Analog Devices\SoundMAX|SMax.log;SMax.log.bak
-FileKey2=%ProgramFiles%\Analog Devices\SoundMAX|SMax.log;SMax.log.bak
+FileKey1=%ProgramFiles%\Analog Devices\SoundMAX|SMax.log;SMax.log.bak
 
 [Space Engineers *]
 Section=Games
@@ -15831,8 +15034,7 @@ FileKey1=%AppData%\SpaceEngineers|*.log
 LangSecRef=3024
 Detect=HKCU\Software\SpeedFan
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\SpeedFan|debug.nfo;SFLog*.csv
-FileKey2=%ProgramFiles%\SpeedFan|debug.nfo;SFLog*.csv
+FileKey1=%ProgramFiles%\SpeedFan|debug.nfo;SFLog*.csv
 
 [SpeedRunners *]
 Section=Games
@@ -15864,26 +15066,21 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\209790
 Default=False
 FileKey1=%Documents%|GALog.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\splice|output_log.txt
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Splice\Splice_Data|output_log.txt
-FileKey4=%ProgramFiles%\Steam\steamapps\common\splice|output_log.txt
-FileKey5=%ProgramFiles%\Steam\steamapps\common\Splice\Splice_Data|output_log.txt
+FileKey2=%ProgramFiles%\Steam\steamapps\common\splice|output_log.txt
+FileKey3=%ProgramFiles%\Steam\steamapps\common\Splice\Splice_Data|output_log.txt
 
 [SpongeBob Diner Dash *]
 Section=Games
 DetectFile=%ProgramFiles%\SpongeBob Diner Dash
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\SpongeBob Diner Dash|logfile.*
-FileKey2=%ProgramFiles%\SpongeBob Diner Dash|logfile.*
+FileKey1=%ProgramFiles%\SpongeBob Diner Dash|logfile.*
 
 [Spooky Mall *]
 Section=Games
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Spooky Mall1.0
 Default=False
 FileKey1=%CommonAppData%\SpookyMall|*.xml_log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Foxy Games\Spooky Mall|*.log
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\SpookyMall|*.xml_log
-FileKey4=%ProgramFiles%\Foxy Games\Spooky Mall|*.log
+FileKey2=%ProgramFiles%\Foxy Games\Spooky Mall|*.log
 
 [SporTV *]
 LangSecRef=3021
@@ -15925,8 +15122,6 @@ Default=False
 FileKey1=%CommonAppData%\Spybot - Search & Destroy\Logs|*.*|RECURSE
 FileKey2=%CommonAppData%\Spybot - Search & Destroy\System Configuration Snapshots|*.*|REMOVESELF
 FileKey3=%Documents%\ProcAlyzer Dumps|*.*|REMOVESELF
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Spybot - Search & Destroy\Logs|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Spybot - Search & Destroy\System Configuration Snapshots|*.*|REMOVESELF
 
 [Spybot Search and Destroy History *]
 LangSecRef=3024
@@ -15935,9 +15130,6 @@ Default=False
 FileKey1=%CommonAppData%\Spybot - Search & Destroy\Backups|*.*|RECURSE
 FileKey2=%CommonAppData%\Spybot - Search & Destroy\Recovery|*.*|RECURSE
 FileKey3=%CommonAppData%\Spybot - Search & Destroy\Snapshots*|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Spybot - Search & Destroy\Backups|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Spybot - Search & Destroy\Recovery|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Spybot - Search & Destroy\Snapshots*|*.*|RECURSE
 
 [Spybot Search and Destroy Hosts Backups *]
 LangSecRef=3024
@@ -15951,10 +15143,8 @@ LangSecRef=3024
 Detect1=HKCU\Software\Safer Networking Limited\Spybot - Search & Destroy 2
 Detect2=HKLM\Software\Safer Networking Limited\SpybotSnD
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Spybot - Search & Destroy 2\Updates|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Spybot - Search & Destroy\Updates|*.zip
-FileKey3=%ProgramFiles%\Spybot - Search & Destroy 2\Updates|*.*|RECURSE
-FileKey4=%ProgramFiles%\Spybot - Search & Destroy\Updates|*.zip
+FileKey1=%ProgramFiles%\Spybot - Search & Destroy 2\Updates|*.*|RECURSE
+FileKey2=%ProgramFiles%\Spybot - Search & Destroy\Updates|*.zip
 ExcludeKey1=FILE|%ProgramFiles%\Spybot - Search & Destroy 2\Updates\Downloads\|updates.uid
 
 [SpyDefense *]
@@ -15969,15 +15159,13 @@ LangSecRef=3024
 Detect=HKCU\Software\PCTools\Spyware Doctor
 Default=False
 FileKey1=%AppData%\pctsGui|bugreport.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Spyware Doctor\Log|*.*
-FileKey3=%ProgramFiles%\Spyware Doctor\Log|*.*
+FileKey2=%ProgramFiles%\Spyware Doctor\Log|*.*
 
 [Spyware Terminator *]
 LangSecRef=3024
 Detect=HKCU\Software\Spyware Terminator
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Spyware Terminator|*.err;*.old|RECURSE
-FileKey2=%ProgramFiles%\Spyware Terminator|*.err;*.old|RECURSE
+FileKey1=%ProgramFiles%\Spyware Terminator|*.err;*.old|RECURSE
 
 [SpywareBlaster Update File *]
 LangSecRef=3024
@@ -15991,7 +15179,6 @@ LangSecRef=3021
 DetectFile=%CommonAppData%\SQL Anywhere 11
 Default=False
 FileKey1=%CommonAppData%\SQL Anywhere 11\Diagnostics|*.dmp;*.crash_log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\SQL Anywhere 11\Diagnostics|*.dmp;*.crash_log
 
 [SQLite Expert 3 *]
 LangSecRef=3024
@@ -16017,10 +15204,8 @@ FileKey1=%LocalAppData%\Abelssoft\SSD Fresh|backup.*
 LangSecRef=3021
 Detect=HKCU\Software\Star Downloader
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Star Downloader|serverstats.txt;LastURLs
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Star Downloader\Partial Downloads|*.*|RECURSE
-FileKey3=%ProgramFiles%\Star Downloader|serverstats.txt;LastURLs
-FileKey4=%ProgramFiles%\Star Downloader\Partial Downloads|*.*|RECURSE
+FileKey1=%ProgramFiles%\Star Downloader|serverstats.txt;LastURLs
+FileKey2=%ProgramFiles%\Star Downloader\Partial Downloads|*.*|RECURSE
 
 [Star Swarm Stress Test *]
 Section=Games
@@ -16033,19 +15218,16 @@ Section=Games
 Detect1=HKCU\Software\Cryptic\Star Trek Online
 Detect2=HKCU\Software\Valve\Steam\Apps\9900
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\Common\star trek online\Star Trek Online\*\cache|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\steam\steamapps\common\star trek online\star trek online\*\logs\GameClient|*.*
-FileKey3=%ProgramFiles%\Steam\Steamapps\Common\star trek online\Star Trek Online\*\cache|*.*
-FileKey4=%ProgramFiles%\steam\steamapps\common\star trek online\star trek online\*\logs\GameClient|*.*
-FileKey5=%Public%\Games\Cryptic Studios\Star Trek Online\*\Cache|*.*
-FileKey6=%Public%\Games\Cryptic Studios\Star Trek Online\*\Logs\GameClient|*.*
+FileKey1=%ProgramFiles%\Steam\Steamapps\Common\star trek online\Star Trek Online\*\cache|*.*
+FileKey2=%ProgramFiles%\steam\steamapps\common\star trek online\star trek online\*\logs\GameClient|*.*
+FileKey3=%Public%\Games\Cryptic Studios\Star Trek Online\*\Cache|*.*
+FileKey4=%Public%\Games\Cryptic Studios\Star Trek Online\*\Logs\GameClient|*.*
 
 [Star Wars: Battlefront II *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\6060
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Star Wars BattleFront II|update*.txt
-FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Star Wars BattleFront II|update*.txt
+FileKey1=%ProgramFiles%\Steam\SteamApps\Common\Star Wars BattleFront II|update*.txt
 
 [Star Wars: The Force Unleashed *]
 Section=Games
@@ -16059,18 +15241,12 @@ Detect=HKLM\Software\BioWare\Star Wars-The Old Republic
 Default=False
 FileKey1=%Documents%|*Install STAR WARS The Old Republic.log
 FileKey2=%LocalAppData%\SWTOR\CrashDump\swtor|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Electronic Arts\BioWare\Star Wars-The Old Republic\betatest\retailclient\Temp|*.log
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Electronic Arts\BioWare\Star Wars-The Old Republic\logs|*.log
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Electronic Arts\BioWare\Star Wars-The Old Republic\swtor\retailclient\swtor\logs|*.log
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Origin Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Origin Games\Star Wars - The Old Republic\logs|*.*
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\Origin Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
-FileKey9=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\betatest\retailclient\Temp|*.log
-FileKey10=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\logs|*.log
-FileKey11=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\swtor\retailclient\swtor\logs|*.log
-FileKey12=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
-FileKey13=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\logs|*.*
-FileKey14=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
+FileKey3=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\betatest\retailclient\Temp|*.log
+FileKey4=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\logs|*.log
+FileKey5=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\swtor\retailclient\swtor\logs|*.log
+FileKey6=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
+FileKey7=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\logs|*.*
+FileKey8=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
 
 [StarCraft II *]
 Section=Games
@@ -16078,9 +15254,7 @@ Detect=HKLM\Software\Blizzard Entertainment\StarCraft II
 Default=False
 FileKey1=%CommonAppData%\Blizzard Entertainment\Starcraft II\Maps\Cache|*.*|RECURSE
 FileKey2=%Documents%\StarCraft II\*Logs|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Starcraft II\Logs|*.*
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Blizzard Entertainment\Starcraft II\Maps\Cache|*.*|RECURSE
-FileKey5=%ProgramFiles%\Starcraft II\Logs|*.*
+FileKey3=%ProgramFiles%\Starcraft II\Logs|*.*
 
 [StarCraft II Editor *]
 Section=Games
@@ -16094,8 +15268,7 @@ Detect1=HKLM\Software\Stardock\Misc\Fences
 Detect2=HKLM\Software\Stardock\Misc\Fences2
 Default=False
 FileKey1=%AppData%\Stardock\Fences\TroubleshootingLog|*.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Stardock\Fences|*.txt
-FileKey3=%ProgramFiles%\Stardock\Fences|*.txt
+FileKey2=%ProgramFiles%\Stardock\Fences|*.txt
 
 [Stardock ObjectDock Plus *]
 LangSecRef=3024
@@ -16105,14 +15278,12 @@ FileKey1=%AppData%\Stardock|*.*|REMOVESELF
 FileKey2=%CommonAppData%\Stardock|*.*|RECURSE
 FileKey3=%LocalAppData%\ODUI|*.*|REMOVESELF
 FileKey4=%LocalAppData%\Stardock\ObjectDockPlus|*Backup.ini
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Stardock|*.*|RECURSE
 
 [StarMoney *]
 LangSecRef=3021
 DetectFile=%CommonAppData%\StarMoney*
 Default=False
 FileKey1=%CommonAppData%\StarMoney *|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\StarMoney *|*.log|RECURSE
 
 [StarOffice *]
 LangSecRef=3021
@@ -16133,8 +15304,7 @@ RegKey2=HKLM\Software\Microsoft\Windows\CurrentVersion\UFH\ARP
 LangSecRef=3024
 Detect=HKLM\Software\Start Menu Reviver
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ReviverSoft\Start Menu Reviver\Logs|*.*
-FileKey2=%ProgramFiles%\ReviverSoft\Start Menu Reviver\Logs|*.*
+FileKey1=%ProgramFiles%\ReviverSoft\Start Menu Reviver\Logs|*.*
 
 [StartMenu8 *]
 LangSecRef=3024
@@ -16178,33 +15348,24 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam
 Default=False
 FileKey1=%AppData%\SteamVR\Logs|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam|*log.last;*.log;*_log.txt;connection_log_*.txt;remote_connections.txt|RECURSE
-FileKey3=%ProgramFiles%\Steam|*.old
-FileKey4=%ProgramFiles%\Steam|*log.last;*.log;*_log.txt;connection_log_*.txt;remote_connections.txt|RECURSE
-FileKey5=%ProgramFiles%\Steam\vr\runtime\logs|*.*|RECURSE
+FileKey2=%ProgramFiles%\Steam|*.old
+FileKey3=%ProgramFiles%\Steam|*log.last;*.log;*_log.txt;connection_log_*.txt;remote_connections.txt|RECURSE
+FileKey4=%ProgramFiles%\Steam\vr\runtime\logs|*.*|RECURSE
 
 [Steam Cache *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam
 Default=False
 FileKey1=%LocalAppData%\Steam\htmlcache|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\appcache\httpcache|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\config\cookies|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Steam\config\htmlcache|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Steam\config\overlay*|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Steam\depotcache|*.*
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\shadercache|*.*|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\Steam\tenfoot\config\httpcache|*.*|RECURSE
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\Steam\tenfoot\config\images\web|*.*|RECURSE
-FileKey10=%ProgramFiles%\Steam\appcache\httpcache|*.*|RECURSE
-FileKey11=%ProgramFiles%\Steam\config\cookies|*.*|RECURSE
-FileKey12=%ProgramFiles%\Steam\config\htmlcache|*.*|RECURSE
-FileKey13=%ProgramFiles%\Steam\config\overlay*|*.*|RECURSE
-FileKey14=%ProgramFiles%\Steam\depotcache|*.*
-FileKey15=%ProgramFiles%\Steam\steamapps\shadercache|*.*|RECURSE
-FileKey16=%ProgramFiles%\Steam\tenfoot\config\httpcache|*.*|RECURSE
-FileKey17=%ProgramFiles%\Steam\tenfoot\config\images\web|*.*|RECURSE
-FileKey18=%ProgramFiles%\Steam\userdata\*\ugcmsgcache|*.*|RECURSE
+FileKey2=%ProgramFiles%\Steam\appcache\httpcache|*.*|RECURSE
+FileKey3=%ProgramFiles%\Steam\config\cookies|*.*|RECURSE
+FileKey4=%ProgramFiles%\Steam\config\htmlcache|*.*|RECURSE
+FileKey5=%ProgramFiles%\Steam\config\overlay*|*.*|RECURSE
+FileKey6=%ProgramFiles%\Steam\depotcache|*.*
+FileKey7=%ProgramFiles%\Steam\steamapps\shadercache|*.*|RECURSE
+FileKey8=%ProgramFiles%\Steam\tenfoot\config\httpcache|*.*|RECURSE
+FileKey9=%ProgramFiles%\Steam\tenfoot\config\images\web|*.*|RECURSE
+FileKey10=%ProgramFiles%\Steam\userdata\*\ugcmsgcache|*.*|RECURSE
 
 [Steam Games *]
 Section=Games
@@ -16238,15 +15399,13 @@ FileKey1=%ProgramFiles%\Steam\package|*.zip.*
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\252410
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\SteamWorld Dig|*.mdmp
-FileKey2=%ProgramFiles%\Steam\Steamapps\common\SteamWorld Dig|*.mdmp
+FileKey1=%ProgramFiles%\Steam\Steamapps\common\SteamWorld Dig|*.mdmp
 
 [Steed *]
 LangSecRef=3022
 DetectFile=%CommonAppData%\Steed
 Default=False
 FileKey1=%CommonAppData%\Steed\Logs|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Steed\Logs|*.*|REMOVESELF
 
 [Stellarium *]
 LangSecRef=3021
@@ -16345,8 +15504,7 @@ FileKey1=%AppData%\Streamripper|*.*|REMOVESELF
 Section=Games
 DetectFile=%ProgramFiles%\Firefly Studios\Stronghold Crusader
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Firefly Studios\Stronghold Crusader\gfx|*log.txt
-FileKey2=%ProgramFiles%\Firefly Studios\Stronghold Crusader\gfx|*log.txt
+FileKey1=%ProgramFiles%\Firefly Studios\Stronghold Crusader\gfx|*log.txt
 
 [Structured Storage Viewer *]
 LangSecRef=3024
@@ -16405,9 +15563,7 @@ Detect2=HKLM\Software\SUPERAntiSpyware.com\SUPERAntiSpyware
 Default=False
 FileKey1=%CommonAppData%\!SASCORE\AppLogs|*.dmp;*.SDB
 FileKey2=%CommonAppData%\SUPERAntiSpyware.com\SUPERAntiSpyware\Applogs|*.dmp;*.SDB;*.ZIP
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\!SASCORE\AppLogs|*.dmp;*.SDB
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\SUPERAntiSpyware\Applogs|*.dmp;*.SDB;*.ZIP
-FileKey5=%ProgramFiles%\SUPERAntiSpyware|*.tmp
+FileKey3=%ProgramFiles%\SUPERAntiSpyware|*.tmp
 
 [SuperMP3Download *]
 LangSecRef=3023
@@ -16415,8 +15571,6 @@ DetectFile=%ProgramFiles%\SuperMp3Download\SuperMp3Download.exe
 Default=False
 FileKey1=%CommonAppData%\SuperMP3Download|downloadlist.sav
 FileKey2=%CommonAppData%\SuperMP3Download\Downloading|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\SuperMP3Download|downloadlist.sav
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\SuperMP3Download\Downloading|*.*|RECURSE
 
 [Superstar Racing *]
 Section=Games
@@ -16503,7 +15657,6 @@ LangSecRef=3024
 Detect=HKCU\Software\Syncovery
 Default=False
 FileKey1=%CommonAppData%\Syncovery\Logs|*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Syncovery\Logs|*.log|RECURSE
 
 [Syncthing *]
 LangSecRef=3022
@@ -16534,14 +15687,9 @@ FileKey3=%CommonAppData%\iolo|*.xml;*.txt
 FileKey4=%CommonAppData%\iolo\ACRSummaryFiles|*.*|REMOVESELF
 FileKey5=%CommonAppData%\iolo\logs|*.*|REMOVESELF
 FileKey6=%CommonAppData%\iolo\TempResources|*.*|REMOVESELF
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\iolo\System Mechanic|*.txt;*.xml
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\iolo|*.xml;*.txt
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\iolo\ACRSummaryFiles|*.*|REMOVESELF
-FileKey10=%LocalAppData%\VirtualStore\ProgramData\iolo\logs|*.*|REMOVESELF
-FileKey11=%LocalAppData%\VirtualStore\ProgramData\iolo\TempResources|*.*|REMOVESELF
-FileKey12=%ProgramFiles%\iolo\System Mechanic|*.txt;*.xml
-FileKey13=%SystemDrive%\Documents and Settings\LocalService\*\iolo|*.*|REMOVESELF
-FileKey14=%WinDir%\System32\config|iolo App.evt
+FileKey7=%ProgramFiles%\iolo\System Mechanic|*.txt;*.xml
+FileKey8=%SystemDrive%\Documents and Settings\LocalService\*\iolo|*.*|REMOVESELF
+FileKey9=%WinDir%\System32\config|iolo App.evt
 
 [System Mechanic Snapshots *]
 LangSecRef=3024
@@ -16554,10 +15702,8 @@ FileKey1=%AppData%\iolo\System Snapshots Data|*.*
 LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\SysTracer
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\SysTracer|SysTracerLog.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\SysTracer\tmp|*.*|REMOVESELF
-FileKey3=%ProgramFiles%\SysTracer|SysTracerLog.txt
-FileKey4=%ProgramFiles%\SysTracer\tmp|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\SysTracer|SysTracerLog.txt
+FileKey2=%ProgramFiles%\SysTracer\tmp|*.*|REMOVESELF
 
 [Tag&Rename *]
 LangSecRef=3024
@@ -16606,8 +15752,7 @@ LangSecRef=3022
 Detect=HKCU\Software\TeamSpeak 3 Client
 Default=False
 FileKey1=%LocalAppData%\TeamSpeak 3 Client\config\logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\TeamSpeak 3 Client\config\logs|*.*
-FileKey3=%ProgramFiles%\TeamSpeak 3 Client\config\logs|*.*
+FileKey2=%ProgramFiles%\TeamSpeak 3 Client\config\logs|*.*
 
 [TeamSpeak 3 Chats *]
 LangSecRef=3022
@@ -16621,9 +15766,8 @@ Detect=HKCU\Software\TeamViewer
 Default=False
 FileKey1=%AppData%\TeamViewer|*.log;*.mdmp
 FileKey2=%LocalAppData%\TeamViewer\*Cache|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\TeamViewer|*.log
-FileKey4=%ProgramFiles%\TeamViewer|*.log
-FileKey5=%WinDir%\System32|TeamViewer*_Hooks.log
+FileKey3=%ProgramFiles%\TeamViewer|*.log
+FileKey4=%WinDir%\System32|TeamViewer*_Hooks.log
 RegKey1=HKCU\Software\TeamViewer\Version5|Last_Machine_Connections
 RegKey2=HKCU\Software\TeamViewer\Version5.1|Last_Machine_Connections
 RegKey3=HKCU\Software\TeamViewer\Version6|Last_Machine_Connections
@@ -16648,8 +15792,7 @@ FileKey1=%AppData%\.technic*\*\Backups|*.*|RECURSE
 LangSecRef=3023
 Detect=HKCU\Software\TechSmith\DubIt
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\TechSmith\DubIt|*.gid
-FileKey2=%ProgramFiles%\TechSmith\DubIt|*.gid
+FileKey1=%ProgramFiles%\TechSmith\DubIt|*.gid
 RegKey1=HKCU\Software\TechSmith\DubIt\Recent Audio Files
 RegKey2=HKCU\Software\TechSmith\DubIt\Recent Video Files
 
@@ -16678,9 +15821,7 @@ LangSecRef=3022
 DetectFile=%ProgramFiles%\Tele2 Mobile Partner\Tele2 Mobile Partner.exe
 Default=False
 FileKey1=%CommonAppData%\Tele2 Mobile Partner\log|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Tele2 Mobile Partner\Log|*.txt
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Tele2 Mobile Partner\log|*.*
-FileKey4=%ProgramFiles%\Tele2 Mobile Partner\Log|*.txt
+FileKey2=%ProgramFiles%\Tele2 Mobile Partner\Log|*.txt
 
 [TeraCopy *]
 LangSecRef=3024
@@ -16688,8 +15829,7 @@ Detect=HKCU\Software\Code Sector\TeraCopy
 Default=False
 FileKey1=%AppData%\TeraCopy|FileList.dat;Transfer.log
 FileKey2=%AppData%\TeraCopy\History|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\TeraCopy|FileList.dat;Transfer.log
-FileKey4=%ProgramFiles%\TeraCopy|FileList.dat;Transfer.log
+FileKey3=%ProgramFiles%\TeraCopy|FileList.dat;Transfer.log
 RegKey1=HKCU\Software\Code Sector\TeraCopy|LastTargetFolder
 
 [Terraria *]
@@ -16697,8 +15837,7 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\105600
 Default=False
 FileKey1=%Documents%\My Games\Terraria|*.bak;*.wld.bak|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\terraria|client-crashlog.txt
-FileKey3=%ProgramFiles%\Steam\steamapps\common\terraria|client-crashlog.txt
+FileKey2=%ProgramFiles%\Steam\steamapps\common\terraria|client-crashlog.txt
 
 [Tesla Legacy *]
 Section=Games
@@ -16745,8 +15884,7 @@ Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\cleaner8.exe
 Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\cleaner9.exe
 Default=False
 FileKey1=%AppData%\thecleaner|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\The Cleaner|*.log;*.tmp;*.bak|RECURSE
-FileKey3=%ProgramFiles%\The Cleaner|*.log;*.tmp;*.bak|RECURSE
+FileKey2=%ProgramFiles%\The Cleaner|*.log;*.tmp;*.bak|RECURSE
 
 [The Clumsys 2: The Butterfly Effect *]
 Section=Games
@@ -16758,8 +15896,7 @@ FileKey1=%AppData%\BanzaiInteractive\Clumsys2|logfile.txt
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\94300
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\The Dream Machine\the_dream_machine.app|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Steam\steamapps\common\The Dream Machine\the_dream_machine.app|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\Steam\steamapps\common\The Dream Machine\the_dream_machine.app|*.*|REMOVESELF
 
 [The Elder Scrolls Online *]
 Section=Games
@@ -16779,10 +15916,8 @@ FileKey2=%LocalAppData%\Turbine|*.log|RECURSE
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\239220
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\CrashReport|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\Log|*.*
-FileKey3=%ProgramFiles%\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\CrashReport|*.*
-FileKey4=%ProgramFiles%\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\Log|*.*
+FileKey1=%ProgramFiles%\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\CrashReport|*.*
+FileKey2=%ProgramFiles%\Steam\SteamApps\Common\The Mighty Quest For Epic Loot\Log|*.*
 
 [The Mystery of the Mary Celeste *]
 Section=Games
@@ -16808,7 +15943,6 @@ Section=Games
 DetectFile=%CommonAppData%\TERMINAL Studio\The Rise of Atlantis
 Default=False
 FileKey1=%CommonAppData%\Terminal Studio\The Rise of Atlantis|log.html
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Terminal Studio\The Rise of Atlantis|log.html
 
 [The Sims 3 *]
 Section=Games
@@ -16848,8 +15982,7 @@ FileKey1=%Documents%\Electronic Arts\The Sims Medieval|*.log;*.xml|RECURSE
 Section=Games
 DetectFile=%ProgramFiles%\The Sims Resource\TSR Merlin
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\The Sims Resource\TSR Merlin\Logs|*.*
-FileKey2=%ProgramFiles%\The Sims Resource\TSR Merlin\Logs|*.*
+FileKey1=%ProgramFiles%\The Sims Resource\TSR Merlin\Logs|*.*
 
 [The Surge *]
 Section=Games
@@ -16901,8 +16034,7 @@ FileKey2=%LocalAppData%\Thinstall|*.*|REMOVESELF
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\220780
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\thomaswasalone\ThomasWasAlone_Data|output_log.txt
-FileKey2=%ProgramFiles%\Steam\Steamapps\common\thomaswasalone\ThomasWasAlone_Data|output_log.txt
+FileKey1=%ProgramFiles%\Steam\Steamapps\common\thomaswasalone\ThomasWasAlone_Data|output_log.txt
 
 [ThumbsPlus *]
 LangSecRef=3023
@@ -16947,10 +16079,8 @@ FileKey1=%AppData%\TimeRabbit\Cache|*.*|RECURSE
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Timeslips
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\TimeSlips\Data01\logs|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Timeslips\logs|*.*
-FileKey3=%ProgramFiles%\TimeSlips\Data01\logs|*.*
-FileKey4=%ProgramFiles%\Timeslips\logs|*.*
+FileKey1=%ProgramFiles%\TimeSlips\Data01\logs|*.*
+FileKey2=%ProgramFiles%\Timeslips\logs|*.*
 
 [Tinder++ *]
 LangSecRef=3021
@@ -16986,30 +16116,24 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\15300
 DetectFile=%ProgramFiles%\Red Storm Entertainment\Ghost Recon
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Red Storm Entertainment\Ghost Recon|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Ghost Recon|*.log
-FileKey3=%ProgramFiles%\Red Storm Entertainment\Ghost Recon|*.log
-FileKey4=%ProgramFiles%\Steam\SteamApps\Ghost Recon|*.log
+FileKey1=%ProgramFiles%\Red Storm Entertainment\Ghost Recon|*.log
+FileKey2=%ProgramFiles%\Steam\SteamApps\Ghost Recon|*.log
 
 [Tom Clancy's Rainbow Six 3: Raven Shield *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\19830
 DetectFile=%ProgramFiles%\Red Storm Entertainment\RavenShield
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Red Storm Entertainment\RavenShield|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\RavenShield|*.log
-FileKey3=%ProgramFiles%\Red Storm Entertainment\RavenShield|*.log
-FileKey4=%ProgramFiles%\Steam\SteamApps\Common\RavenShield|*.log
+FileKey1=%ProgramFiles%\Red Storm Entertainment\RavenShield|*.log
+FileKey2=%ProgramFiles%\Steam\SteamApps\Common\RavenShield|*.log
 
 [Tom Clancy's Rainbow Six: Vegas 2 *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\15120
 DetectFile=%ProgramFiles%\Ubisoft\Tom Clancy's Rainbow Six Vegas 2
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Tom Clancy's Rainbow Six Vegas 2|CrashReport*.*;*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Tom Clancy's Rainbow Six Vegas 2|CrashReport*.*;*.log|RECURSE
-FileKey3=%ProgramFiles%\Steam\SteamApps\Common\Tom Clancy's Rainbow Six Vegas 2|CrashReport*.*;*.log|RECURSE
-FileKey4=%ProgramFiles%\Ubisoft\Tom Clancy's Rainbow Six Vegas 2|CrashReport*.*;*.log|RECURSE
+FileKey1=%ProgramFiles%\Steam\SteamApps\Common\Tom Clancy's Rainbow Six Vegas 2|CrashReport*.*;*.log|RECURSE
+FileKey2=%ProgramFiles%\Ubisoft\Tom Clancy's Rainbow Six Vegas 2|CrashReport*.*;*.log|RECURSE
 
 [Tomahawk *]
 LangSecRef=3023
@@ -17056,16 +16180,14 @@ FileKey1=%ProgramFiles%\ToniArts\EasyCleaner|Duplicat.*
 Section=Games
 DetectFile=%LocalLowAppData%\Panda3D
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Disney\Disney Online\ToontownOnline|*.log
-FileKey2=%LocalLowAppData%\Panda3D\Log|*.*
-FileKey3=%ProgramFiles%\Disney\Disney Online\ToontownOnline|*.log
+FileKey1=%LocalLowAppData%\Panda3D\Log|*.*
+FileKey2=%ProgramFiles%\Disney\Disney Online\ToontownOnline|*.log
 
 [Toontown Rewritten *]
 Section=Games
 DetectFile=%ProgramFiles%\ToonTown Rewritten
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\ToonTown ReWritten\logs|*.*
-FileKey2=%ProgramFiles%\ToonTown ReWritten\logs|*.*
+FileKey1=%ProgramFiles%\ToonTown ReWritten\logs|*.*
 
 [TopStyle 5 *]
 LangSecRef=3021
@@ -17092,8 +16214,7 @@ FileKey2=%Documents%\My Games\Runic Games\Torchlight 2\logs|*.*
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Torrent Search
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Torrent Search|*.log
-FileKey2=%ProgramFiles%\Torrent Search|*.log
+FileKey1=%ProgramFiles%\Torrent Search|*.log
 
 [TortoiseHg *]
 LangSecRef=3021
@@ -17154,9 +16275,7 @@ Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall
 Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 6_is1
 Default=False
 FileKey1=%CommonAppData%\Martau\Total Uninstall*|*.Folders;*.cache|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Total Uninstall*|*.rtf;*.txt;*.GID|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*|*.Folders;*.cache|RECURSE
-FileKey4=%ProgramFiles%\Total Uninstall*|*.rtf;*.txt;*.GID|RECURSE
+FileKey2=%ProgramFiles%\Total Uninstall*|*.rtf;*.txt;*.GID|RECURSE
 
 [Total Uninstall Backups *]
 LangSecRef=3024
@@ -17169,24 +16288,18 @@ FileKey1=%CommonAppData%\Martau\Total Uninstall*|*.tlg;*.zsns;*.zip|RECURSE
 FileKey2=%CommonAppData%\Martau\Total Uninstall*\Analyzed Programs|*.*
 FileKey3=%CommonAppData%\Martau\Total Uninstall*\Backup|*.zip
 FileKey4=%CommonAppData%\Martau\Total Uninstall*\System Snapshots|*.zsns
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*|*.tlg;*.zsns;*.zip|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*\Analyzed Programs|*.*
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*\Backup|*.zip
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\Martau\Total Uninstall*\System Snapshots|*.zsns
 
 [Towns *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\221020
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\Steamapps\common\towns|*.log
-FileKey2=%ProgramFiles%\Steam\Steamapps\common\towns|*.log
+FileKey1=%ProgramFiles%\Steam\Steamapps\common\towns|*.log
 
 [TP-Link *]
 LangSecRef=3022
 DetectFile=%CommonAppData%\TP-Link
 Default=False
 FileKey1=%CommonAppData%\TP-Link|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\TP-Link|*.log
 
 [TrackMania Forever Cache *]
 Section=Games
@@ -17194,15 +16307,12 @@ DetectFile=%CommonAppData%\TrackMania
 Default=False
 FileKey1=%CommonAppData%\TrackMania\Cache|*.*
 FileKey2=%CommonAppData%\TrackMania\Cache\ManiaCode|*.*
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\TrackMania\Cache|*.*
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\TrackMania\Cache\ManiaCode|*.*
 
 [TrackMania Forever Manialinks *]
 Section=Games
 DetectFile=%CommonAppData%\TrackMania
 Default=False
 FileKey1=%CommonAppData%\TrackMania\Manialinks|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\TrackMania\Manialinks|*.*
 
 [TrackMania Forever Scores *]
 Section=Games
@@ -17212,24 +16322,18 @@ FileKey1=%CommonAppData%\TrackMania\CampaignsScores|*.*
 FileKey2=%CommonAppData%\TrackMania\CampaignsScores\General|*.*
 FileKey3=%CommonAppData%\TrackMania\CampaignsScores\UnitedRace|*.*
 FileKey4=%CommonAppData%\TrackMania\LadderScores|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\TrackMania\CampaignsScores|*.*
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\TrackMania\CampaignsScores\General|*.*
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\TrackMania\CampaignsScores\UnitedRace|*.*
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\TrackMania\LadderScores|*.*
 
 [Tracks Eraser Pro *]
 LangSecRef=3024
 Detect=HKLM\Software\Acesoft\tracks eraser pro
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Acesoft\Tracks Eraser Pro|te.log
-FileKey2=%ProgramFiles%\Acesoft\Tracks Eraser Pro|te.log
+FileKey1=%ProgramFiles%\Acesoft\Tracks Eraser Pro|te.log
 
 [Trade Manager *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Trademanager
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Trademanager|OneClickEnd.log
-FileKey2=%ProgramFiles%\Trademanager|OneClickEnd.log
+FileKey1=%ProgramFiles%\Trademanager|OneClickEnd.log
 
 [Treesize *]
 LangSecRef=3024
@@ -17244,21 +16348,18 @@ Detect=HKCU\Software\Trend Micro
 DetectFile=%CommonAppData%\Trend Micro
 Default=False
 FileKey1=%CommonAppData%\Trend Micro|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Trend Micro|*.log
 
 [Trend Micro AntiRansomware Tool *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\AntiRansomware2.0
 Default=False
 FileKey1=%CommonAppData%\AntiRansomware|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\AntiRansomware|*.log
 
 [TrendMicro RUBotted *]
 LangSecRef=3024
 Detect=HKLM\Software\TrendMicro\RUBotted
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Trend Micro\RUBotted\DebugLogs|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Trend Micro\RUBotted\DebugLogs|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\Trend Micro\RUBotted\DebugLogs|*.*|REMOVESELF
 
 [Tribes: Ascend *]
 Section=Games
@@ -17266,8 +16367,7 @@ Detect=HKCU\Software\Valve\Steam\Apps\17080
 Default=False
 FileKey1=%CommonAppData%\Hi-Rez Studios\BrowserCacheTribes\Default\Cache|*.*|RECURSE
 FileKey2=%Documents%\My Games\Tribes Ascend\TribesGame\Logs|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\tribes\Binaries\Logs|*.*
-FileKey4=%ProgramFiles%\Steam\steamapps\common\tribes\Binaries\Logs|*.*
+FileKey3=%ProgramFiles%\Steam\steamapps\common\tribes\Binaries\Logs|*.*
 
 [Trillian *]
 LangSecRef=3022
@@ -17279,31 +16379,24 @@ FileKey3=%AppData%\Trillian\users\*\cache|*.*
 FileKey4=%AppData%\Trillian\users\*\instantlookup|*.*
 FileKey5=%AppData%\Trillian\users\*\logs|*.*|RECURSE
 FileKey6=%AppData%\Trillian\users\global\skin_cache|*.*
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Trillian\Crash Files|*.*|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\Program Files*\Trillian\Users\Default\buddyicons|*.*|RECURSE
-FileKey9=%LocalAppData%\VirtualStore\Program Files*\Trillian\Users\Default\instantlookup|*.*
-FileKey10=%ProgramFiles%\Trillian\Crash Files|*.*|RECURSE
-FileKey11=%ProgramFiles%\Trillian\Users\Default\buddyicons|*.*|RECURSE
-FileKey12=%ProgramFiles%\Trillian\Users\Default\instantlookup|*.*
+FileKey7=%ProgramFiles%\Trillian\Crash Files|*.*|RECURSE
+FileKey8=%ProgramFiles%\Trillian\Users\Default\buddyicons|*.*|RECURSE
+FileKey9=%ProgramFiles%\Trillian\Users\Default\instantlookup|*.*
 
 [Trine *]
 Section=Games
 Detect1=HKCU\Software\Valve\Steam\Apps\35700
 Detect2=HKCU\Software\Valve\Steam\Apps\35720
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\Common\Trine*\log*|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\Trine\_enchanted_edition_\log|*.*
-FileKey3=%ProgramFiles%\Steam\SteamApps\Common\Trine*\log*|*.*
-FileKey4=%ProgramFiles%\Steam\SteamApps\common\Trine\_enchanted_edition_\log|*.*
+FileKey1=%ProgramFiles%\Steam\SteamApps\Common\Trine*\log*|*.*
+FileKey2=%ProgramFiles%\Steam\SteamApps\common\Trine\_enchanted_edition_\log|*.*
 
 [TrojanHunter *]
 LangSecRef=3024
 Detect=HKCU\Software\TrojanHunter
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\TrojanHunter*|Debug.log;DebugLog.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\TrojanHunter*\Scan Reports|*.*
-FileKey3=%ProgramFiles%\TrojanHunter*|Debug.log;DebugLog.txt
-FileKey4=%ProgramFiles%\TrojanHunter*\Scan Reports|*.*
+FileKey1=%ProgramFiles%\TrojanHunter*|Debug.log;DebugLog.txt
+FileKey2=%ProgramFiles%\TrojanHunter*\Scan Reports|*.*
 
 [Tropico *]
 Section=Games
@@ -17333,15 +16426,13 @@ FileKey1=%AppData%\TuneDroid\Logs|*.*
 LangSecRef=3021
 DetectFile=%ProgramFiles%\TuneXP
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\TuneXP\docs|*.bak
-FileKey2=%ProgramFiles%\TuneXP\docs|*.bak
+FileKey1=%ProgramFiles%\TuneXP\docs|*.bak
 
 [TunnelBear *]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\TunnelBear
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\TunnelBear|*.log
-FileKey2=%ProgramFiles%\TunnelBear|*.log
+FileKey1=%ProgramFiles%\TunnelBear|*.log
 
 [TV-Browser *]
 LangSecRef=3021
@@ -17360,14 +16451,12 @@ FileKey2=%LocalLowAppData%\TV_Net\Logs|*.*|RECURSE
 LangSecRef=3023
 Detect=HKLM\Software\TVersity\Media Server
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\TVersity Codec Pack|*.exe;*.url
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\TVersity\Media Server\logs|*.log;*.txt;*.xml;*.zip|RECURSE
-FileKey3=%ProgramFiles%\TVersity Codec Pack|*.exe;*.url
-FileKey4=%ProgramFiles%\TVersity\Media Server|*.rtf;*.url;*TVersityCodecPackSetup*
-FileKey5=%ProgramFiles%\TVersity\Media Server\logs|*.log;*.txt;*.xml;*.zip|RECURSE
-FileKey6=%WinDir%\System32|tversity.cookies;TVersityMediaServer.log;*.1;*.2;*.3
-FileKey7=%WinDir%\System32\config\systemprofile\AppData\Local\Temp\TVersity Media Server|*.*|REMOVESELF
-FileKey8=%WinDir%\System32\config\systemprofile\Local Settings\Application Data\Temp\TVersity Media Server|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\TVersity Codec Pack|*.exe;*.url
+FileKey2=%ProgramFiles%\TVersity\Media Server|*.rtf;*.url;*TVersityCodecPackSetup*
+FileKey3=%ProgramFiles%\TVersity\Media Server\logs|*.log;*.txt;*.xml;*.zip|RECURSE
+FileKey4=%WinDir%\System32|tversity.cookies;TVersityMediaServer.log;*.1;*.2;*.3
+FileKey5=%WinDir%\System32\config\systemprofile\AppData\Local\Temp\TVersity Media Server|*.*|REMOVESELF
+FileKey6=%WinDir%\System32\config\systemprofile\Local Settings\Application Data\Temp\TVersity Media Server|*.*|REMOVESELF
 ExcludeKey1=FILE|%ProgramFiles%\TVersity Codec Pack\|uninst.exe
 ExcludeKey2=PATH|%ProgramFiles%\TVersity\Media Server\|*version.txt;*HOWTO Share Media.txt
 
@@ -17375,8 +16464,7 @@ ExcludeKey2=PATH|%ProgramFiles%\TVersity\Media Server\|*version.txt;*HOWTO Share
 LangSecRef=3023
 Detect=HKCU\Software\TVU networks
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\TVUPlayer|log.txt
-FileKey2=%ProgramFiles%\TVUPlayer|log.txt
+FileKey1=%ProgramFiles%\TVUPlayer|log.txt
 
 [TWC Desktop Weather *]
 LangSecRef=3021
@@ -17390,16 +16478,14 @@ Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Tweaking.com - W
 DetectFile1=%ProgramFiles%\Tweaking.com
 DetectFile2=%SystemDrive%\Tweaking.com_Windows_Repair_Logs
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Tweaking.com\Windows Repair (All in One)\Logs|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Tweaking.com\Windows Repair (All in One)\Logs|*.*|REMOVESELF
-FileKey3=%SystemDrive%\Tweaking.com_Windows_Repair_Logs|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\Tweaking.com\Windows Repair (All in One)\Logs|*.*|REMOVESELF
+FileKey2=%SystemDrive%\Tweaking.com_Windows_Repair_Logs|*.*|REMOVESELF
 
 [TweakNow PowerPack Backups *]
 LangSecRef=3024
 Detect=HKCU\Software\TweakNow PowerPack
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\TweakNow PowerPack\Backup|*.*
-FileKey2=%ProgramFiles%\TweakNow PowerPack\Backup|*.*
+FileKey1=%ProgramFiles%\TweakNow PowerPack\Backup|*.*
 
 [TweetDeck *]
 LangSecRef=3022
@@ -17407,8 +16493,7 @@ Detect=HKCU\Software\Twitter\TweetDeck
 Default=False
 Warning=May delete your password and require you to log in again.
 FileKey1=%LocalAppData%\Twitter\TweetDeck\localStorage|*.*
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Twitter\TweetDeck|*.log
-FileKey3=%ProgramFiles%\Twitter\TweetDeck|*.log
+FileKey2=%ProgramFiles%\Twitter\TweetDeck|*.log
 
 [Tweetro *]
 LangSecRef=3031
@@ -17476,14 +16561,10 @@ FileKey1=%Documents%\TwoWorlds Files\FontsCache|*.tmp
 Section=Games
 DetectFile=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Ubisoft Game Launcher|*.log
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Ubisoft Game Launcher\Cache\assets|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Ubisoft Game Launcher\Cache\http*|*.*|RECURSE
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Ubisoft\Ubisoft Game Launcher\Logs|*.*
-FileKey5=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher|*.log
-FileKey6=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\assets|*.*
-FileKey7=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\http*|*.*|RECURSE
-FileKey8=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Logs|*.*
+FileKey1=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher|*.log
+FileKey2=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\assets|*.*
+FileKey3=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Cache\http*|*.*|RECURSE
+FileKey4=%ProgramFiles%\Ubisoft\Ubisoft Game Launcher\Logs|*.*
 
 [Ubisoft Game Launcher Installers *]
 Section=Games
@@ -17502,8 +16583,7 @@ RegKey1=HKCU\Software\Ulead Systems\Ulead GIF Animator\5.05\Recent File List
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Disktrix\UltimateDefrag\Udefrag.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Disktrix\UltimateDefrag|*.db;*Crash.dmp
-FileKey2=%ProgramFiles%\Disktrix\UltimateDefrag|*.db;*Crash.dmp
+FileKey1=%ProgramFiles%\Disktrix\UltimateDefrag|*.db;*Crash.dmp
 
 [UltraDefrag *]
 LangSecRef=3024
@@ -17521,15 +16601,13 @@ LangSecRef=3021
 Detect=HKCU\Software\IDM Computer Solutions\UltraEdit
 Default=False
 FileKey1=%AppData%\IDMComp\UltraEdit\autorec|*.*|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\IDM Computer Solutions\UltraEdit|*.txt
-FileKey3=%ProgramFiles%\IDM Computer Solutions\UltraEdit|*.txt
+FileKey2=%ProgramFiles%\IDM Computer Solutions\UltraEdit|*.txt
 
 [UltraISO *]
 LangSecRef=3024
 Detect=HKCU\Software\EasyBoot Systems
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\UltraISO\backup|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\UltraISO\backup|*.*|REMOVESELF
+FileKey1=%ProgramFiles%\UltraISO\backup|*.*|REMOVESELF
 RegKey1=HKCU\Software\EasyBoot Systems\UltraISO\5.0|LogFile
 RegKey2=HKCU\Software\EasyBoot Systems\UltraISO\5.0|OpenFolder
 
@@ -17562,15 +16640,13 @@ LangSecRef=3024
 Detect=HKLM\Software\Greatis
 Default=False
 FileKey1=%Documents%\RegRun2|*.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\UnHackMe|*.err;*.txt;*.log|RECURSE
-FileKey3=%ProgramFiles%\UnHackMe|*.err;*.txt;*.log|RECURSE
+FileKey2=%ProgramFiles%\UnHackMe|*.err;*.txt;*.log|RECURSE
 
 [Unicenta Open POS *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Unicentaopos*
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Unicentaopos*|*.log
-FileKey2=%ProgramFiles%\Unicentaopos*|*.log
+FileKey1=%ProgramFiles%\Unicentaopos*|*.log
 
 [Unified Remote *]
 LangSecRef=3023
@@ -17589,8 +16665,7 @@ FileKey2=%UserProfile%\Unigine Heaven\save|*.*|REMOVESELF
 LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Uninstall Tool_is1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Uninstall Tool|*.dmp
-FileKey2=%ProgramFiles%\Uninstall Tool|*.dmp
+FileKey1=%ProgramFiles%\Uninstall Tool|*.dmp
 
 [Unity Web Player *]
 LangSecRef=3023
@@ -17602,25 +16677,21 @@ FileKey1=%LocalLowAppData%\Unity\*Player\Cache|*.*|RECURSE
 LangSecRef=3022
 DetectFile=%ProgramFiles%\USDownloader\USDownloader.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\USDownloader|USDownloader.log;*.bak;*.bmp;*.jpg;*.png
-FileKey2=%ProgramFiles%\USDownloader|USDownloader.log;*.bak;*.bmp;*.jpg;*.png
+FileKey1=%ProgramFiles%\USDownloader|USDownloader.log;*.bak;*.bmp;*.jpg;*.png
 
 [Unlocker *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Unlocker\Unlocker.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Unlocker|Unlocker-List.txt
-FileKey2=%ProgramFiles%\Unlocker|Unlocker-List.txt
+FileKey1=%ProgramFiles%\Unlocker|Unlocker-List.txt
 
 [Unlockroot *]
 LangSecRef=3024
 Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\unlockroot.exe
 Detect2=HKLM\Software\UnlockrootPro
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Unlockroot*|*.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Unlockroot\tools|*.zip
-FileKey3=%ProgramFiles%\Unlockroot*|*.txt
-FileKey4=%ProgramFiles%\Unlockroot*\tools|*.zip
+FileKey1=%ProgramFiles%\Unlockroot*|*.txt
+FileKey2=%ProgramFiles%\Unlockroot*\tools|*.zip
 
 [UPX Shell *]
 LangSecRef=3024
@@ -17651,8 +16722,7 @@ FileKey1=%AppData%\Zbshareware Lab|*.*|REMOVESELF
 LangSecRef=3022
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{FB9376AC-5253-42a5-AC0A-D306F32FFAD2}
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\USB Redirector|*.log;*.txt
-FileKey2=%ProgramFiles%\USB Redirector|*.log;*.txt
+FileKey1=%ProgramFiles%\USB Redirector|*.log;*.txt
 
 [USB Safely Remove *]
 LangSecRef=3024
@@ -17660,15 +16730,13 @@ Detect=HKCU\Software\SafelyRemove
 Default=False
 FileKey1=%AppData%\USBSafelyRemove|*.txt
 FileKey2=%AppData%\USBSRService|*.txt
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\USB Safely Remove|*.DIZ;*.rtf;*.url
-FileKey4=%ProgramFiles%\USB Safely Remove|*.DIZ;*.rtf;*.url
+FileKey3=%ProgramFiles%\USB Safely Remove|*.DIZ;*.rtf;*.url
 
 [USBChargerPlus *]
 LangSecRef=3021
 DetectFile=%CommonAppData%\USBChargerPlus
 Default=False
 FileKey1=%CommonAppData%|AsACPLog.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData|AsACPLog.*
 
 [UsbFix *]
 LangSecRef=3023
@@ -17691,9 +16759,8 @@ Detect=HKCU\Software\BitTorrent\uTorrent
 Default=False
 FileKey1=%AppData%\utorrent|*.log;*.dmp;*.bad;*.older;*.benc
 FileKey2=%AppData%\utorrent\updates|*.exe
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\uTorrent|*.tmp;*.old
-FileKey4=%LocalLowAppData%\uTorrentBar\Logs|*.*
-FileKey5=%ProgramFiles%\uTorrent|*.tmp;*.old
+FileKey3=%LocalLowAppData%\uTorrentBar\Logs|*.*
+FileKey4=%ProgramFiles%\uTorrent|*.tmp;*.old
 
 [uTorrent IPFilter Backups *]
 LangSecRef=3022
@@ -17747,22 +16814,19 @@ FileKey1=%LocalAppData%\SupportSoft\verizondm\*\*\logs|*.*
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Verizon\IHA_MessageCenter
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Verizon\IHA_MessageCenter\Log|mc-log;mc-log*.*
-FileKey2=%ProgramFiles%\Verizon\IHA_MessageCenter\Log|mc-log;mc-log*.*
+FileKey1=%ProgramFiles%\Verizon\IHA_MessageCenter\Log|mc-log;mc-log*.*
 
 [VIA/S3G UniChrome Pro IGP *]
 LangSecRef=3024
 Detect=HKLM\Software\S3
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\S3\UChromeP|s3iscfg.log
-FileKey2=%ProgramFiles%\S3\UChromeP|s3iscfg.log
+FileKey1=%ProgramFiles%\S3\UChromeP|s3iscfg.log
 
 [VideoGet *]
 LangSecRef=3022
 Detect=HKCU\Software\Nuclear Coffee\VideoGet
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\VideoGet\Temp|*.*
-FileKey2=%ProgramFiles%\VideoGet\Temp|*.*
+FileKey1=%ProgramFiles%\VideoGet\Temp|*.*
 
 [VideoInspector *]
 LangSecRef=3023
@@ -17878,10 +16942,8 @@ Detect=HKCU\Software\Vodafone
 Default=False
 FileKey1=%AppData%\Vodafone\Vodafone Mobile Broadband\Log|*.*
 FileKey2=%CommonAppData%\Vodafone\Log|*.*
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Vodafone\Vodafone Mobile Broadband\Bin|SwiHpAux.log
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\Vodafone\Log|*.*
-FileKey5=%ProgramFiles%\Vodafone\Vodafone Mobile Broadband\Bin|SwiHpAux.log
-FileKey6=%WinDir%|ModemLog_*.txt
+FileKey3=%ProgramFiles%\Vodafone\Vodafone Mobile Broadband\Bin|SwiHpAux.log
+FileKey4=%WinDir%|ModemLog_*.txt
 
 [Vodafone Database *]
 LangSecRef=3022
@@ -17942,8 +17004,7 @@ FileKey1=%AppData%|pcouffin.log;ezplay.log
 FileKey2=%AppData%\VSO|*.log|REMOVESELF
 FileKey3=%CommonAppData%\VSO\Blindwrite\*|*.log|REMOVESELF
 FileKey4=%Documents%\PcSetup|*.log|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\VSO\Blindwrite\*|*.log|REMOVESELF
-FileKey6=%UserProfile%|timestamp.txt
+FileKey5=%UserProfile%|timestamp.txt
 
 [VSO Converter *]
 LangSecRef=3023
@@ -17956,11 +17017,7 @@ FileKey2=%CommonAppData%\VSO|*.cache
 FileKey3=%CommonAppData%\VSO\*Converter*\*\Log|*.log;*.crashlist|REMOVESELF
 FileKey4=%CommonAppData%\VSO\vsothumbs|*.*|REMOVESELF
 FileKey5=%Documents%\PcSetup|*.log|REMOVESELF
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\VSO\*Converter*\*|*.txt
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\VSO|*.cache
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\VSO\*Converter*\*\Log|*.log;*.crashlist|REMOVESELF
-FileKey9=%LocalAppData%\VirtualStore\ProgramData\VSO\vsothumbs|*.*|REMOVESELF
-FileKey10=%ProgramFiles%\VSO\*Converter*\*|*.txt
+FileKey6=%ProgramFiles%\VSO\*Converter*\*|*.txt
 RegKey1=HKCU\Software\VSO\Blu-ray Converter Ultimate\2|BDMVInputFolders
 RegKey2=HKCU\Software\VSO\Blu-ray Converter Ultimate\2|ISOInputFolders
 RegKey3=HKCU\Software\VSO\Blu-ray Converter Ultimate\2|MediaLabel
@@ -17992,9 +17049,7 @@ Detect=HKCU\Software\VSO\ConvertXtoDVD\5
 Default=False
 FileKey1=%AppData%|pcouffin.log
 FileKey2=%CommonAppData%\VSO\vsothumbs|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\VSO\ConvertX\5|*.log;*.rtf
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\VSO\vsothumbs|*.*|REMOVESELF
-FileKey5=%ProgramFiles%\VSO\ConvertX\5|*.log;*.rtf
+FileKey3=%ProgramFiles%\VSO\ConvertX\5|*.log;*.rtf
 
 [VSO CopyTo *]
 LangSecRef=3021
@@ -18004,8 +17059,7 @@ FileKey1=%AppData%|pcouffin.log;ezplay.log
 FileKey2=%AppData%\VSO|*.log|REMOVESELF
 FileKey3=%CommonAppData%\VSO|*.cache;*.crashlist;*.log;*.vsothumb|RECURSE
 FileKey4=%Documents%\PcSetup|*.log|REMOVESELF
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\VSO|*.cache;*.crashlist;*.log;*.vsothumb|RECURSE
-FileKey6=%UserProfile%|timestamp.txt
+FileKey5=%UserProfile%|timestamp.txt
 
 [VSO Downloader *]
 LangSecRef=3023
@@ -18015,8 +17069,6 @@ FileKey1=%AppData%\VSO|*.log
 FileKey2=%AppData%\VSO\VSO Downloader\*\items|*.item|RECURSE
 FileKey3=%CommonAppData%\VSO\VSO Downloader\*\items|*.item|RECURSE
 FileKey4=%CommonAppData%\VSO\VSO Downloader\*\log|*.log
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\VSO\VSO Downloader\*\items|*.item|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\VSO\VSO Downloader\*\log|*.log
 
 [VSO Media Player 1 *]
 LangSecRef=3023
@@ -18026,9 +17078,6 @@ FileKey1=%AppData%\VSO\VSO Media Player\1|autoresume.xml
 FileKey2=%CommonAppData%\VSO|font.cache
 FileKey3=%CommonAppData%\VSO\VSO Media Player\1\log|*.log;*.crashlist
 FileKey4=%CommonAppData%\VSO\vsothumbs|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\VSO|font.cache
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\VSO\VSO Media Player\1\log|*.log;*.crashlist
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\VSO\vsothumbs|*.*|RECURSE
 RegKey1=HKCU\Software\VSO\VSO Media Player\1\RecentlyOpenedFiles
 
 [VueScan *]
@@ -18036,9 +17085,8 @@ LangSecRef=3024
 DetectFile1=%ProgramFiles%\VueScan
 DetectFile2=%SystemDrive%\VueScan
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\VueScan|*.log|RECURSE
-FileKey2=%ProgramFiles%\VueScan|*.log|RECURSE
-FileKey3=%SystemDrive%\VueScan|*.log|RECURSE
+FileKey1=%ProgramFiles%\VueScan|*.log|RECURSE
+FileKey2=%SystemDrive%\VueScan|*.log|RECURSE
 
 [Vuze *]
 LangSecRef=3022
@@ -18061,7 +17109,6 @@ LangSecRef=3022
 DetectFile=%CommonAppData%\W3i
 Default=False
 FileKey1=%CommonAppData%\W3i\InstallQUpdater|*.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\W3i\InstallQUpdater|*.log
 
 [Walgreens PhotoShow Express CD *]
 LangSecRef=3021
@@ -18073,46 +17120,37 @@ FileKey1=%AppData%\Walgreens\Photoshow Express CD\Cache|*.*|RECURSE
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Wallpaper Juggler
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Wallpaper Juggler|*.log
-FileKey2=%ProgramFiles%\Wallpaper Juggler|*.log
+FileKey1=%ProgramFiles%\Wallpaper Juggler|*.log
 
 [WallWatcher *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Wall Watcher\WallWatcher.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Wall Watcher\Logs|*.*
-FileKey2=%ProgramFiles%\Wall Watcher\Logs|*.*
+FileKey1=%ProgramFiles%\Wall Watcher\Logs|*.*
 
 [War of the Human Tanks *]
 Section=Games
 DetectFile=%ProgramFiles%\Desura\Common\war-of-the-human-tanks
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Desura\Common\war-of-the-human-tanks\LOG|*.*
-FileKey2=%ProgramFiles%\Desura\Common\war-of-the-human-tanks\LOG|*.*
+FileKey1=%ProgramFiles%\Desura\Common\war-of-the-human-tanks\LOG|*.*
 
 [War Thunder *]
 Section=Games
 Detect1=HKCU\Software\Gaijin\WarThunder
 Detect2=HKCU\Software\Valve\Steam\Apps\236390
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\War Thunder\.launcher_log|*.txt
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Steam\SteamApps\common\War Thunder\_debuginfo|*.clog
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\War Thunder\.launcher_log|*.txt
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\War Thunder\_debuginfo|*.clog
-FileKey5=%ProgramFiles%\Steam\SteamApps\common\War Thunder\.launcher_log|*.txt
-FileKey6=%ProgramFiles%\Steam\SteamApps\common\War Thunder\_debuginfo|*.clog
-FileKey7=%ProgramFiles%\War Thunder\.launcher_log|*.txt
-FileKey8=%ProgramFiles%\War Thunder\_debuginfo|*.clog
+FileKey1=%ProgramFiles%\Steam\SteamApps\common\War Thunder\.launcher_log|*.txt
+FileKey2=%ProgramFiles%\Steam\SteamApps\common\War Thunder\_debuginfo|*.clog
+FileKey3=%ProgramFiles%\War Thunder\.launcher_log|*.txt
+FileKey4=%ProgramFiles%\War Thunder\_debuginfo|*.clog
 
 [Warcraft III *]
 Section=Games
 Detect=HKLM\Software\Blizzard Entertainment\Warcraft III
 DetectFile=%ProgramFiles%\Warcraft III\Warcraft III.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Warcraft III|*.log;*.html
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Warcraft III\Errors|*.dmp;*.txt
-FileKey3=%ProgramFiles%\Warcraft III|*.log;*.html
-FileKey4=%ProgramFiles%\Warcraft III\Errors|*.dmp;*.txt
+FileKey1=%ProgramFiles%\Warcraft III|*.log;*.html
+FileKey2=%ProgramFiles%\Warcraft III\Errors|*.dmp;*.txt
 ExcludeKey1=PATH|%ProgramFiles%\Warcraft III\|*CustomKeyInfo.txt;*CustomKeysSample.txt
 
 [Warcraft III Backups *]
@@ -18120,8 +17158,7 @@ Section=Games
 Detect=HKLM\Software\Blizzard Entertainment\Warcraft III
 Default=False
 Warning=This will delete all your Warcraft III backup files. You won't be able to restore from them if something goes wrong.
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Warcraft III|*.bak;*.old|RECURSE
-FileKey2=%ProgramFiles%\Warcraft III|*.bak;*.old|RECURSE
+FileKey1=%ProgramFiles%\Warcraft III|*.bak;*.old|RECURSE
 
 [Warframe *]
 Section=Games
@@ -18133,8 +17170,7 @@ FileKey1=%LocalAppData%\Warframe|*.log
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\4570
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Steam\steamapps\common\Dawn of War Gold\Logfiles|*.*
-FileKey2=%ProgramFiles%\Steam\steamapps\common\Dawn of War Gold\Logfiles|*.*
+FileKey1=%ProgramFiles%\Steam\steamapps\common\Dawn of War Gold\Logfiles|*.*
 
 [WashAndGo *]
 LangSecRef=3024
@@ -18155,8 +17191,7 @@ DetectFile=%AppData%\Wave Systems Corp
 Default=False
 FileKey1=%AppData%\Wave Systems Corp|DSM_AM.*
 FileKey2=%CommonAppData%\Wave Systems Corp|*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Wave Systems Corp|*.log|RECURSE
-FileKey4=%LocalAppData%\Wave Systems Corp\WCLIENTDLL|errors.txt
+FileKey3=%LocalAppData%\Wave Systems Corp\WCLIENTDLL|errors.txt
 
 [WavePad *]
 LangSecRef=3023
@@ -18168,8 +17203,7 @@ RegKey1=HKCU\Software\NCH Software\WavePad\Recent
 LangSecRef=3023
 DetectFile=%ProgramFiles%\Wavosaur\wavosaur.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Wavosaur|wavosaur.log
-FileKey2=%ProgramFiles%\Wavosaur|wavosaur.log
+FileKey1=%ProgramFiles%\Wavosaur|wavosaur.log
 
 [Weather *]
 LangSecRef=3031
@@ -18194,8 +17228,7 @@ RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 LangSecRef=3024
 Detect=HKLM\Software\Weather It Up
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Weather It Up|*.log
-FileKey2=%ProgramFiles%\Weather It Up|*.log
+FileKey1=%ProgramFiles%\Weather It Up|*.log
 
 [Weather Watcher Live *]
 LangSecRef=3021
@@ -18223,8 +17256,7 @@ FileKey2=%LocalAppData%\Ericom\PtRdp|*.*
 LangSecRef=3022
 Detect=HKCU\Software\CM\WebMon
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\WebMon|UpdateLog.*
-FileKey2=%ProgramFiles%\WebMon|UpdateLog.*
+FileKey1=%ProgramFiles%\WebMon|UpdateLog.*
 
 [WebPI Installer *]
 LangSecRef=3025
@@ -18236,8 +17268,7 @@ FileKey1=%LocalAppData%\Microsoft\Web Platform Installer\logs\webpi|*.txt
 LangSecRef=3022
 DetectFile=%ProgramFiles%\WebPictures Downloader
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\WebPictures Downloader\Projects|*.*|RECURSE
-FileKey2=%ProgramFiles%\WebPictures Downloader\Projects|*.*|RECURSE
+FileKey1=%ProgramFiles%\WebPictures Downloader\Projects|*.*|RECURSE
 
 [WebReaper *]
 LangSecRef=3022
@@ -18250,7 +17281,6 @@ LangSecRef=3024
 DetectFile=%ProgramFiles%\Webroot\WRSA.exe
 Default=False
 FileKey1=%CommonAppData%\WRData|WRLog.log
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\WRData|WRLog.log
 
 [WebStorm *]
 LangSecRef=3021
@@ -18273,7 +17303,6 @@ LangSecRef=3024
 DetectFile=%ProgramFiles%\WeFi
 Default=False
 FileKey1=%CommonAppData%\WeFi\LogFiles|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\WeFi\LogFiles|*.*|REMOVESELF
 
 [Western Digital Firmware Updater *]
 LangSecRef=3024
@@ -18289,10 +17318,8 @@ FileKey1=%AppData%\Western Digital\WD SmartWare\Logs|*.*
 FileKey2=%CommonAppData%\Western Digital\Logs\WD *\*|*.log
 FileKey3=%CommonAppData%\Western Digital\WD SmartWare|*.log
 FileKey4=%CommonAppData%\Western Digital\WDFME|*.*
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\Western Digital\WD SmartWare|*.log
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Western Digital\WDFME|*.*
-FileKey7=%LocalAppData%\Western Digital\WD SmartWare|*log.txt
-FileKey8=%Public%\Documents\Downloads\WD_SmartWare_Installer_*|*.*|REMOVESELF
+FileKey5=%LocalAppData%\Western Digital\WD SmartWare|*log.txt
+FileKey6=%Public%\Documents\Downloads\WD_SmartWare_Installer_*|*.*|REMOVESELF
 
 [WhatPulse *]
 LangSecRef=3021
@@ -18310,8 +17337,7 @@ FileKey1=%AppData%\WhatPulse|*.bak
 LangSecRef=3022
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{010D45A1-093D-4534-8147-4E10E80F81CC}_is1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\IO3O LLC\Who Is On My Wifi\logs|*.*
-FileKey2=%ProgramFiles%\IO3O LLC\Who Is On My Wifi\logs|*.*
+FileKey1=%ProgramFiles%\IO3O LLC\Who Is On My Wifi\logs|*.*
 
 [WildTangent *]
 LangSecRef=3021
@@ -18347,8 +17373,7 @@ RegKey6=HKCU\Software\Softany\WinCHM|RecentFile6
 LangSecRef=3024
 Detect=HKCU\Software\Yamicsoft\Windows 7 Manager
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Yamicsoft\Windows 7 Manager\DiskAnalyzerXML|*.*
-FileKey2=%ProgramFiles%\Yamicsoft\Windows 7 Manager\DiskAnalyzerXML|*.*
+FileKey1=%ProgramFiles%\Yamicsoft\Windows 7 Manager\DiskAnalyzerXML|*.*
 
 [Windows Communications Apps *]
 LangSecRef=3031
@@ -18499,9 +17524,6 @@ FileKey2=%CommonAppData%\Microsoft\WLSetup\*logs|*.*|RECURSE
 FileKey3=%CommonAppData%\WLInstaller|*.log
 FileKey4=%CommonProgramFiles%\Windows Live\.cache|*.tmp
 FileKey5=%LocalAppData%\Microsoft\WLSetup\*logs|*.*|RECURSE
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\Microsoft\WLSetup|*.tmp
-FileKey7=%LocalAppData%\VirtualStore\ProgramData\Microsoft\WLSetup\*logs|*.*|RECURSE
-FileKey8=%LocalAppData%\VirtualStore\ProgramData\WLInstaller|*.log
 
 [Windows Live Setup Files *]
 LangSecRef=3022
@@ -18569,7 +17591,6 @@ Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\Media Center
 Default=False
 FileKey1=%CommonAppData%\Microsoft\eHome\thmb|TVThumb.db
 FileKey2=%LocalAppData%\Microsoft\Ehome|Image.db;Video.db;musicThumbs.db
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\Microsoft\eHome\thmb|TVThumb.db
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Media Center\MRU\SettingsMRU
 
 [Windows Movie Maker *]
@@ -18690,27 +17711,16 @@ FileKey10=%CommonAppData%\Microsoft\Windows\Sqm\Sessions|*.psqm;*.sqm
 FileKey11=%LocalAppData%\Microsoft\Windows\PRICache|*.*|RECURSE
 FileKey12=%LocalAppData%\Microsoft\Windows\SettingSync\metastore|*.jrs
 FileKey13=%LocalAppData%\Microsoft\Windows\SettingSync\remotemetastore\*|*.jrs
-FileKey14=%LocalAppData%\VirtualStore\ProgramData\Microsoft\PlayReady|*.hds
-FileKey15=%LocalAppData%\VirtualStore\ProgramData\Microsoft\PlayReady\Cache|*.*
-FileKey16=%LocalAppData%\VirtualStore\ProgramData\Microsoft\RAC\PublishedData|*.log;*.jrs
-FileKey17=%LocalAppData%\VirtualStore\ProgramData\Microsoft\RAC\StateData|*.log;*.jrs
-FileKey18=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\DRM|*.log
-FileKey19=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\DRM\Cache|*.*|RECURSE
-FileKey20=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\DRM\PreUpgrade|*.log
-FileKey21=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\Sqm\Manifest|*.bin
-FileKey22=%LocalAppData%\VirtualStore\ProgramData\Microsoft\Windows\Sqm\Sessions|*.psqm;*.sqm
-FileKey23=%SystemDrive%\spoolerlogs|spooler.xml
-FileKey24=%WinDir%\ehome|PRDMOWrapper.log
-FileKey25=%WinDir%\System32|PRDMOWrapper.log
-FileKey26=%WinDir%\system32\spool|spooler.xml
-FileKey27=%WinDir%\System32\sru|*.*|RECURSE
-RegKey1=HKCU\Software\Classes\VirtualStore\MACHINE\Software\Microsoft\DirectDraw\MostRecentApplication
-RegKey2=HKCU\Software\Classes\VirtualStore\MACHINE\Software\Wow6432Node\Microsoft\DirectDraw\MostRecentApplication
-RegKey3=HKCU\Software\Microsoft\Direct3D\MostRecentApplication
-RegKey4=HKLM\Software\Microsoft\Direct3D\MostRecentApplication
-RegKey5=HKLM\Software\Microsoft\Windows\CurrentVersion\Setup|Installation Sources
-RegKey6=HKLM\Software\Wow6432Node\Microsoft\Direct3D\MostRecentApplication
-RegKey7=HKLM\Software\Wow6432Node\Microsoft\DirectDraw\MostRecentApplication
+FileKey14=%SystemDrive%\spoolerlogs|spooler.xml
+FileKey15=%WinDir%\ehome|PRDMOWrapper.log
+FileKey16=%WinDir%\System32|PRDMOWrapper.log
+FileKey17=%WinDir%\system32\spool|spooler.xml
+FileKey18=%WinDir%\System32\sru|*.*|RECURSE
+RegKey1=HKCU\Software\Microsoft\Direct3D\MostRecentApplication
+RegKey2=HKLM\Software\Microsoft\Direct3D\MostRecentApplication
+RegKey3=HKLM\Software\Microsoft\Windows\CurrentVersion\Setup|Installation Sources
+RegKey4=HKLM\Software\Wow6432Node\Microsoft\Direct3D\MostRecentApplication
+RegKey5=HKLM\Software\Wow6432Node\Microsoft\DirectDraw\MostRecentApplication
 
 [Windows Update *]
 LangSecRef=3025
@@ -18745,10 +17755,8 @@ LangSecRef=3021
 Detect=HKCU\Software\Qbik Software\GateKeeper
 DetectFile=%ProgramFiles%\WinGate\WinGate.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\WinGate|*Log.txt;*.log|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\WinGate\Logs\Global|*.idx
-FileKey3=%ProgramFiles%\WinGate|*Log.txt;*.log|RECURSE
-FileKey4=%ProgramFiles%\WinGate\Logs\Global|*.idx
+FileKey1=%ProgramFiles%\WinGate|*Log.txt;*.log|RECURSE
+FileKey2=%ProgramFiles%\WinGate\Logs\Global|*.idx
 
 [WinHasher *]
 LangSecRef=3024
@@ -18760,8 +17768,7 @@ RegKey1=HKCU\Software\GPF Comics\WinHasher|LastDirectory
 LangSecRef=3022
 Detect=HKCU\Software\WinHTTrack Website Copier
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\WinHTTrack|winhttrack.log
-FileKey2=%ProgramFiles%\WinHTTrack|winhttrack.log
+FileKey1=%ProgramFiles%\WinHTTrack|winhttrack.log
 
 [WinImage *]
 LangSecRef=3024
@@ -18814,15 +17821,13 @@ FileKey1=%AppData%\WinMount|*.dat
 LangSecRef=3022
 Detect=HKLM\Software\WinPcap
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\WinPcap|*.log
-FileKey2=%ProgramFiles%\WinPcap|*.log
+FileKey1=%ProgramFiles%\WinPcap|*.log
 
 [WinRAR *]
 LangSecRef=3024
 Detect=HKCU\Software\WinRAR
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\WinRAR|*.tmp|RECURSE
-FileKey2=%ProgramFiles%\WinRAR|*.tmp|RECURSE
+FileKey1=%ProgramFiles%\WinRAR|*.tmp|RECURSE
 RegKey1=HKCU\Software\WinRAR SFX
 RegKey2=HKCU\Software\WinRAR\DialogEditHistory
 RegKey3=HKCU\Software\WinRAR\General\Info|CommentFile
@@ -18832,7 +17837,6 @@ LangSecRef=3021
 DetectFile=%CommonAppData%\Banamalon\WinRemoteService
 Default=False
 FileKey1=%CommonAppData%\Banamalon\WinRemoteService\log|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Banamalon\WinRemoteService\log|*.*
 
 [WinSAT Shader Cache *]
 DetectOS=|6.2
@@ -18846,9 +17850,8 @@ LangSecRef=3024
 DetectFile1=%ProgramFiles%\WinSetupFromUSB
 DetectFile2=%SystemDrive%\WinSetupFromUSB
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\WinSetupFromUSB|*.log|RECURSE
-FileKey2=%ProgramFiles%\WinSetupFromUSB|*.log|RECURSE
-FileKey3=%SystemDrive%\WinSetupFromUSB|*.log|RECURSE
+FileKey1=%ProgramFiles%\WinSetupFromUSB|*.log|RECURSE
+FileKey2=%SystemDrive%\WinSetupFromUSB|*.log|RECURSE
 
 [WinTK *]
 LangSecRef=3024
@@ -18860,8 +17863,7 @@ FileKey1=%Documents%\WinTK|ExLog.txt
 LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\WinToUSB_is1
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\WinToUSB\bin|*.log
-FileKey2=%ProgramFiles%\WinToUSB\bin|*.log
+FileKey1=%ProgramFiles%\WinToUSB\bin|*.log
 
 [WinWAP *]
 LangSecRef=3022
@@ -18922,8 +17924,7 @@ FileKey3=%SystemDrive%\ThumbnailCache|*.*
 LangSecRef=3024
 Detect=HKLM\Software\Wistron Corp\Launch Manager
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Launch Manager|*.log
-FileKey2=%ProgramFiles%\Launch Manager|*.log
+FileKey1=%ProgramFiles%\Launch Manager|*.log
 
 [WM Recorder *]
 LangSecRef=3023
@@ -18933,8 +17934,7 @@ Detect3=HKCU\Software\WMR12
 Detect4=HKCU\Software\WMR13
 Detect5=HKCU\Software\WMR14
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\WM Recorder*|log.txt;urls.txt
-FileKey2=%ProgramFiles%\WM Recorder*|log.txt;urls.txt
+FileKey1=%ProgramFiles%\WM Recorder*|log.txt;urls.txt
 
 [Wolfenstein: MP *]
 Section=Games
@@ -18946,8 +17946,7 @@ FileKey1=%LocalAppData%\id Software\WolfMP|*.log|RECURSE
 Section=Games
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{9E6AD6CF-1EFF-43E4-86C4-5C00254C3D8E}
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\WolfQuest|*.txt|RECURSE
-FileKey2=%ProgramFiles%\WolfQuest|*.txt|RECURSE
+FileKey1=%ProgramFiles%\WolfQuest|*.txt|RECURSE
 ExcludeKey1=FILE|%ProgramFiles%\WolfQuest\|Help.txt
 
 [Wondershare AllMyTube *]
@@ -18985,9 +17984,6 @@ FileKey1=%CommonProgramFiles%\Wondershare\Wondershare Helper Compact|ProductUpda
 FileKey2=%CommonProgramFiles%\Wondershare\Wondershare Helper Compact\DATADICT|*.*|RECURSE
 FileKey3=%CommonProgramFiles%\Wondershare\Wondershare Helper Compact\Log|*.*|RECURSE
 FileKey4=%CommonProgramFiles%\Wondershare\Wondershare Helper Compact\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\VirtualStore\Program Files*\Common Files\Wondershare\Wondershare Helper Compact|ProductUpdateLists.xml;WSHelper.exe_temp;WSHelperSetup.exe_temp
-FileKey6=%LocalAppData%\VirtualStore\Program Files*\Common Files\Wondershare\Wondershare Helper Compact\Log|*.*|RECURSE
-FileKey7=%LocalAppData%\VirtualStore\Program Files*\Common Files\Wondershare\Wondershare Helper Compact\Temp|*.*|RECURSE
 RegKey1=HKLM\Software\Wondershare\Wondershare Helper Compact
 RegKey2=HKLM\Software\Wow6432Node\Wondershare\Wondershare Helper Compact
 
@@ -19039,9 +18035,8 @@ Detect2=HKLM\Software\Wondershare\Wondershare Video Converter Ultimate
 Default=False
 FileKey1=%CommonAppData%\Wondershare\ProductFeatures\*Logs|*.*|RECURSE
 FileKey2=%Documents%\Wondershare MediaServer\log|*.*|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Wondershare Video Converter Ultimate\TempThumbDir|*.*|RECURSE
-FileKey4=%ProgramFiles%\Wondershare Video Converter Ultimate\TempThumbDir|*.*|RECURSE
-FileKey5=%Public%\Documents\Wondershare|*.*|REMOVESELF
+FileKey3=%ProgramFiles%\Wondershare Video Converter Ultimate\TempThumbDir|*.*|RECURSE
+FileKey4=%Public%\Documents\Wondershare|*.*|REMOVESELF
 
 [Wordweb *]
 LangSecRef=3021
@@ -19053,28 +18048,24 @@ FileKey1=%AppData%\WordWeb|History.txt
 Section=Games
 Detect=HKCU\Software\Blizzard Entertainment\World of Warcraft
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\World of Warcraft\Cache|*.*|REMOVESELF
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\World of Warcraft\Errors|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\World of Warcraft\Logs|*.log
-FileKey4=%ProgramFiles%\World of Warcraft\Cache|*.*|REMOVESELF
-FileKey5=%ProgramFiles%\World of Warcraft\Errors|*.*|REMOVESELF
-FileKey6=%ProgramFiles%\World of Warcraft\Logs|*.log
-FileKey7=%Public%\Games\World of Warcraft\Cache|*.*|REMOVESELF
-FileKey8=%Public%\games\World of Warcraft\Errors|*.*|REMOVESELF
-FileKey9=%Public%\games\World of Warcraft\Logs|*.log
-FileKey10=%SystemDrive%\World of Warcraft\Cache|*.*|REMOVESELF
-FileKey11=%SystemDrive%\World of Warcraft\Errors|*.*|REMOVESELF
-FileKey12=%SystemDrive%\World of Warcraft\Logs|*.log
+FileKey1=%ProgramFiles%\World of Warcraft\Cache|*.*|REMOVESELF
+FileKey2=%ProgramFiles%\World of Warcraft\Errors|*.*|REMOVESELF
+FileKey3=%ProgramFiles%\World of Warcraft\Logs|*.log
+FileKey4=%Public%\Games\World of Warcraft\Cache|*.*|REMOVESELF
+FileKey5=%Public%\games\World of Warcraft\Errors|*.*|REMOVESELF
+FileKey6=%Public%\games\World of Warcraft\Logs|*.log
+FileKey7=%SystemDrive%\World of Warcraft\Cache|*.*|REMOVESELF
+FileKey8=%SystemDrive%\World of Warcraft\Errors|*.*|REMOVESELF
+FileKey9=%SystemDrive%\World of Warcraft\Logs|*.log
 
 [World of Warcraft Backups *]
 Section=Games
 Detect=HKCU\Software\Blizzard Entertainment\World of Warcraft
 Default=False
 Warning=This will delete all your World of Warcraft backup files. You won't be able to restore from them if something goes wrong.
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\World of Warcraft|*.bak;*.old|RECURSE
-FileKey2=%ProgramFiles%\World of Warcraft|*.bak;*.old|RECURSE
-FileKey3=%Public%\games\World of Warcraft|*.bak;*.old|RECURSE
-FileKey4=%SystemDrive%\World of Warcraft|*.bak;*.old|RECURSE
+FileKey1=%ProgramFiles%\World of Warcraft|*.bak;*.old|RECURSE
+FileKey2=%Public%\games\World of Warcraft|*.bak;*.old|RECURSE
+FileKey3=%SystemDrive%\World of Warcraft|*.bak;*.old|RECURSE
 
 [WorldWide Telescope *]
 LangSecRef=3021
@@ -19090,16 +18081,13 @@ Detect=HKCU\Software\Wowhead\WowHead Client
 Default=False
 FileKey1=%CommonAppData%\wowhead\wowhead client\cache|*.*|REMOVESELF
 FileKey2=%CommonAppData%\wowhead\wowhead client\log|*.*|REMOVESELF
-FileKey3=%LocalAppData%\VirtualStore\ProgramData\wowhead\wowhead client\cache|*.*|REMOVESELF
-FileKey4=%LocalAppData%\VirtualStore\ProgramData\wowhead\wowhead client\log|*.*|REMOVESELF
 RegKey1=HKCU\Software\Wowhead\WowHead Client|Statistics
 
 [WRAL Desktop Alert *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\WRAL Desktop Alert
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\WRAL Desktop Alert|*.log
-FileKey2=%ProgramFiles%\WRAL Desktop Alert|*.log
+FileKey1=%ProgramFiles%\WRAL Desktop Alert|*.log
 
 [WS FTP Pro *]
 LangSecRef=3022
@@ -19125,8 +18113,7 @@ FileKey2=%AppData%\X-Chat 2\xchatlogs|*.*|REMOVESELF
 LangSecRef=3024
 DetectFile=%ProgramFiles%\X-Cleaner
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\X-Cleaner|XCL_LOG.txt
-FileKey2=%ProgramFiles%\X-Cleaner|XCL_LOG.txt
+FileKey1=%ProgramFiles%\X-Cleaner|XCL_LOG.txt
 
 [X-NetStat *]
 LangSecRef=3024
@@ -19220,7 +18207,6 @@ LangSecRef=3021
 DetectFile=%CommonAppData%\Xerox\PrinterDriver
 Default=False
 FileKey1=%CommonAppData%\Xerox\PrinterDriver|*.tmp|RECURSE
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Xerox\PrinterDriver|*.tmp|RECURSE
 
 [Xilisoft AVI to DVD Converter *]
 LangSecRef=3023
@@ -19260,8 +18246,7 @@ Detect3=HKLM\Software\XnView
 Default=False
 FileKey1=%AppData%\XnView\cache|*.db
 FileKey2=%AppData%\XnViewMP|*.db;category.bak
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\XnViewMP|category.bak;*.db
-FileKey4=%ProgramFiles%\XnViewMP|category.bak;*.db
+FileKey3=%ProgramFiles%\XnViewMP|category.bak;*.db
 RegKey1=HKCU\Software\XnView\Start|DirName_0
 RegKey2=HKCU\Software\XnView\Start|DirName_1
 RegKey3=HKCU\Software\XnView\Start|DirName_2
@@ -19312,7 +18297,6 @@ LangSecRef=3023
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\XPressUpdate.exe
 Default=False
 FileKey1=%CommonProgramFiles%\XpressUpdate|*.log;*old
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Common Files\XpressUpdate|*.log;*old
 
 [Xsplit *]
 LangSecRef=3023
@@ -19322,8 +18306,6 @@ FileKey1=%AppData%\SplitMediaLabs\XSplit|*.log|RECURSE
 FileKey2=%CommonAppData%\SplitMediaLabs\XSplit\LocalStore\Temp|*.*
 FileKey3=%CommonAppData%\SplitMediaLabs\XSplit\Temp|*.*
 FileKey4=%LocalAppData%\SplitMediaLabs\XSplit\*|bwtestlogs.txt
-FileKey5=%LocalAppData%\VirtualStore\ProgramData\SplitMediaLabs\XSplit\LocalStore\Temp|*.*
-FileKey6=%LocalAppData%\VirtualStore\ProgramData\SplitMediaLabs\XSplit\Temp|*.*
 
 [XviD *]
 LangSecRef=3023
@@ -19347,15 +18329,13 @@ FileKey1=%Documents%\XWidget\Backup|*.*|RECURSE
 LangSecRef=3022
 Detect=HKCU\Software\Yahoo!\Autosync for Yahoo!
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Yahoo!\Yahoo! Autosync\Logs|*.*
-FileKey2=%ProgramFiles%\Yahoo!\Yahoo! Autosync\Logs|*.*
+FileKey1=%ProgramFiles%\Yahoo!\Yahoo! Autosync\Logs|*.*
 
 [Yahoo Companion *]
 LangSecRef=3022
 DetectFile=%CommonAppData%\Yahoo! Companion
 Default=False
 FileKey1=%CommonAppData%\Yahoo! Companion\Cache|*.*
-FileKey2=%LocalAppData%\VirtualStore\ProgramData\Yahoo! Companion\Cache|*.*
 
 [YourPhone *]
 DetectOS=10.0|
@@ -19373,8 +18353,7 @@ FileKey6=%LocalAppData%\Packages\Microsoft.YourPhone_*\TempState|*.*|RECURSE
 LangSecRef=3021
 DetectFile=%ProgramFiles%\YPOPs\ypops.exe
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\YPOPs|ypops.log
-FileKey2=%ProgramFiles%\YPOPs|ypops.log
+FileKey1=%ProgramFiles%\YPOPs|ypops.log
 
 [yWriter5 *]
 LangSecRef=3021
@@ -19394,14 +18373,10 @@ FileKey1=%LocalAppData%\Zemana\Zemana AntiMalware\reports|*.txt
 LangSecRef=3021
 Detect=HKCU\Software\Zend\ZendStudio
 Default=False
-FileKey1=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0|*.html
-FileKey2=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0|*.log|RECURSE
-FileKey3=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0\docs|*.txt|REMOVESELF
-FileKey4=%LocalAppData%\VirtualStore\Program Files*\Zend\Zend Studio 10.0.0\features|*.html|RECURSE
-FileKey5=%ProgramFiles%\Zend\Zend Studio 10.0.0|*.html
-FileKey6=%ProgramFiles%\Zend\Zend Studio 10.0.0|*.log|RECURSE
-FileKey7=%ProgramFiles%\Zend\Zend Studio 10.0.0\docs|*.txt|REMOVESELF
-FileKey8=%ProgramFiles%\Zend\Zend Studio 10.0.0\features|*.html|RECURSE
+FileKey1=%ProgramFiles%\Zend\Zend Studio 10.0.0|*.html
+FileKey2=%ProgramFiles%\Zend\Zend Studio 10.0.0|*.log|RECURSE
+FileKey3=%ProgramFiles%\Zend\Zend Studio 10.0.0\docs|*.txt|REMOVESELF
+FileKey4=%ProgramFiles%\Zend\Zend Studio 10.0.0\features|*.html|RECURSE
 
 [Zer0 *]
 LangSecRef=3024


### PR DESCRIPTION
Removed all VirtualStore Keys from winapp2.ini, because most of them were not necessary. Also, no one has added new VirtualStore Keys for years.

Removing the VirtualStore Keys is not a problem, because the upcoming version of Winapp2ool will have an advanced trimming feature that will automatically add VirtualStore Keys if they are present on the system (#356).