### PR TITLE
Restore some entries lost to virtualstore cull

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
 ; Version: 190121
-; # of entries: 2,038
+; # of entries: 2,041
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -2083,6 +2083,13 @@ FileKey1=%AppData%\Adobe\Acrobat\Distiller 11|*.log
 FileKey2=%AppData%\Adobe\Acrobat\Distiller 11\Cache|*.*
 RegKey1=HKCU\Software\Adobe\Acrobat Distiller\PrinterJobControl
 
+[Adobe Acrobat Reader 7.0 *]
+LangSecRef=3021
+Detect=HKCU\Software\Adobe\Acrobat Reader\7.0\AVGeneral
+Default=False
+FileKey1=%ProgramFiles%\Adobe\Acrobat 7.0\ActiveX|*.bak
+FileKey2=%ProgramFiles%\Adobe\Acrobat 7.0\Reader|*.bak|RECURSE
+
 [Adobe Acrobat XI *]
 LangSecRef=3021
 Detect=HKCU\Software\Adobe\Adobe Acrobat\11.0
@@ -2278,6 +2285,12 @@ LangSecRef=3024
 DetectFile=%AppData%\Hulubulu\Advanced Renamer 3
 Default=False
 FileKey1=%AppData%\Hulubulu\Advanced Renamer 3\Data\UndoLists|*.*
+
+[Advanced Searchbar *]
+LangSecRef=3022
+DetectFile=%ProgramFiles%\AdvancedSearchbar\advancedsearchbar.dll
+Default=False
+FileKey1=%ProgramFiles%\AdvancedSearchbar\cache|*.*
 
 [Advanced System Optimizer 3 *]
 LangSecRef=3024
@@ -3994,6 +4007,14 @@ Detect1=HKCU\Software\BlueStacks
 Detect2=HKLM\Software\BlueStacks
 Default=False
 FileKey1=%CommonAppData%\BlueStacksSetup|*.apk
+
+[BlueStacks Installer *]
+LangSecRef=3021
+Detect1=HKCU\Software\Bluestacks
+Detect2=HKLM\Software\Bluestacks
+Default=False
+FileKey1=%CommonAppData%\BlueStacksSetup|runtimedata_*.zip;runtimedata_*.zip.manifest
+FileKey2=%CommonAppData%\BlueStacksSetup\Images|*.*|REMOVESELF
 
 [Bluetack Blocklist Manager *]
 LangSecRef=3024


### PR DESCRIPTION
These entries were removed for having only VirtualStore keys lets restore them with the normal system equivalents