### PR TITLE
Microsoft Edge Insider

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
 ; Version: 190420
-; # of entries: 2,104
+; # of entries: 2,105
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -7079,7 +7079,7 @@ FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|Cookies
 Section=Microsoft Edge Insider
 DetectFile=%LocalAppData%\Microsoft\Edge*
 Default=False
-FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\IndexedDB\https_*.indexeddb.leveldb|*.*|REMOVESELF
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\IndexedDB\https_*.indexeddb.*|*.*|REMOVESELF
 
 [Edge Crash Reports *]
 Section=Microsoft Edge Insider
@@ -7128,7 +7128,7 @@ Section=Microsoft Edge Insider
 DetectFile=%LocalAppData%\Microsoft\Edge*
 Default=False
 FileKey1=%LocalAppData%\Microsoft\Edge*|*.tmp|RECURSE
-FileKey2=%LocalAppData%\Microsoft\Edge*\User Data\*|*-journal
+FileKey2=%LocalAppData%\Microsoft\Edge*\User Data|*-journal|RECURSE
 FileKey3=%LocalAppData%\Microsoft\Edge*\User Data\*\Cache|*.*|RECURSE
 FileKey4=%LocalAppData%\Microsoft\Edge*\User Data\*\File System|*.*|REMOVESELF
 FileKey5=%LocalAppData%\Microsoft\Edge*\User Data\*\GPUCache|*.*|RECURSE
@@ -7173,6 +7173,12 @@ Section=Microsoft Edge Insider
 DetectFile=%LocalAppData%\Microsoft\Edge*
 Default=False
 FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|Shortcuts
+
+[Edge PNaCl Translation Cache *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\PnaclTranslationCache|*.*|RECURSE
 
 [Edge Quota Manager Data *]
 Section=Microsoft Edge Insider

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
 ; Version: 190420
-; # of entries: 2,075
+; # of entries: 2,104
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -7028,6 +7028,206 @@ LangSecRef=3021
 DetectFile=%AppData%\The Toro Company
 Default=False
 FileKey1=%AppData%\The Toro Company|ECXTRAoutput.txt
+
+[Edge Blob Storage *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\blob_storage|*.*|RECURSE
+
+[Edge Bookmarks Backup *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|*Bookmarks.bak
+
+[Edge Bookmarks Icons *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+Warning=This will delete all the icons of your bookmarks. The icons will be rebuilt as websites are manually re-visited.
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|Favicons
+
+[Edge BrowserMetrics *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data|BrowserMetrics-spare.pma
+FileKey2=%LocalAppData%\Microsoft\Edge*\User Data\BrowserMetrics|*.*|RECURSE
+
+[Edge Budget Database *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\BudgetDatabase|*.*|RECURSE
+
+[Edge Code Cache *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\Code Cache|*.*|RECURSE
+FileKey2=%LocalAppData%\Microsoft\Edge*\User Data\*\Storage\ext\*\def\Code Cache|*.*|RECURSE
+
+[Edge Cookies *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+Warning=This will delete all cookies at once. Overrides the option "Cookies to Keep".
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|Cookies
+
+[Edge Cookies CC *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\IndexedDB\https_*.indexeddb.leveldb|*.*|REMOVESELF
+
+[Edge Crash Reports *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\CrashReports|*.*
+FileKey2=%LocalAppData%\Microsoft\Edge*\User Data|CrashpadMetrics*.pma
+FileKey3=%LocalAppData%\Microsoft\Edge*\User Data\Crashpad|metadata
+FileKey4=%LocalAppData%\Microsoft\Edge*\User Data\Crashpad\reports|*.*
+FileKey5=%ProgramFiles%\Microsoft\CrashReports|*.*
+
+[Edge Data Reduction Proxy *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\data_reduction_proxy_leveldb|*.*|RECURSE
+
+[Edge Feature Engagement Tracker *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\Feature Engagement Tracker|*.*|RECURSE
+
+[Edge FlashPlayer AssetCache *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\Pepper Data\Shockwave Flash\CacheWritableAdobeRoot\AssetCache|*.*|RECURSE
+
+[Edge FlashPlayer SharedObjects *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\Pepper Data\Shockwave Flash\WritableRoot\#SharedObjects|*.*|RECURSE
+ExcludeKey1=FILE|%LocalAppData%\Microsoft\Edge*\User Data\*\Pepper Data\Shockwave Flash\WritableRoot\#SharedObjects\*\macromedia.com\support\flashplayer\sys\|settings.sol
+
+[Edge Internet Cache *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|*.ldb;*.log;CURRENT;LOCK;MANIFEST-*;Network Persistent State;Origin Bound Certs
+FileKey2=%LocalAppData%\Microsoft\Edge*\User Data\*\Storage\ext\*\def|Network Persistent State
+
+[Edge Internet Cache CC *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*|*.tmp|RECURSE
+FileKey2=%LocalAppData%\Microsoft\Edge*\User Data\*|*-journal
+FileKey3=%LocalAppData%\Microsoft\Edge*\User Data\*\Cache|*.*|RECURSE
+FileKey4=%LocalAppData%\Microsoft\Edge*\User Data\*\File System|*.*|REMOVESELF
+FileKey5=%LocalAppData%\Microsoft\Edge*\User Data\*\GPUCache|*.*|RECURSE
+FileKey6=%LocalAppData%\Microsoft\Edge*\User Data\*\Service Worker|*.*|REMOVESELF
+FileKey7=%LocalAppData%\Microsoft\Edge*\User Data\*\Storage\ext\*\def\GPUCache|*.*|RECURSE
+FileKey8=%LocalAppData%\Microsoft\Edge*\User Data\ShaderCache\GPUCache|*.*|RECURSE
+
+[Edge Internet History *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|History
+
+[Edge Internet History CC *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|Current Tabs;History Provider Cache;Last Tabs;Network Action Predictor;Top Sites;Visited Links
+
+[Edge Jump List Icons *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\JumpListIcons*|*.*|RECURSE
+
+[Edge Local Storage *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\Local Storage|http*.*|RECURSE
+
+[Edge Logs *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\Application|debug.log
+FileKey2=%LocalAppData%\Microsoft\Edge*\User Data\*|LOG;LOG.old|RECURSE
+FileKey3=%ProgramFiles%\Microsoft\Edge*\Application|debug.log
+
+[Edge Omnibox Shortcuts *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|Shortcuts
+
+[Edge Quota Manager Data *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|QuotaManager
+
+[Edge Saved Passwords CC *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|Login Data
+
+[Edge Session CC *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|Current Session;Last Session
+FileKey2=%LocalAppData%\Microsoft\Edge*\User Data\*\Extension State|*.*|RECURSE
+FileKey3=%LocalAppData%\Microsoft\Edge*\User Data\*\Session Storage|*.*|RECURSE
+
+[Edge SetupMetrics *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\Application\SetupMetrics|*.*|REMOVESELF
+FileKey2=%ProgramFiles%\Microsoft\Edge*\Application\SetupMetrics|*.*|REMOVESELF
+
+[Edge Site Characteristics Database *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\Site Characteristics Database|*.*|RECURSE
+
+[Edge Updates *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\EdgeUpdate\Download|*.*|RECURSE
+FileKey2=%LocalAppData%\Microsoft\EdgeUpdate\Install|*.*|RECURSE
+FileKey3=%ProgramFiles%\Microsoft\EdgeUpdate\Download|*.*|RECURSE
+FileKey4=%ProgramFiles%\Microsoft\EdgeUpdate\Install|*.*|RECURSE
+
+[Edge Video Decode Stats *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\VideoDecodeStats|*.*|RECURSE
+
+[Edge Web Data *]
+Section=Microsoft Edge Insider
+DetectFile=%LocalAppData%\Microsoft\Edge*
+Default=False
+Warning=This will remove Autofill, Autocomplete, Search Engines keyword, Sign-in and Credit Card info.
+FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|Web Data
 
 [Edna & Harvey: Harvey's New Eyes *]
 Section=Games


### PR DESCRIPTION
- Added support for the Chromium-based Microsoft Edge browser.

Tested with the "Dev" and "Canary" builds. Should also work with the upcoming "Beta" build.

The entries marked with "CC" are the built-in "Google Chrome" entries of CCleaner. We have separated them to remove them quickly and easily as soon as CCleaner officially supports the new Microsoft Edge browser.

Many thanks to **siliconman01** from the community for providing most of the entries.