### PR TITLE
Add a rule for system-wide chrome installer

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1352,7 +1352,8 @@ LangSecRef=3029
 Detect1=HKCU\Software\BraveSoftware
 Detect2=HKCU\Software\CocCoc\Browser
 Detect3=HKCU\Software\Torch
-DetectFile=%LocalAppData%\Google\Chrome*
+DetectFile1=%LocalAppData%\Google\Chrome*
+DetectFile2=%ProgramFiles%\Google\Chrome*
 Default=False
 FileKey1=%LocalAppData%\CocCoc\Update\Download|*.*|RECURSE
 FileKey2=%LocalAppData%\CocCoc\Update\Install|*.*|RECURSE
@@ -1369,6 +1370,7 @@ FileKey12=%ProgramFiles%\BraveSoftware\Update\Offline|*.*|RECURSE
 FileKey13=%ProgramFiles%\Google\Update\Download|*.*|RECURSE
 FileKey14=%ProgramFiles%\Google\Update\Install|*.*|RECURSE
 FileKey15=%ProgramFiles%\Google\Update\Offline|*.*|RECURSE
+FileKey16=%ProgramFiles%\Google\Chrome*\Application\*\Installer|*.7z
 
 [Video Decode Stats *]
 LangSecRef=3029


### PR DESCRIPTION
The Chrome installer on my Win7 PC is
```
C:\Program Files (x86)\Google\Chrome\Application\74.0.3729.157\Installer\chrome.7z
```

It's not deleted via current rules.