### PR TITLE
Many game additions

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
-; Version: 190617
-; # of entries: 2,131
+; Version: 190621
+; # of entries: 2,159
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -8916,15 +8916,13 @@ FileKey1=%ProgramFiles%\Steam\steamapps\common\Deserts of Kharak\out\backup|*.*|
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\244160
 Default=False
-FileKey1=%ProgramFiles%\Steam\steamapps\common\Homeworld\Homeworld2Classic\Bin\LOGFILES|*.*
-FileKey2=%ProgramFiles%\Steam\steamapps\common\Homeworld\HomeworldRM\Bin\LOGFILES|*.*
+FileKey1=%ProgramFiles%\Steam\steamapps\common\Homeworld\Homeworld*\Bin\LOGFILES|*.*
 
 [Homeworld Remastered Collection Cache *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\244160
 Default=False
-FileKey1=%ProgramFiles%\Steam\steamapps\common\Homeworld\Homeworld2Classic\Bin\CACHE|*.*|RECURSE
-FileKey2=%ProgramFiles%\Steam\steamapps\common\Homeworld\HomeworldRM\Bin\CACHE|*.*|RECURSE
+FileKey1=%ProgramFiles%\Steam\steamapps\common\Homeworld\Homeworld*\Bin\CACHE|*.*|RECURSE
 
 [Honeyview Bookmarks *]
 LangSecRef=3023

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -3541,7 +3541,7 @@ Detect4=HKCU\Software\Ashampoo\Ashampoo Snap 10
 Default=False
 FileKey1=%Pictures%\Ashampoo Snap *\_SNAPDOC|*.*|RECURSE
 
-[Ashes of the Sinularity *]
+[Ashes of the Singularity *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\507490
 Default=False
@@ -5752,10 +5752,10 @@ Section=Games
 Detect1=HKLM\Software\Valve\Steam\Apps\17300
 Detect2=HKLM\Software\Valve\Steam\Apps\17330
 Detect3=HKLM\Software\Valve\Steam\Apps\108800
-Detect4=HKLM\Software\WOW6432Node\Origin Games\71503
-Detect5=HKLM\Software\WOW6432Node\Origin Games\1003295
-Detect6=HKLM\Software\WOW6432Node\Origin Games\1003302
-Detect7=HKLM\Software\WOW6432Node\Origin Games\1003310
+Detect4=HKLM\Software\Origin Games\71503
+Detect5=HKLM\Software\Origin Games\1003295
+Detect6=HKLM\Software\Origin Games\1003302
+Detect7=HKLM\Software\Origin Games\1003310
 Default=False
 FileKey1=%ProgramFiles%\Origin Games\Crysis *|*.log
 FileKey2=%ProgramFiles%\Origin Games\Crysis *\LogBackups|*.*
@@ -5767,10 +5767,10 @@ Section=Games
 Detect1=HKLM\Software\Valve\Steam\Apps\17300
 Detect2=HKLM\Software\Valve\Steam\Apps\17330
 Detect3=HKLM\Software\Valve\Steam\Apps\108800
-Detect4=HKLM\Software\WOW6432Node\Origin Games\71503
-Detect5=HKLM\Software\WOW6432Node\Origin Games\1003295
-Detect6=HKLM\Software\WOW6432Node\Origin Games\1003302
-Detect7=HKLM\Software\WOW6432Node\Origin Games\1003310
+Detect4=HKLM\Software\Origin Games\71503
+Detect5=HKLM\Software\Origin Games\1003295
+Detect6=HKLM\Software\Origin Games\1003302
+Detect7=HKLM\Software\Origin Games\1003310
 Default=False
 FileKey1=%Documents%\My Games\Crysis*\Shaders\Cache|*.*|RECURSE
 FileKey2=%UserProfile%\Saved Games\Crysis*\Shaders\Cache|*.*|RECURSE
@@ -8847,13 +8847,13 @@ FileKey1=%Documents%\Heroes of Newerth\game|console.log
 
 [Heroes of the Storm *]
 Section=Games
-Detect=HKLM\Software\WOW6432Node\Blizzard Entertainment\Heroes of the Storm
+Detect=HKLM\Software\Blizzard Entertainment\Heroes of the Storm
 Default=False
 FileKey1=%Documents%\Heroes of the Storm\GameLogs|*.*
 
 [Heroes of the Storm Cache *]
 Section=Games
-Detect=HKLM\Software\WOW6432Node\Blizzard Entertainment\Heroes of the Storm
+Detect=HKLM\Software\Blizzard Entertainment\Heroes of the Storm
 Default=False
 FileKey1=%LocalAppData%\Blizzard Entertainment\Heroes of the Storm\BrowserCookies|*.*|RECURSE
 
@@ -10856,9 +10856,9 @@ FileKey2=%ProgramFiles%\Mass Downloader\Index|*.*|RECURSE
 Section=Games
 Detect1=HKCU\Software\Valve\Steam\Apps\17460
 Detect2=HKCU\Software\Valve\Steam\Apps\24980
-Detect3=HKLM\Software\WOW6432Node\BioWare\Mass Effect
-Detect4=HKLM\Software\WOW6432Node\BioWare\Mass Effect 2
-Detect5=HKLM\Software\WOW6432Node\BioWare\Mass Effect 3
+Detect3=HKLM\Software\BioWare\Mass Effect
+Detect4=HKLM\Software\BioWare\Mass Effect 2
+Detect5=HKLM\Software\BioWare\Mass Effect 3
 Default=False
 FileKey1=%Documents%\BioWare\Mass Effect*\BIOGame\Logs|*.*
 FileKey2=%Documents%\BioWare\Mass Effect*\Logs|*.*
@@ -11395,7 +11395,7 @@ FileKey1=%AppData%\mirkes.de\Tiny Hexer\*|*.bak
 
 [Mirrors Edge Catalyst Backup *]
 Section=Games
-Detect=HKLM\Software\WOW6432Node\Origin Games\1026480
+Detect=HKLM\Software\Origin Games\1026480
 Default=False
 Warning=You will not be able to restore old profiles.
 FileKey1=%Documents%\Mirrors Edge Catalyst\settings|PROF_SAVE_backup*
@@ -13400,15 +13400,10 @@ FileKey2=%ProgramFiles%\Osu!|debug-import.txt
 
 [Outlast *]
 Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\238320
+Detect1=HKCU\Software\Valve\Steam\Apps\238320
+Detect2=HKCU\Software\Valve\Steam\Apps\414700
 Default=False
-FileKey1=%Documents%\My Games\Outlast\OLGame\Logs|*.*
-
-[Outlast 2 *]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\414700
-Default=False
-FileKey1=%Documents%\My Games\Outlast2\OLGame\Logs|*.*
+FileKey1=%Documents%\My Games\Outlast*\OLGame\Logs|*.*
 
 [Outlook 2003 *]
 LangSecRef=3021
@@ -13776,21 +13771,11 @@ RegKey3=HKCU\Software\Pelle Orinius\PellesC\Recent Search List
 
 [Penumbra Black Plague *]
 Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\22120
+Detect1=HKCU\Software\Valve\Steam\Apps\22120
+Detect2=HKCU\Software\Valve\Steam\Apps\22140
+Detect3=HKCU\Software\Valve\Steam\Apps\22180
 Default=False
-FileKey1=%Documents%\Penumbra\Black Plague|*.log
-
-[Penumbra Overture *]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\22180
-Default=False
-FileKey1=%Documents%\Penumbra\Requiem|*.log
-
-[Penumbra Requiem *]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\22140
-Default=False
-FileKey1=%Documents%\Penumbra Overture\Episode1|*.log
+FileKey1=%Documents%\Penumbra*\*|*.log
 
 [People *]
 DetectOS=10.0|
@@ -15368,7 +15353,6 @@ Detect6=HKCU\Software\Valve\Steam\Apps\41070
 Detect7=HKCU\Software\Valve\Steam\Apps\204340
 Detect8=HKCU\Software\Valve\Steam\Apps\227780
 Detect9=HKCU\Software\Valve\Steam\Apps\564310
-DetectFile=%ProgramFiles%\Croteam\Serious Sam *
 Default=False
 FileKey1=%ProgramFiles%\Steam\steamApps\Common\Serious Sam *|*.log
 FileKey2=%ProgramFiles%\Steam\steamApps\Common\Serious Sam *\Log|*.*|RECURSE
@@ -16265,8 +16249,7 @@ FileKey2=%Documents%\StarCraft\Errors|*.*
 
 [StarCraft II *]
 Section=Games
-Detect1=HKLM\Software\Blizzard Entertainment\StarCraft II
-Detect2=HKLM\Software\WOW6432Node\Blizzard Entertainment\StarCraft II
+Detect=HKLM\Software\Blizzard Entertainment\StarCraft II
 Default=False
 FileKey1=%Documents%\StarCraft II\*Logs|*.*|RECURSE
 
@@ -19367,17 +19350,12 @@ FileKey10=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\LocalState\PlayReady
 FileKey11=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxLIVEGames_8wekyb3d8bbwe\SearchHistory
 
-[XCOM: Enemy Unknown *]
+[XCOM *]
 Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\200510
+Detect1=HKCU\Software\Valve\Steam\Apps\200510
+Detect2=HKCU\Software\Valve\Steam\Apps\268500
 Default=False
-FileKey1=%Documents%\My Games\Outlast\OLGame\Logs|*.*
-
-[XCOM 2 *]
-Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\268500
-Default=False
-FileKey1=%Documents%\My Games\XCOM2\XComGame\Logs|*.*
+FileKey1=%Documents%\My Games\XCOM*\XComGame\Logs|*.*
 
 [Xenocode Sandbox *]
 LangSecRef=3021

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
 ; Version: 190621
-; # of entries: 2,159
+; # of entries: 2,158
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -5749,13 +5749,13 @@ RegKey1=HKCU\Software\CrypTool2.0|recentFileList
 
 [Crysis *]
 Section=Games
-Detect1=HKLM\Software\Valve\Steam\Apps\17300
-Detect2=HKLM\Software\Valve\Steam\Apps\17330
-Detect3=HKLM\Software\Valve\Steam\Apps\108800
-Detect4=HKLM\Software\Origin Games\71503
-Detect5=HKLM\Software\Origin Games\1003295
-Detect6=HKLM\Software\Origin Games\1003302
-Detect7=HKLM\Software\Origin Games\1003310
+Detect1=HKLM\Software\Origin Games\71503
+Detect2=HKLM\Software\Origin Games\1003295
+Detect3=HKLM\Software\Origin Games\1003302
+Detect4=HKLM\Software\Origin Games\1003310
+Detect5=HKLM\Software\Valve\Steam\Apps\17300
+Detect6=HKLM\Software\Valve\Steam\Apps\17330
+Detect7=HKLM\Software\Valve\Steam\Apps\108800
 Default=False
 FileKey1=%ProgramFiles%\Origin Games\Crysis *|*.log
 FileKey2=%ProgramFiles%\Origin Games\Crysis *\LogBackups|*.*
@@ -5764,13 +5764,13 @@ FileKey4=%ProgramFiles%\Steam\Steamapps\common\Crysis *\LogBackups|*.*
 
 [Crysis Cache *]
 Section=Games
-Detect1=HKLM\Software\Valve\Steam\Apps\17300
-Detect2=HKLM\Software\Valve\Steam\Apps\17330
-Detect3=HKLM\Software\Valve\Steam\Apps\108800
-Detect4=HKLM\Software\Origin Games\71503
-Detect5=HKLM\Software\Origin Games\1003295
-Detect6=HKLM\Software\Origin Games\1003302
-Detect7=HKLM\Software\Origin Games\1003310
+Detect1=HKLM\Software\Origin Games\71503
+Detect2=HKLM\Software\Origin Games\1003295
+Detect3=HKLM\Software\Origin Games\1003302
+Detect4=HKLM\Software\Origin Games\1003310
+Detect5=HKLM\Software\Valve\Steam\Apps\17300
+Detect6=HKLM\Software\Valve\Steam\Apps\17330
+Detect7=HKLM\Software\Valve\Steam\Apps\108800
 Default=False
 FileKey1=%Documents%\My Games\Crysis*\Shaders\Cache|*.*|RECURSE
 FileKey2=%UserProfile%\Saved Games\Crysis*\Shaders\Cache|*.*|RECURSE
@@ -10852,11 +10852,11 @@ FileKey2=%ProgramFiles%\Mass Downloader\Index|*.*|RECURSE
 
 [Mass Effect *]
 Section=Games
-Detect1=HKCU\Software\Valve\Steam\Apps\17460
-Detect2=HKCU\Software\Valve\Steam\Apps\24980
-Detect3=HKLM\Software\BioWare\Mass Effect
-Detect4=HKLM\Software\BioWare\Mass Effect 2
-Detect5=HKLM\Software\BioWare\Mass Effect 3
+Detect1=HKLM\Software\BioWare\Mass Effect
+Detect2=HKLM\Software\BioWare\Mass Effect 2
+Detect3=HKLM\Software\BioWare\Mass Effect 3
+Detect4=HKCU\Software\Valve\Steam\Apps\17460
+Detect5=HKCU\Software\Valve\Steam\Apps\24980
 Default=False
 FileKey1=%Documents%\BioWare\Mass Effect*\BIOGame\Logs|*.*
 FileKey2=%Documents%\BioWare\Mass Effect*\Logs|*.*


### PR DESCRIPTION
Hey everyone.

Well, I had some spare time and figured I would come back to this project. I got a somewhat large update here for you guys. All of them are cleaning rules for various game. Here is the summary of whats new (may not be 100% accurate because I changed some things at last minute).

Modify:

Borderlands

- Removed old Detect 3 as it is uneeded and added support for pre-sequel and GOTY enhanced.

Crysis

- Changed name to Crysis, added support for Crysis 1, Crysis Warhead, and Crysis 2, added support for Origin and Steam installs and cleaning.

DOOM 2016

- Changed name to DOOM 2016, to not be confused with the original DOOM.

Mass Effect

- Changed detects to support both Steam and Origin installs.

Outlast

- Changed FileKey 1.

Serious Sam

- Added support for Classic TFE. Classic TSE, Revolution, TFE HD, SS2, and Fusion. Removed FileKey 1 and 2 because they are uneeded.

StarCraft II

- Added Detect2 for 64-bit path, removed FileKey 1 and 3 as no log files existed in those areas anymore with recent updates.

Added:

AMID EVIL

Ashes of the Sinularity

Crysis Cache

Darksiders Warmastered Edition

Darksiders II Deathinitive Edition Backups

Dead Island Definitive Edition

Dead Island Riptide Definitive Edition

DUSK

Dying Light

Hearthstone

Hearthstone Cache

Heroes of the Storm

Heroes of the Storm Cache

Homeworld: Deserts of Kharak Backups

Homeworld Remastered Collection

Homeworld Remastered Collection Cache

Layers of Fear Cache

Mirrors Edge Catalyst

Observer

Observer Cache

Outlast 2

Painkiller Hell and Damnation

Penumbra Black Plague

Penumbra Overture

Penumbra Requiem

Rise of the Tomb Raider

Slender: The Arrival

SOMA

StarCraft

The Witcher 3 Backups

West of Loathing

XCOM: Enemy Unknown

XCOM 2