### PR TITLE
Refactor Winapp3 Part 2

### DIFF
--- a/Winapp3/Winapp3.ini
+++ b/Winapp3/Winapp3.ini
@@ -229,7 +229,7 @@ ExcludeKey79=PATH|%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft
 [Registry Hive Log Files *]
 Section=Dangerous Long
 Detect=HKLM\Software\Microsoft
-FileKey1=%SystemDrive%|*.blg;*.log1;*.log2;.regtrans-ms|RECURSE
+FileKey1=%SystemDrive%|*.blf;*.log1;*.log2;*.regtrans-ms|RECURSE
 
 ; End of Potentially very long scan time (and also dangerous) entries
 ; 

--- a/Winapp3/Winapp3.ini
+++ b/Winapp3/Winapp3.ini
@@ -1,5 +1,5 @@
-; Version: 191010
-; # of entries: 161
+; Version: 191023
+; # of entries: 155
 ;
 ; Winapp3.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp3.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/Winapp3/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp3.ini for your own program or website, please ask first.
@@ -17,7 +17,6 @@
 [7-Zip Languages *]
 Section=Language Files
 DetectFile=%ProgramFiles%\7-zip
-Default=False
 Warning=This will delete all languages excluding English.
 FileKey1=%ProgramFiles%\7-Zip\Lang|*.*
 ExcludeKey1=FILE|%ProgramFiles%\7-Zip\Lang\|en.ttt
@@ -25,7 +24,6 @@ ExcludeKey1=FILE|%ProgramFiles%\7-Zip\Lang\|en.ttt
 [AIMP Languages *]
 Section=Language Files
 DetectFile=%ProgramFiles%\AIMP\AIMP.exe
-Default=False
 Warning=This will delete all languages excluding English.
 FileKey1=%ProgramFiles%\AIMP\Langs|*.*
 ExcludeKey1=FILE|%ProgramFiles%\AIMP\Langs\|english.lng
@@ -33,21 +31,18 @@ ExcludeKey1=FILE|%ProgramFiles%\AIMP\Langs\|english.lng
 [CCleaner Languages *]
 Section=Language Files
 Detect=HKCU\Software\Piriform\CCleaner
-Default=False
 Warning=This will delete all languages excluding English.
 FileKey1=%ProgramFiles%\CCleaner\Lang|*.*|REMOVESELF
 
 [Defraggler Languages *]
 Section=Language Files
 Detect=HKLM\Software\Piriform\Defraggler
-Default=False
 Warning=This will delete all languages excluding English.
 FileKey1=%ProgramFiles%\Defraggler\Lang|*.*|REMOVESELF
 
 [K-Lite Media Player Classic Languages *]
 Section=Language Files
 Detect=HKLM\Software\Classes\Applications\mpc-hc.exe
-Default=False
 Warning=This will delete all languages excluding the default language.
 FileKey1=%ProgramFiles%\K-Lite Codec Pack\MPC-HC\Lang|*.*|REMOVESELF
 FileKey2=%ProgramFiles%\K-Lite Codec Pack\MPC-HC64\Lang|*.*|REMOVESELF
@@ -56,7 +51,6 @@ FileKey2=%ProgramFiles%\K-Lite Codec Pack\MPC-HC64\Lang|*.*|REMOVESELF
 Section=Language Files
 Detect1=HKCU\Software\Malwarebytes
 Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\mbam.exe
-Default=False
 Warning=This will delete all languages excluding English.
 FileKey1=%ProgramFiles%\Malwarebytes' Anti-Malware\Languages|*.lng
 FileKey2=%ProgramFiles%\Malwarebytes Anti-Malware\Languages|*.qm
@@ -68,14 +62,12 @@ ExcludeKey3=PATH|%ProgramFiles%\Malwarebytes\Anti-Malware\Languages\|lang_en_*.q
 [Recuva Languages *]
 Section=Language Files
 Detect=HKLM\Software\Piriform\Recuva
-Default=False
 Warning=This will delete all languages excluding English.
 FileKey1=%ProgramFiles%\Recuva\Lang|*.*|REMOVESELF
 
 [Revo Uninstaller Pro Languages *]
 Section=Language Files
 Detect=HKCU\Software\VS Revo Group\Revo Uninstaller Pro
-Default=False
 Warning=This will delete all languages excluding English.
 FileKey1=%ProgramFiles%\VS Revo Group\Revo Uninstaller Pro\lang|*.ini
 ExcludeKey1=FILE|%ProgramFiles%\VS Revo Group\Revo Uninstaller Pro\lang\|english.ini
@@ -83,35 +75,30 @@ ExcludeKey1=FILE|%ProgramFiles%\VS Revo Group\Revo Uninstaller Pro\lang\|english
 [Speccy Languages *]
 Section=Language Files
 Detect=HKLM\Software\Piriform\Speccy
-Default=False
 Warning=This will delete all languages excluding English.
 FileKey1=%ProgramFiles%\Speccy\Lang|*.*|REMOVESELF
 
 [Spybot Search and Destroy 2 Languages *]
 Section=Language Files
 Detect=HKCU\Software\Safer Networking Limited\Spybot - Search & Destroy 2
-Default=False
 Warning=This will delete all languages excluding the default language.
 FileKey1=%ProgramFiles%\Spybot - Search & Destroy 2\locale|*.*|REMOVESELF
 
 [TeamSpeak 3 Languages *]
 Section=Language Files
 Detect=HKCU\Software\TeamSpeak 3 Client
-Default=False
 Warning=This will delete all languages excluding the default language.
 FileKey1=%LocalAppData%\TeamSpeak 3 Client\translations|*.qm
 
 [TeraCopy Languages *]
 Section=Language Files
 Detect=HKCU\Software\Code Sector\TeraCopy
-Default=False
 Warning=This will delete all languages excluding English.
 FileKey1=%ProgramFiles%\TeraCopy\locale|*.*
 
 [UltraISO Languages *]
 Section=Language Files
 Detect=HKCU\Software\EasyBoot Systems\UltraISO\5.0
-Default=False
 Warning=This will delete all languages excluding the default languages.
 FileKey1=%ProgramFiles%\UltraISO\lang|*.*|REMOVESELF
 
@@ -122,29 +109,21 @@ FileKey1=%ProgramFiles%\UltraISO\lang|*.*|REMOVESELF
 [Backup Files *]
 Section=Dangerous Long
 Detect=HKLM\Software\Microsoft
-Default=False
 Warning=After using this, you may not be able to use some softwares recovery/restore abilities.
-FileKey1=%SystemDrive%|*.ABF;*.ABK;*.ASD;*.ATE;*.ATI;*.BAK*;*.BCK;*.BCM;*.BDB;*.BKF;*.BKP;*.CBK;*.CRDS;*.CRYPT*;*.DA0;*.FBK;*.FUL;*.MBF;*.MIG;*.OLD;*.ONEPKG;*.ORI;*.QIC;*.RBF;*.SBB;*.TMP;*.TRN;*.VPCBACKUP;*.WBCAT;*.WBK;*.XLK|RECURSE
+FileKey1=%SystemDrive%|*.abf;*.abk;*.asd;*.ate;*.ati;*.bak*;*.bck;*.bcm;*.bdb;*.bkf;*.bkp;*.cbk;*.crds;*.crypt*;*.da0;*.fbk;*.ful;*.mbf;*.mig;*.old;*.onepkg;*.ori;*.qic;*.rbf;*.sbb;*.trn;*.vpcbackup;*.wbcat;*.wbk;*.xlk|RECURSE
 ExcludeKey1=PATH|%ProgramFiles%\Adobe\Adobe Media Encoder CC *\|*.bak
 ExcludeKey2=PATH|%ProgramFiles%\Adobe\Adobe Premiere Pro CC *\|*.bak
-ExcludeKey3=PATH|%SystemDrive%\Boot\|*.bak*
-ExcludeKey4=PATH|%SystemDrive%\Users\*\AppData\Local\Google\Chrome\User Data\*\Local Extension Settings\*\|*.old
-ExcludeKey5=PATH|%SystemDrive%\Users\*\AppData\Roaming\steelseries-engine-*-client\Local Storage\leveldb\|*.old
-ExcludeKey6=PATH|%WinDir%\ServiceProfiles\LocalService\|*.bak*
-ExcludeKey7=PATH|%WinDir%\ServiceProfiles\NetworkService\|*.bak*
-ExcludeKey8=PATH|%WinDir%\System32\config\|*.bak*
-ExcludeKey9=PATH|%WinDir%\SysWOW64\config\|*.bak*
-
-[Binary Performance Log Files *]
-Section=Dangerous Long
-Detect=HKLM\Software\Microsoft
-Default=False
-FileKey1=%SystemDrive%|*.BLG|RECURSE
+ExcludeKey3=PATH|%SystemDrive%\Boot\|BCD.*bak*
+ExcludeKey4=PATH|%WinDir%\ServiceProfiles\LocalService\|NTUSER.*bak*
+ExcludeKey5=PATH|%WinDir%\ServiceProfiles\NetworkService\|NTUSER.*bak*
+ExcludeKey6=PATH|%WinDir%\SysWOW64\config\|DEFAULT.bak*
+ExcludeKey7=PATH|%WinDir%\SysWOW64\config\|SAM.bak*
+ExcludeKey8=PATH|%WinDir%\SysWOW64\config\|SECURITY.bak*
+ExcludeKey9=PATH|%WinDir%\SysWOW64\config\|SOFTWARE.bak*
 
 [Changelog/Help/License/Readme Files *]
 Section=Dangerous Long
 Detect=HKLM\Software\Microsoft
-Default=False
 FileKey1=%ProgramFiles%\Audacity\help\manual|*.*|RECURSE
 FileKey2=%ProgramFiles%\OpenOffice*\program\*\lib\idlelib|CREDITS.txt;NEWS.txt;Todo.txt
 FileKey3=%SystemDrive%|*about*.doc;*about*.rtf;*about*.txt;*Acknowledgements*.rtf;*Acknowledgements*.txt;*agreement*.rtf;*agreement*.txt;*apache2.0*.txt;*bzip2*.txt;*change*.doc;*change*.txt;*changelog*.txt;*contents*.rtf;*contents*.txt;*copying*.doc;*copying*.txt;*copyright*.doc;*copyright*.rtf;*copyright*.txt;*cpl1.0*.txt;*epl*.txt;*eula*.doc;*eula*.html;*eula*.txt;*faq*.htm;*faq*.rtf;*faq*.txt;*gnu*.doc;*gnu*.rtf;*gnu*.txt;*gpl*.doc;*gpl*.rtf;*gpl*.txt;*help*.doc;*help*.htm;*help*.rtf;*help*.txt;*History.txt;*hypersonic*.txt;*icu4j*.txt;*libcurl*.txt;*LICENCE*.rtf;*LICENCE*.txt;*LICENSE*.rtf;*license*.txt;*liesdas*.doc;*liesdas*.rtf;*liesdas*.txt;*liesmich*.doc;*liesmich*.rtf;*liesmich*.txt;*LIZENS*.doc;*LIZENS*.rtf;*lizens*.txt;*Lizenz*.doc;*Lizenz*.rtf;*Lizenz*.txt;*loaderbinarylegal*.txt;*notice.txt;*NSIS*.txt;*openssl*.txt;*readme*.htm;*readme*.rtf;*readme*.txt;*release*.rtf;*release*.txt;*THIRDPARTY*.doc;*THIRDPARTY*.rtf;*THIRDPARTY*.txt;*THIRDPARTYLICENSE.txt;*THIRDPARTYLICENSEREADME*.htm;*THIRDPARTYLICENSEREADME*.rtf;*THIRDPARTYLICENSEREADME*.txt;*ThirdPartyNotices*.doc;*ThirdPartyNotices*.rtf;*ThirdPartyNotices*.txt;*whatsnew*.doc;*whatsnew*.rtf;*whatsnew*.txt;*xstream*.txt;libxml2.txt;release*notes*.txt;third-party_attributions.txt|RECURSE
@@ -152,55 +131,21 @@ FileKey3=%SystemDrive%|*about*.doc;*about*.rtf;*about*.txt;*Acknowledgements*.rt
 [Desktop.ini Files *]
 Section=Dangerous Long
 Detect=HKLM\Software\Microsoft
-Default=False
 Warning=This possibly will break the function of shell folders. Do not use on non-English systems.
 FileKey1=%SystemDrive%|desktop.ini|RECURSE
-
-[Error Log Files *]
-Section=Dangerous Long
-Detect=HKLM\Software\Microsoft
-Default=False
-FileKey1=%SystemDrive%|*.ERR|RECURSE
-
-[Exchange Reserve Transaction Log Files *]
-Section=Dangerous Long
-Detect=HKLM\Software\Microsoft\Exchange
-Default=False
-FileKey1=%SystemDrive%|*.JRS|RECURSE
 
 [Flash Local Shared Object Files *]
 Section=Dangerous Long
 Detect=HKLM\Software\Microsoft
-Default=False
 Warning=This will delete Solidity scripts also.
-FileKey1=%SystemDrive%|*.SOL|RECURSE
+FileKey1=%SystemDrive%|*.sol|RECURSE
 ExcludeKey1=FILE|%SystemDrive%\*\|Fontmap.Sol
 
-[Gather Log Files *]
+[Junk File Extensions *]
 Section=Dangerous Long
 Detect=HKLM\Software\Microsoft
-Default=False
-Warning=Log files created after each file indexing process.
-FileKey1=%SystemDrive%|*.GTHR|RECURSE
-
-[Registry Hive Log Files *]
-Section=Dangerous Long
-Detect=HKLM\Software\Microsoft
-Default=False
-FileKey1=%SystemDrive%|*.LOG1;*.LOG2|RECURSE
-
-[Registry Transaction Log Files *]
-Section=Dangerous Long
-Detect=HKLM\Software\Microsoft
-Default=False
-FileKey1=%SystemDrive%|*.BLF;*.REGTRANS-MS|RECURSE
-
-[Useless File Extensions *]
-Section=Dangerous Long
-Detect=HKLM\Software\Microsoft
-Default=False
-Warning=While this is intended to delete useless files, it may also break software. Be sure to review files found before deleting.
-FileKey1=%SystemDrive%|*.~??;*.---;*.$$$;*.$db;*.?$?;*.??$;*.??~;*.?~?;*.^;*.___;*._dd;*._detmp;*._mp;*.~*;*.~mp;*.aps;*.chk;*.crash;*.db$;*.diz;*.dmp;*.ftg;*.fts;*.gid;*.ilk;*.log;*.log?;*.ncb;*.nch;*.pch;*.prv;*.sik;*.temp;*.tmp;*.wbk;*Cache*.txt;*error*.html;*error*.rtf;*error*.txt;*error*.xml;*ERRORLOG*;*fix*.txt*;*log.dat;*log.txt;*report*.xml;*report.txt;*tmp*.dat;*tmp.rtf;chklist.*;CHKLIST.MS;log*.txt;mscreate.dir|RECURSE
+Warning=While this is intended to delete junk files, it may also break software. Be sure to review files found before deleting.
+FileKey1=%SystemDrive%|*.~??;*.---;*.$$$;*.$db;*.?$?;*.??$;*.??~;*.?~?;*.^;*.___;*._dd;*._detmp;*._mp;*.~*;*.~mp;*.aps;*.blg;*.chk;*.crash;*.db$;*.diz;*.dmp;*.err;*.ftg;*.fts;*.gid;*.gthr;*.ilk;*.jrs;*.log;*.log?;*.ncb;*.nch;*.pch;*.prv;*.sik;*.temp;*.tmp;*.wbk;*Cache*.txt;*error*.html;*error*.rtf;*error*.txt;*error*.xml;*ERRORLOG*;*fix*.txt*;*log.dat;*log.txt;*report*.xml;*report.txt;*tmp*.dat;*tmp.rtf;chklist.*;CHKLIST.MS;log*.txt;mscreate.dir|RECURSE
 ExcludeKey1=FILE|%CommonAppData%\Microsoft\Network\Downloader\|edb.chk
 ExcludeKey2=FILE|%CommonAppData%\Microsoft\SmsRouter\MessageStore\|edb.chk
 ExcludeKey3=FILE|%ProgramFiles%\Adobe\Adobe Photoshop CC *\Required\Linguistics\Providers\Plugins2\AdobeHunspellPlugin\dictionaries\*\|Changelog.txt
@@ -235,50 +180,56 @@ ExcludeKey31=PATH|%CommonAppData%\Microsoft\Search\Data\Applications\Windows\|*.
 ExcludeKey32=PATH|%ProgramFiles%\Mozilla*\|*.chk
 ExcludeKey33=PATH|%SystemDrive%\|settings.dat.LOG*
 ExcludeKey34=PATH|%SystemDrive%\|UsrClass.dat.LOG*
-ExcludeKey35=PATH|%SystemDrive%\Boot\|*.LOG*
-ExcludeKey36=PATH|%SystemDrive%\Documents and Settings\*\|NTUSER.DAT.LOG*
+ExcludeKey35=PATH|%SystemDrive%\Boot\|BCD.*LOG*
+ExcludeKey36=PATH|%SystemDrive%\Documents and Settings\*\|NTUSER.*LOG*
 ExcludeKey37=PATH|%SystemDrive%\Documents and Settings\*\Local Settings\Application Data\Microsoft\Windows\|UsrClass.dat.LOG*
 ExcludeKey38=PATH|%SystemDrive%\Documents and Settings\*\Local Settings\Application Data\Microsoft\Windows\WebCache\|*V01*.*
-ExcludeKey39=PATH|%SystemDrive%\EFI\Microsoft\boot\|BCD.LOG*
-ExcludeKey40=PATH|%SystemDrive%\Users\*\|NTUSER.DAT.LOG*
+ExcludeKey39=PATH|%SystemDrive%\EFI\Microsoft\boot\|BCD.*LOG*
+ExcludeKey40=PATH|%SystemDrive%\Users\*\|NTUSER.*LOG*
 ExcludeKey41=PATH|%SystemDrive%\Users\*\AppData\Local\Google\Chrome\User Data\*\Extensions\*\*\ui\|*.html
-ExcludeKey42=PATH|%SystemDrive%\Users\*\AppData\Local\Google\Chrome\User Data\*\JumpListIconsRecentClosed\|*.tmp
-ExcludeKey43=PATH|%SystemDrive%\Users\*\AppData\Local\Microsoft\Windows\|UsrClass.dat.LOG*
-ExcludeKey44=PATH|%SystemDrive%\Users\*\AppData\Local\Microsoft\Windows\Explorer\*CacheToDelete\|*.tmp
-ExcludeKey45=PATH|%SystemDrive%\Users\*\AppData\Local\Microsoft\Windows\WebCache\|*V01*.*
-ExcludeKey46=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\*\*\ActivationStore\|ActivationStore.dat.LOG*
-ExcludeKey47=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\*\Settings\|settings.dat.LOG*
-ExcludeKey48=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\Microsoft.*Cortana_*\AC\AppCache\EGFPDUEB\1\|*.txt
-ExcludeKey49=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\Microsoft.*Cortana_*\AppData\Indexed DB\|*.chk;*.log
-ExcludeKey50=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\Microsoft.*Cortana_*\LocalState\|speech_onecorereg.bin.LOG*
-ExcludeKey51=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\Microsoft.*Cortana_*\LocalState\DeviceSearchCache\|*.txt
-ExcludeKey52=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\DataStore\Data\*\*\DBStore\|*.chk
-ExcludeKey53=PATH|%SystemDrive%\Users\*\AppData\Local\TileDataLayer\Database\|EDB*.*
-ExcludeKey54=PATH|%SystemDrive%\Users\*\AppData\Roaming\steelseries-engine-*-client\Local Storage\leveldb\|*.LOG*
-ExcludeKey55=PATH|%SystemDrive%\Users\All Users\Microsoft\Search\Data\Applications\Windows\|*.chk;*.log
-ExcludeKey56=PATH|%WinDir%\appcompat\Programs\|*.LOG*
-ExcludeKey57=PATH|%WinDir%\Panther\|*.tmp
-ExcludeKey58=PATH|%WinDir%\ServiceProfiles\LocalService\|*.LOG*
-ExcludeKey59=PATH|%WinDir%\ServiceProfiles\NetworkService\|*.LOG*
-ExcludeKey60=PATH|%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\State\|*.LOG*
-ExcludeKey61=PATH|%WinDir%\SoftwareDistribution\DataStore\Logs\|edb*.*
-ExcludeKey62=PATH|%WinDir%\System32\config\|*.LOG*
-ExcludeKey63=PATH|%WinDir%\System32\config\bbimigrate\|*.LOG*
-ExcludeKey64=PATH|%WinDir%\System32\config\RegBack\|*.LOG*
-ExcludeKey65=PATH|%WinDir%\System32\config\systemprofile\|*.LOG*
-ExcludeKey66=PATH|%WinDir%\System32\SMI\Store\Machine\|*.LOG*
-ExcludeKey67=PATH|%WinDir%\SysWOW64\config\|*.LOG*
-ExcludeKey68=PATH|%WinDir%\SysWOW64\config\systemprofile\|*.LOG*
-ExcludeKey69=PATH|%WinDir%\SysWOW64\config\systemprofile\AppData\Local\|*.tmp
-ExcludeKey70=PATH|%WinDir%\SysWOW64\config\systemprofile\AppData\Local\DataSharing\Storage\|*.chk;*.log
-ExcludeKey71=PATH|%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache\|*.chk
+ExcludeKey42=PATH|%SystemDrive%\Users\*\AppData\Local\Microsoft\Windows\|UsrClass.dat.LOG*
+ExcludeKey43=PATH|%SystemDrive%\Users\*\AppData\Local\Microsoft\Windows\WebCache\|*V01*.*
+ExcludeKey44=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\*\*\ActivationStore\|ActivationStore.dat.LOG*
+ExcludeKey45=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\*\Settings\|settings.dat.LOG*
+ExcludeKey46=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\Microsoft.*Cortana_*\AppData\Indexed DB\|*.chk;*.log
+ExcludeKey47=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\Microsoft.*Cortana_*\LocalState\|speech_onecorereg.bin.LOG*
+ExcludeKey48=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\Microsoft.*Cortana_*\LocalState\DeviceSearchCache\|*.txt
+ExcludeKey49=PATH|%SystemDrive%\Users\*\AppData\Local\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\DataStore\Data\*\*\DBStore\|*.chk
+ExcludeKey50=PATH|%SystemDrive%\Users\*\AppData\Local\TileDataLayer\Database\|EDB*.*
+ExcludeKey51=PATH|%SystemDrive%\Users\*\AppData\Roaming\steelseries-engine-*-client\Local Storage\leveldb\|*.log
+ExcludeKey52=PATH|%SystemDrive%\Users\All Users\Microsoft\Search\Data\Applications\Windows\|*.chk;*.log
+ExcludeKey53=PATH|%WinDir%\appcompat\Programs\|*.LOG*
+ExcludeKey54=PATH|%WinDir%\ServiceProfiles\LocalService\|NTUSER.*LOG*
+ExcludeKey55=PATH|%WinDir%\ServiceProfiles\NetworkService\|NTUSER.*LOG*
+ExcludeKey56=PATH|%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\State\|*.LOG*
+ExcludeKey57=PATH|%WinDir%\SoftwareDistribution\DataStore\Logs\|edb*.*
+ExcludeKey58=PATH|%WinDir%\System32\config\|BBI.LOG*
+ExcludeKey59=PATH|%WinDir%\System32\config\|BCD-Template.LOG*
+ExcludeKey60=PATH|%WinDir%\System32\config\|COMPONENTS.LOG*
+ExcludeKey61=PATH|%WinDir%\System32\config\|DEFAULT.LOG*
+ExcludeKey62=PATH|%WinDir%\System32\config\|DRIVERS.LOG*
+ExcludeKey63=PATH|%WinDir%\System32\config\|ELAM.LOG*
+ExcludeKey64=PATH|%WinDir%\System32\config\|SAM.LOG*
+ExcludeKey65=PATH|%WinDir%\System32\config\|SECURITY.LOG*
+ExcludeKey66=PATH|%WinDir%\System32\config\|SOFTWARE.LOG*
+ExcludeKey67=PATH|%WinDir%\System32\config\|SYSTEM.LOG*
+ExcludeKey68=PATH|%WinDir%\System32\config\|userdiff.LOG*
+ExcludeKey69=PATH|%WinDir%\System32\config\bbimigrate\|*.LOG*
+ExcludeKey70=PATH|%WinDir%\System32\config\RegBack\|*.LOG*
+ExcludeKey71=PATH|%WinDir%\System32\config\systemprofile\|NTUSER.*LOG*
+ExcludeKey72=PATH|%WinDir%\System32\SMI\Store\Machine\|SCHEMA.DAT.LOG*
+ExcludeKey73=PATH|%WinDir%\SysWOW64\config\|DEFAULT.*LOG*
+ExcludeKey74=PATH|%WinDir%\SysWOW64\config\|SAM.*LOG*
+ExcludeKey75=PATH|%WinDir%\SysWOW64\config\|SECURITY.*LOG*
+ExcludeKey76=PATH|%WinDir%\SysWOW64\config\|SOFTWARE.*LOG*
+ExcludeKey77=PATH|%WinDir%\SysWOW64\config\systemprofile\|NTUSER.*LOG*
+ExcludeKey78=PATH|%WinDir%\SysWOW64\config\systemprofile\AppData\Local\DataSharing\Storage\|*.chk;*.log
+ExcludeKey79=PATH|%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache\|*.chk
 
-[Usual Log Files *]
+[Registry Hive Log Files *]
 Section=Dangerous Long
 Detect=HKLM\Software\Microsoft
-Default=False
-Warning=You should not delete these files if they are in a Chrome/Chromium profile.
-FileKey1=%SystemDrive%|*.LOG|RECURSE
+FileKey1=%SystemDrive%|*.blg;*.log1;*.log2;.regtrans-ms|RECURSE
 
 ; End of Potentially very long scan time (and also dangerous) entries
 ; 
@@ -287,20 +238,17 @@ FileKey1=%SystemDrive%|*.LOG|RECURSE
 [3DMark Saved Benchmarks *]
 Section=Dangerous Games
 DetectFile=%Documents%\3DMark
-Default=False
 FileKey1=%Documents%\3DMark|*.3dmark-result
 
 [Adobe Acrobat Setup Files *]
 Section=Dangerous Applications
 Detect=HKCU\Software\Adobe\Adobe Acrobat
-Default=False
 Warning=This will prevent a repair installation and successful online updates. You will need to download the installer for a reinstallation.
 FileKey1=%ProgramFiles%\Adobe\Acrobat*\Setup Files|*.*|REMOVESELF
 
 [Adobe Reader Setup Files *]
 Section=Dangerous Applications
 Detect=HKLM\Software\Adobe\Acrobat Reader
-Default=False
 Warning=This will prevent a repair installation and successful online updates. You will need to download the installer for a reinstallation.
 FileKey1=%CommonAppData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AA1000000001}|*.*|RECURSE
 FileKey2=%CommonAppData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AB0000000001}|*.*|RECURSE
@@ -310,13 +258,11 @@ FileKey4=%ProgramFiles%\Adobe\*Reader*\Setup Files|*.*|REMOVESELF
 [Agent NewsReader *]
 Section=Dangerous Applications
 DetectFile=%ProgramFiles%\Agent
-Default=False
 FileKey1=%ProgramFiles%\Agent\Data|*.BAK;*.DAT;*.IDX
 
 [All App Packages *]
 Section=Dangerous Windows Store
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData
-Default=False
 FileKey1=%LocalAppData%\Packages\*\AC\AppCache|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\*\AC\BackgroundTransferApi|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\*\AC\INet*|*.*|RECURSE
@@ -341,7 +287,6 @@ Detect1=HKLM\Software\AMD
 Detect2=HKLM\Software\ATI
 Detect3=HKLM\Software\ATI Technologies
 DetectFile=%ProgramFiles%\ATI Technologies\ATI.ACE
-Default=False
 Warning=This will delete your promo videos. You cannot restore back.
 FileKey1=%ProgramFiles%\ATI Technologies\ATI.ACE\Core-Static|*.mp4
 FileKey2=%WinDir%\winsxs\amd64_microsoft-windows-videosamples_*|Wildlife.wmv
@@ -349,7 +294,6 @@ FileKey2=%WinDir%\winsxs\amd64_microsoft-windows-videosamples_*|Wildlife.wmv
 [Anvisoft Cloud System Booster Backups *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\Anvisoft\Cloud System Booster
-Default=False
 Warning=This will delete your backups. You will be unable to undo any changes made with Cloud System Booster.
 FileKey1=%LocalAppData%\Anvisoft\Anvi Slim Toolbar\FFToobar|*.*|REMOVESELF
 FileKey2=%LocalAppData%\Anvisoft\Anvi Slim Toolbar\IEToobar|*.*|REMOVESELF
@@ -358,14 +302,12 @@ FileKey3=%ProgramFiles%\Anvisoft\Cloud System Booster\bak|*.*
 [Anvsoft Any Video Converter Output *]
 Section=Dangerous Multimedia
 Detect=HKCU\Software\AnvSoft\Any Video Converter
-Default=False
 Warning=This will delete the contents of your output folder.
 FileKey1=%Documents%\Any Video Converter|*.*|RECURSE
 
 [Apple Installer Cache *]
 Section=Dangerous Multimedia
 Detect=HKCU\Software\Apple Computer, Inc.
-Default=False
 Warning=You have to reinstall iTunes after adding a new Windows user account.
 FileKey1=%CommonAppData%\Apple Computer\Installer Cache|*.*|REMOVESELF
 FileKey2=%CommonAppData%\Apple\Installer Cache|*.*|REMOVESELF
@@ -373,33 +315,28 @@ FileKey2=%CommonAppData%\Apple\Installer Cache|*.*|REMOVESELF
 [Apple iPhone Updater Logs *]
 Section=Dangerous Multimedia
 Detect=HKLM\Software\Apple Computer, Inc.
-Default=False
 FileKey1=%AppData%\Apple Computer\iTunes\iPhone Updater Logs|*.*
 
 [Apple iTunes Media Mobile Applications *]
 Section=Dangerous Multimedia
 Detect=HKLM\Software\Apple Computer, Inc.
-Default=False
 Warning=This will delete your mobile applications backed up by iTunes.
 FileKey1=%Music%\iTunes\iTunes Media\Mobile Applications|*.*|RECURSE
 
 [Background Activity Moderator *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft
-Default=False
 RegKey1=HKLM\System\CurrentControlSet\Services\bam\State\UserSettings
 
 [Bandicam Output *]
 Section=Dangerous Multimedia
 Detect=HKCU\Software\BANDISOFT\BANDICAM
-Default=False
 Warning=This will delete the contents of your output folder.
 FileKey1=%Documents%\Bandicam|*.*|RECURSE
 
 [BleachBit Console Removal *]
 Section=Dangerous Utilities
 Detect=HKCU\Software\BleachBit
-Default=False
 Warning=This removes the debugger for BleachBit. Don't use if you need it.
 FileKey1=%ProgramFiles%\BleachBit|bleachbit_console.exe
 
@@ -407,41 +344,35 @@ FileKey1=%ProgramFiles%\BleachBit|bleachbit_console.exe
 Section=Dangerous Applications
 Detect1=HKCU\Software\BlueStacks
 Detect2=HKLM\Software\BlueStacks
-Default=False
 FileKey1=%CommonAppData%\BlueStacks\UserData\SharedFolder|*.*
 
 [Brawlhalla Replays *]
 Section=Dangerous Games
 DetectFile=%UserProfile%\BrawlhallaReplays
-Default=False
 Warning=You will delete your saved replays.
 FileKey1=%UserProfile%\BrawlhallaReplays|*.replay|REMOVESELF
 
 [CCleaner 32-bit Removal *]
 Section=Dangerous Utilities
 Detect=HKCU\Software\Piriform\CCleaner
-Default=False
 Warning=Only use if you use the 64-bit version.
 FileKey1=%ProgramFiles%\CCleaner|CCleaner.exe
 
 [CCleaner 64-bit Removal *]
 Section=Dangerous Utilities
 Detect=HKCU\Software\Piriform\CCleaner
-Default=False
 Warning=Only use if you use the 32-bit version.
 FileKey1=%ProgramFiles%\CCleaner|CCleaner64.exe
 
 [CCleaner Updater Removal *]
 Section=Dangerous Utilities
 Detect=HKCU\Software\Piriform\CCleaner
-Default=False
 Warning=You will need to manually update CCleaner after running this.
 FileKey1=%ProgramFiles%\CCleaner|CCupdater.exe
 
 [CheckDisk Restored Files Folder *]
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft
-Default=False
 Warning=This will delete all your restored files you have restored with Windows CheckDisk on all drives.
 FileKey1=%SystemDrive%\FOUND.*|*.*|REMOVESELF
 FileKey2=C:\FOUND.*|*.*|REMOVESELF
@@ -492,7 +423,6 @@ Detect18=HKCU\Software\Vivaldi
 Detect19=HKCU\Software\Yandex\YandexBrowser
 DetectFile1=%AppData%\brave
 DetectFile2=%LocalAppData%\Google\Chrome*
-Default=False
 Warning=This may cause some extensions to not work as intended.
 FileKey1=%AppData%\brave\IndexedDB|*.*|RECURSE
 FileKey2=%LocalAppData%\7Star\7Star\User Data\*\IndexedDB|*.*|RECURSE
@@ -534,7 +464,6 @@ Detect13=HKCU\Software\Torch
 Detect14=HKCU\Software\Vivaldi
 Detect15=HKCU\Software\Yandex\YandexBrowser
 DetectFile=%LocalAppData%\Google\Chrome*
-Default=False
 Warning=This will prevent successful online updates. You will need to download the installer for a reinstallation.
 FileKey1=%LocalAppData%\7Star\7Star\Application\*\Installer|*.7z
 FileKey2=%LocalAppData%\360Browser\Browser\Application\*\Installer|*.7z
@@ -578,7 +507,6 @@ Detect18=HKCU\Software\Vivaldi
 Detect19=HKCU\Software\Yandex\YandexBrowser
 DetectFile1=%AppData%\brave
 DetectFile2=%LocalAppData%\Google\Chrome*
-Default=False
 Warning=This may cause some extensions to not work as intended.
 FileKey1=%AppData%\brave\Local Storage\leveldb|*.*
 FileKey2=%LocalAppData%\7Star\7Star\User Data\*\Local Storage\leveldb|*.*
@@ -605,14 +533,12 @@ FileKey21=%LocalAppData%\Yandex\YandexBrowser\User Data\*\Local Storage\leveldb|
 [Chrome Software Reporter *]
 Section=Dangerous Google Chrome
 DetectFile=%LocalAppData%\Google\Chrome*
-Default=False
 Warning=Removes the Software Reporter Tool ("Clean up computer").
 FileKey1=%LocalAppData%\Google\Chrome*\User Data\SwReporter|*.*|RECURSE
 
 [CONEXANT Driver Installation Files *]
 Section=Dangerous Utilities
 DetectFile=%ProgramFiles%\CONEXANT
-Default=False
 FileKey1=%ProgramFiles%\CONEXANT\PREINSTALL|*.*|REMOVESELF
 FileKey2=%WinDir%\Cnxt|*.*|REMOVESELF
 FileKey3=%WinDir%\UCI|*.*|REMOVESELF
@@ -620,13 +546,11 @@ FileKey3=%WinDir%\UCI|*.*|REMOVESELF
 [Container.dat Files *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft
-Default=False
 FileKey1=%UserProfile%\AppData|Container.dat|RECURSE
 
 [Credentials *]
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft\Windows
-Default=False
 Warning=This will remove all your locally stored user names and passwords.
 FileKey1=%AppData%\Microsoft\Credentials|*.*|RECURSE
 FileKey2=%LocalAppData%\Microsoft\Credentials|*.*|RECURSE
@@ -637,7 +561,6 @@ FileKey4=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Credent
 Section=Dangerous Applications
 Detect1=HKCU\Software\Microsoft\Office
 Detect2=HKLM\Software\Microsoft\Office
-Default=False
 Warning=This will only temporarily disable the Microsoft Office installed file ctfmon.exe from starting with Windows.
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Run|ctfmon.exe
 RegKey2=HKLM\Software\Microsoft\Windows\CurrentVersion\Run|ctfmon.exe
@@ -646,67 +569,57 @@ RegKey3=HKU\.DEFAULT\Software\Microsoft\Windows\CurrentVersion\Run|ctfmon.exe
 [CyberLink PowerDVD Playlists *]
 Section=Dangerous Multimedia
 Detect=HKCU\Software\Cyberlink\PowerDVD
-Default=False
 FileKey1=%Documents%\CyberLink\PowerDVD|*.pls
 FileKey2=%ProgramFiles%\CyberLink\PowerDVD|*.pls
 
 [Defraggler 32-bit Removal *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\Piriform\Defraggler
-Default=False
 Warning=Only use if you use the 64-bit version.
 FileKey1=%ProgramFiles%\Defraggler|Defraggler.exe;df.exe
 
 [Defraggler 64-bit Removal *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\Piriform\Defraggler
-Default=False
 Warning=Only use if you use the 32-bit version.
 FileKey1=%ProgramFiles%\Defraggler|Defraggler64.exe;df64.exe
 
 [Delivery Optimization Files *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft\Windows
-Default=False
 FileKey1=%WinDir%\SoftwareDistribution\DeliveryOptimization|*.*|RECURSE
 RegKey1=HKLM\Software\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Jobs
 
 [Dolphin Emulator Dumps *]
 Section=Dangerous Games
 DetectFile=%Documents%\Dolphin Emulator
-Default=False
 FileKey1=%Documents%\Dolphin Emulator\Dump|*.*|RECURSE
 
 [Downloaded Installations *]
 Section=Dangerous Windows
 DetectFile=%LocalAppData%\Downloaded Installations
-Default=False
 Warning=This prevents a modification of some program installations. You must download the installer to modify these installations.
 FileKey1=%LocalAppData%\Downloaded Installations|*.*|REMOVESELF
 
 [Downloaded Program Files *]
 Section=Dangerous Windows
 DetectFile=%WinDir%\Downloaded Program Files
-Default=False
 FileKey1=%WinDir%\Downloaded Program Files|*.*|REMOVESELF
 
 [Eclipse Workspace *]
 Section=Dangerous Applications
 DetectFile=%UserProfile%\workspace
-Default=False
 FileKey1=%UserProfile%\workspace|*.*|RECURSE
 
 [Edge Indexed Database Extended *]
 Section=Dangerous Microsoft Edge Insider
 DetectFile=%LocalAppData%\Microsoft\Edge*
-Default=False
 Warning=This may cause some extensions to not work as intended.
 FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\IndexedDB|*.*|RECURSE
 
 [Edge Installer *]
 Section=Dangerous Microsoft Edge Insider
 DetectFile=%LocalAppData%\Microsoft\Edge*
-Default=False
 Warning=This will prevent successful online updates. You will need to download the installer for a reinstallation.
 FileKey1=%LocalAppData%\Microsoft\Edge*\Application\*\Installer|*.7z
 FileKey2=%ProgramFiles%\Microsoft\Edge*\Application\*\Installer|*.7z
@@ -714,7 +627,6 @@ FileKey2=%ProgramFiles%\Microsoft\Edge*\Application\*\Installer|*.7z
 [Edge Local Storage Extended *]
 Section=Dangerous Microsoft Edge Insider
 DetectFile=%LocalAppData%\Microsoft\Edge*
-Default=False
 Warning=This may cause some extensions to not work as intended.
 FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*\Local Storage\leveldb|*.*
 
@@ -723,7 +635,6 @@ DetectOS=6.0|6.0
 Section=Dangerous Utilities
 DetectFile1=%ProgramFiles%\ERUNT\ERUNT.EXE
 DetectFile2=%ProgramFiles%\ERUNT\NTREGOPT.EXE
-Default=False
 FileKey1=%LocalAppData%\Microsoft\Windows|UsrClass.bak;UsrClass.tmp.LOG*
 FileKey2=%SystemDrive%\Boot|BCD.bak;BCD.tmp.LOG*
 FileKey3=%UserProfile%|NTUSER.bak;NTUSER.tmp.LOG*
@@ -737,7 +648,6 @@ DetectOS=|5.1
 Section=Dangerous Utilities
 DetectFile1=%ProgramFiles%\ERUNT\ERUNT.EXE
 DetectFile2=%ProgramFiles%\ERUNT\NTREGOPT.EXE
-Default=False
 FileKey1=%AppData%\Microsoft\Windows|UsrClass.bak;UsrClass.tmp.LOG
 FileKey2=%SystemDrive%\Documents and Settings\Administrator|NTUSER.bak;NTUSER.tmp.LOG
 FileKey3=%SystemDrive%\Documents and Settings\Administrator\Local Settings\Application Data\Microsoft\Windows|UsrClass.bak;UsrClass.tmp.LOG
@@ -757,7 +667,6 @@ Detect2=HKLM\Software\Mozilla\Pale Moon
 Detect3=HKLM\Software\Mozilla\SeaMonkey
 Detect4=HKLM\Software\Mozilla\Waterfox
 DetectFile=%AppData%\Mozilla\Firefox
-Default=False
 FileKey1=%ProgramFiles%\Firefox*|*.chk|RECURSE
 FileKey2=%ProgramFiles%\Mozilla*|*.chk|RECURSE
 FileKey3=%ProgramFiles%\Pale Moon|*.chk|RECURSE
@@ -772,7 +681,6 @@ Detect2=HKLM\Software\Mozilla\Pale Moon
 Detect3=HKLM\Software\Mozilla\SeaMonkey
 Detect4=HKLM\Software\Mozilla\Waterfox
 DetectFile=%AppData%\Mozilla\Firefox
-Default=False
 Warning=This can lead to a slow start of the browser.
 FileKey1=%AppData%\FlashPeak\SlimBrowser\Profiles\*\storage|*.*|RECURSE
 FileKey2=%AppData%\Moonchild Productions\Pale Moon\Profiles\*\storage|*.*|RECURSE
@@ -789,7 +697,6 @@ ExcludeKey5=PATH|%AppData%\Waterfox\Profiles\*\storage\default\moz-extension+++*
 Section=Dangerous Firefox
 Detect=HKLM\Software\Mozilla\Waterfox
 DetectFile=%AppData%\Mozilla\Firefox
-Default=False
 Warning=The folders are created as part of the "Refresh Firefox" process and can contain important data.
 FileKey1=%UserProfile%\Desktop\Old Firefox Data*|*.*|REMOVESELF
 FileKey2=%UserProfile%\Desktop\Old Waterfox Data*|*.*|REMOVESELF
@@ -797,21 +704,18 @@ FileKey2=%UserProfile%\Desktop\Old Waterfox Data*|*.*|REMOVESELF
 [FMV Extractor *]
 Section=Dangerous Multimedia
 DetectFile=%ProgramFiles%\FMV-Extractor
-Default=False
 Warning=This will delete all your extracted video files.
 FileKey1=%ProgramFiles%\FMV-Extractor\Clip|*.*|RECURSE
 
 [Font Cache Extended *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft\Windows
-Default=False
 Warning=This possibly could cause a boot failure if fast startup is enabled.
 FileKey1=%WinDir%\System32|FNTCACHE.DAT
 
 [Format Factory Output *]
 Section=Dangerous Multimedia
 Detect=HKCU\Software\FreeTime\FormatFactory
-Default=False
 Warning=This will delete the contents of your output folder. All your converted files will be deleted.
 FileKey1=%Documents%\FFOutput|*.*|RECURSE
 FileKey2=%SystemDrive%\FFOutput|*.*|RECURSE
@@ -819,52 +723,44 @@ FileKey2=%SystemDrive%\FFOutput|*.*|RECURSE
 [Future Technology E-dice Dongle Driver Installation Files *]
 Section=Dangerous Utilities
 DetectFile=%SystemDrive%\E-dice Dongle Driver
-Default=False
 FileKey1=%SystemDrive%\E-dice Dongle Driver|*.*|REMOVESELF
 
 [Hedgewars Saves *]
 Section=Dangerous Games
 Detect=HKLM\Software\Hedgewars
-Default=False
 FileKey1=%Documents%\Hedgewars\Saves|*.*
 
 [Hedgewars Videos *]
 Section=Dangerous Games
 Detect=HKLM\Software\Hedgewars
-Default=False
 FileKey1=%Documents%\Hedgewars\Videos|*.*
 
 [Incredimail *]
 Section=Dangerous Internet
 Detect=HKLM\Software\Clients\Mail\IncrediMail
-Default=False
 Warning=This will empty the contents of your "Deleted" and "Sent" folders.
 FileKey1=%LocalAppData%\IM\Identities\*\Message Store|deleted items.imm;sent items.imm
 
 [Inno Setup Installers Temp *]
 Section=Dangerous Applications
 DetectFile=%LocalAppData%\Programs
-Default=False
 Warning=Some programs use this folder as installation and home folder (e.g. the browser Opera).
 FileKey1=%LocalAppData%\Programs|*.*|REMOVESELF
 
 [IObit Game Booster Backups *]
 Section=Dangerous Utilities
 DetectFile=%ProgramFiles%\IObit\Game Booster 3
-Default=False
 Warning=This will delete your GameBox applications.
 FileKey1=%CommonAppData%\IObit\Game Booster 3|TweaksBackup.reg
 
 [JDownloader Configs *]
 Section=Dangerous Internet
 Detect=HKLM\Software\JDownloader
-Default=False
 FileKey1=%ProgramFiles%\JDownloader\config|*.*
 
 [LastGood Folders *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft\Windows
-Default=False
 Warning=You will not be able to use "Last Known Good Configuration" after running this.
 FileKey1=%WinDir%\LastGood|*.*|REMOVESELF
 FileKey2=%WinDir%\LastGood.Tmp|*.*|REMOVESELF
@@ -872,66 +768,56 @@ FileKey2=%WinDir%\LastGood.Tmp|*.*|REMOVESELF
 [Left 4 Dead 2 Movie Files *]
 Section=Dangerous Games
 Detect=HKCU\Software\Valve\Steam\Apps\550
-Default=False
 Warning=You will need to run "verify integrity of game files" in order to restore these.
 FileKey1=%ProgramFiles%\Steam\steamapps\common\left 4 dead 2\left4dead2\media|l4d2_intro.bik;l4d2_upsell.bik;valve.bik;valve_xbox_legals.bik
 
 [Lenovo Cam S MIC Driver Installation Files *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\Lenovo
-Default=False
 FileKey1=%SystemDrive%\Cam S MIC Driver|*.*|REMOVESELF
 
 [Lenovo Silk Wireless Keyboard Driver Installation Files *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\Lenovo
-Default=False
 FileKey1=%SystemDrive%\Lenovo Silver Silk Keyboard Driver|*.*|REMOVESELF
 
 [Lenovo ST SensorHub Easy FW Update Driver Installation Files *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\Lenovo
-Default=False
 FileKey1=%SystemDrive%\SensorHub FW|*.*|REMOVESELF
 
 [LibreOffice Recent List *]
 Section=Dangerous Applications
 Detect=HKLM\Software\LibreOffice
-Default=False
 Warning=This will revert all custom settings to default.
 FileKey1=%AppData%\LibreOffice\*\User|*.xcu
 
 [Local Install Source MSOCache *]
 Section=Dangerous Applications
 DetectFile=%SystemDrive%\MSOCache
-Default=False
 Warning=This option can ruin your MS Office Installation.
 FileKey1=%SystemDrive%\MSOCache|*.*|RECURSE
 
 [LoL Summonerinfo Replays *]
 Section=Dangerous Games
 DetectFile=%ProgramFiles%\LSI\replays
-Default=False
 Warning=This will delete all your saved replays.
 FileKey1=%ProgramFiles%\LSI\replays|*.*
 
 [Microsoft Security Essentials Backups *]
 Section=Dangerous Applications
 Detect=HKLM\Software\Microsoft\Microsoft Antimalware
-Default=False
 Warning=This will make it impossible to rollback to a previous definition file.
 FileKey1=%CommonAppData%\Microsoft\Microsoft Antimalware\Definition Updates\Backup|*.*|RECURSE
 
 [Minecraft Screenshots *]
 Section=Dangerous Games
 DetectFile=%AppData%\.minecraft
-Default=False
 FileKey1=%AppData%\.minecraft\screenshots|*.*
 
 [Mounted Volumes *]
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer
-Default=False
 Warning=Can cause issues with the Windows 8 system drive icon.
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\MountPoints2
 
@@ -939,14 +825,12 @@ RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\MountPoints2
 Section=Dangerous Applications
 Detect1=HKCU\Software\Microsoft\Office\15.0
 Detect2=HKCU\Software\Microsoft\Office\16.0
-Default=False
 Warning=This can remove downloaded update files even before they are applied.
 FileKey1=%CommonAppData%\Microsoft\ClickToRun\ProductReleases|*.*|RECURSE
 
 [MS Search Extended *]
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft\Windows
-Default=False
 Warning=Use only in Windows Safe Mode.
 FileKey1=%CommonAppData%\Microsoft\Search\Data\Applications\Windows\Projects\SystemIndex\PropMap|*.*|RECURSE
 FileKey2=%CommonAppData%\Microsoft\Search\Data\Applications\Windows\Projects\SystemIndex\SecStore|*.*|RECURSE
@@ -955,14 +839,12 @@ RegKey1=HKLM\Software\Microsoft\Windows Search\VolumeInfoCache
 [MS Search Index *]
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft\Windows
-Default=False
 Warning=Use only in Windows Safe Mode. This forces the search index to be rebuilt.
 FileKey1=%CommonAppData%\Microsoft\Search\Data\Applications\Windows|Windows.edb
 
 [MSConfig *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft\Shared Tools\MSConfig
-Default=False
 RegKey1=HKLM\Software\Microsoft\Shared Tools\MSConfig\ExpandFrom
 RegKey2=HKLM\Software\Microsoft\Shared Tools\MSConfig\ExpandTo
 RegKey3=HKLM\Software\Microsoft\Windows\CurrentVersion\Run|MSConfig
@@ -970,34 +852,29 @@ RegKey3=HKLM\Software\Microsoft\Windows\CurrentVersion\Run|MSConfig
 [MTA: San Andreas Dedicated Server Banned Players List *]
 Section=Dangerous Games
 Detect=HKLM\Software\Multi Theft Auto: San Andreas All
-Default=False
 Warning=This will allow banned players to join again.
 FileKey1=%ProgramFiles%\MTA San Andreas 1.*\server\mods\deathmatch|banlist.xml
 
 [MTA: San Andreas Dedicated Server Custom Resource Settings *]
 Section=Dangerous Games
 Detect=HKLM\Software\Multi Theft Auto: San Andreas All
-Default=False
 Warning=This will clean your settings but may solve some common problems.
 FileKey1=%ProgramFiles%\MTA San Andreas 1.*\server\mods\deathmatch|settings.xml
 
 [MTA: San Andreas Dedicated Server Temp Databases *]
 Section=Dangerous Games
 Detect=HKLM\Software\Multi Theft Auto: San Andreas All
-Default=False
 Warning=This can lead to resource performance periodic graphs loss.
 FileKey1=%ProgramFiles%\MTA San Andreas 1.*\server\mods\deathmatch\databases\system|fileblock.db;stats.db
 
 [MTA: San Andreas Screenshots *]
 Section=Dangerous Games
 Detect=HKLM\Software\Multi Theft Auto: San Andreas All
-Default=False
 FileKey1=%ProgramFiles%\MTA San Andreas 1.*\screenshots|*.*|RECURSE
 
 [Need for Speed: Hot Pursuit 2010 Saves *]
 Section=Dangerous Games
 Detect=HKCU\Software\Electronic Arts\Need for Speed(TM) Hot Pursuit
-Default=False
 Warning=This will delete your saved games.
 FileKey1=%Documents%\Criterion Games|*.*|REMOVESELF
 
@@ -1005,7 +882,6 @@ FileKey1=%Documents%\Criterion Games|*.*|REMOVESELF
 Section=Dangerous Applications
 Detect1=HKCU\Software\Nero\Nero 11
 Detect2=HKLM\Software\Nero\Nero 12
-Default=False
 FileKey1=%AppData%\Nero|*.log|RECURSE
 FileKey2=%AppData%\Nero\Nero*\Nero Vision|*.FAC|RECURSE
 FileKey3=%CommonAppData%\Nero|*.log|RECURSE
@@ -1016,7 +892,6 @@ FileKey6=%ProgramFiles%\Nero\Update|*.txt|RECURSE
 [Nexus Mod Manager Old Configs *]
 Section=Dangerous Games
 DetectFile=%LocalAppData%\Black_Tree_Gaming\NexusClient.exe*
-Default=False
 Warning=Deletes all config from versions older than 0.6.
 FileKey1=%LocalAppData%\Black_Tree_Gaming\NexusClient.exe*\0.0*|*.*|REMOVESELF
 FileKey2=%LocalAppData%\Black_Tree_Gaming\NexusClient.exe*\0.1*|*.*|REMOVESELF
@@ -1028,13 +903,11 @@ FileKey6=%LocalAppData%\Black_Tree_Gaming\NexusClient.exe*\0.5*|*.*|REMOVESELF
 [Notepad++ Backups *]
 Section=Dangerous Applications
 Detect=HKLM\Software\Notepad++
-Default=False
 FileKey1=%AppData%\Notepad++\backup|*.*|REMOVESELF
 
 [Nuclear Dawn Demos/Screenshots *]
 Section=Dangerous Games
 Detect=HKCU\Software\Valve\Steam\Apps\17710
-Default=False
 Warning=This will remove all demos and screenshots which are not uploaded to steam cloud.
 FileKey1=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\donedemos|*.*|RECURSE
 FileKey2=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\maps|*.dem*|RECURSE
@@ -1043,14 +916,12 @@ FileKey3=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\screensh
 [NVIDIA Installer2 Cache *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\NVIDIA Corporation
-Default=False
 Warning=This will prevent the possibility of uninstalling the NVIDIA software. You will need to download the installer for a reinstallation first.
 FileKey1=%ProgramFiles%\NVIDIA Corporation\Installer2|*.*|RECURSE
 
 [NVIDIA Play On My TV *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\NVIDIA Corporation
-Default=False
 Warning=If you output to multiple displays, such as an HDTV or another monitor, don't use this.
 RegKey1=HKCR\AVIFile\shellex\ContextMenuHandlers\NvPlayOnMyTV
 RegKey2=HKCR\AVIFile\shellex\ContextMenuHandlers\PlayOnMyTV
@@ -1068,13 +939,11 @@ RegKey12=HKLM\Software\Classes\WMVFile\shellex\ContextMenuHandlers\PlayOnMyTV
 [NVIDIA Startup *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\NVIDIA Corporation
-Default=False
 RegKey1=HKLM\Software\Microsoft\Windows\CurrentVersion\Run|NvMediaCenter
 
 [Old Windows Installation *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft
-Default=False
 Warning=This will make it impossible to rollback to the previous Windows installation.
 FileKey1=%SystemDrive%\$INPLACE.~TR|*.*|REMOVESELF
 FileKey2=%SystemDrive%\$SysReset|*.*|REMOVESELF
@@ -1086,47 +955,40 @@ FileKey6=%SystemDrive%\Windows.old*|*.*|REMOVESELF
 [OpenRA Replays *]
 Section=Dangerous Games
 DetectFile=%Documents%\OpenRA
-Default=False
 Warning=This will remove all of your replays.
 FileKey1=%Documents%\OpenRA\Replays|*.*|RECURSE
 
 [Opera Indexed Database Extended *]
 Section=Dangerous Opera
 Detect=HKCU\Software\Opera Software
-Default=False
 Warning=This may cause some extensions to not work as intended.
 FileKey1=%AppData%\Opera Software\Opera*\IndexedDB|*.*|RECURSE
 
 [Opera Local Storage Extended *]
 Section=Dangerous Opera
 Detect=HKCU\Software\Opera Software
-Default=False
 Warning=This may cause some extensions to not work as intended.
 FileKey1=%AppData%\Opera Software\Opera*\Local Storage\leveldb|*.*
 
 [Prefetched Files *]
 Section=Dangerous Windows
 DetectFile=%WinDir%\Prefetch
-Default=False
 FileKey1=%WinDir%\Prefetch|*.*
 
 [Project64 2.X Cache *]
 Section=Dangerous Games
 DetectFile=%ProgramFiles%\Project64 2.*
-Default=False
 FileKey1=%ProgramFiles%\Project64 2.*\Config|Project64.cache3;Project64.zcache
 
 [Project64 2.X Saves *]
 Section=Dangerous Games
 DetectFile=%ProgramFiles%\Project64 2.*
-Default=False
 Warning=This will delete your save files. Don't use if you need them.
 FileKey1=%ProgramFiles%\Project64 2.*\Save|*.*
 
 [Project64 2.X Screenshots *]
 Section=Dangerous Games
 DetectFile=%ProgramFiles%\Project64 2.*
-Default=False
 Warning=This will delete your screenshots. Don't use if you need them.
 FileKey1=%ProgramFiles%\Project64 2.*\Screenshots|*.*
 
@@ -1134,7 +996,6 @@ FileKey1=%ProgramFiles%\Project64 2.*\Screenshots|*.*
 DetectOS=10.0|
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft\Windows
-Default=False
 Warning=Use only in Windows Safe Mode. This will break the Live Tiles of apps.
 FileKey1=%LocalAppData%\Microsoft\Windows\Notifications|*.db;*.db-shm;*.db-wal;*.tmp
 FileKey2=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\Notifications|*.db;*.db-shm;*.db-wal;*.tmp
@@ -1143,7 +1004,6 @@ FileKey2=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\
 DetectOS=6.1|
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft\Internet Explorer
-Default=False
 Warning=This will remove all of your Quick Launch icons.
 FileKey1=%AppData%\Microsoft\Internet Explorer\Quick Launch|*.lnk
 
@@ -1151,14 +1011,12 @@ FileKey1=%AppData%\Microsoft\Internet Explorer\Quick Launch|*.lnk
 DetectOS=6.1|
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft\Internet Explorer
-Default=False
 Warning=This will break pinned configuration shortcuts, like control panel.
 FileKey1=%AppData%\Microsoft\Internet Explorer\Quick Launch\User Pinned\ImplicitAppShortcuts|*.*|RECURSE
 
 [ReadyBoot Trace Files *]
 Section=Dangerous Windows
 DetectFile=%WinDir%\Prefetch\ReadyBoot
-Default=False
 Warning=After using this option, all ReadyBoot traces will reset. You will need to reboot to generate new ones.
 FileKey1=%WinDir%\Prefetch\ReadyBoot|Trace*.fx
 
@@ -1166,7 +1024,6 @@ FileKey1=%WinDir%\Prefetch\ReadyBoot|Trace*.fx
 Section=Dangerous Utilities
 Detect1=HKLM\Software\Realtek Semiconductor Corp.\Realtek PC Camera
 Detect2=HKLM\Software\Vimicro Corporation\Lenovo USB2.0 UVC Camera
-Default=False
 Warning=This will delete your Realtek Cam Driver installation files.
 FileKey1=%SystemDrive%\Cam Driver|*.*|REMOVESELF
 FileKey2=%SystemDrive%\Realtek Cam Driver|*.*|REMOVESELF
@@ -1174,124 +1031,106 @@ FileKey2=%SystemDrive%\Realtek Cam Driver|*.*|REMOVESELF
 [Recuva 32-bit Removal *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\Piriform\Recuva
-Default=False
 Warning=Only use if you use the 64-bit version.
 FileKey1=%ProgramFiles%\Recuva|Recuva.exe
 
 [Recuva 64-bit Removal *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\Piriform\Recuva
-Default=False
 Warning=Only use if you use the 32-bit version.
 FileKey1=%ProgramFiles%\Recuva|Recuva64.exe
 
 [Registry Virtualization *]
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft\Windows
-Default=False
 RegKey1=HKCU\Software\Classes\VirtualStore
 
 [Revo Uninstaller Logs *]
 Section=Dangerous Utilities
 DetectFile=%LocalAppData%\VS Revo group
-Default=False
 FileKey1=%LocalAppData%\VS Revo Group\Revo Uninstaller*\Logs|*.*
 
 [Samsung Kies Applications *]
 Section=Dangerous Multimedia
 Detect1=HKCU\Software\Samsung\Kies2.0
 Detect2=HKCU\Software\Samsung\Kies3.0
-Default=False
 FileKey1=%Documents%\samsung\Kies*\Application|*.*|RECURSE
 
 [Samsung Kies EBooks *]
 Section=Dangerous Multimedia
 Detect1=HKCU\Software\Samsung\Kies2.0
 Detect2=HKCU\Software\Samsung\Kies3.0
-Default=False
 FileKey1=%Documents%\samsung\Kies*\EBook|*.*|RECURSE
 
 [Samsung Kies Music *]
 Section=Dangerous Multimedia
 Detect1=HKCU\Software\Samsung\Kies2.0
 Detect2=HKCU\Software\Samsung\Kies3.0
-Default=False
 FileKey1=%Documents%\samsung\Kies*\Music|*.*|RECURSE
 
 [Samsung Kies Photos *]
 Section=Dangerous Multimedia
 Detect1=HKCU\Software\Samsung\Kies2.0
 Detect2=HKCU\Software\Samsung\Kies3.0
-Default=False
 FileKey1=%Documents%\samsung\Kies*\Photo|*.*|RECURSE
 
 [Samsung Kies PIMS *]
 Section=Dangerous Multimedia
 Detect1=HKCU\Software\Samsung\Kies2.0
 Detect2=HKCU\Software\Samsung\Kies3.0
-Default=False
 FileKey1=%Documents%\samsung\Kies*\PIMS|*.*|RECURSE
 
 [Samsung Kies Podcasts *]
 Section=Dangerous Multimedia
 Detect1=HKCU\Software\Samsung\Kies2.0
 Detect2=HKCU\Software\Samsung\Kies3.0
-Default=False
 FileKey1=%Documents%\samsung\Kies*\Podcast|*.*|RECURSE
 
 [Samsung Kies Ringtones *]
 Section=Dangerous Multimedia
 Detect1=HKCU\Software\Samsung\Kies2.0
 Detect2=HKCU\Software\Samsung\Kies3.0
-Default=False
 FileKey1=%Documents%\samsung\Kies*\Ringtone|*.*|RECURSE
 
 [Samsung Kies Videos *]
 Section=Dangerous Multimedia
 Detect1=HKCU\Software\Samsung\Kies2.0
 Detect2=HKCU\Software\Samsung\Kies3.0
-Default=False
 FileKey1=%Documents%\samsung\Kies*\Video|*.*|RECURSE
 
 [ShareX Screenshots *]
 Section=Dangerous Applications
 DetectFile=%Documents%\ShareX
-Default=False
 Warning=This will delete all Screenshots captured by ShareX.
 FileKey1=%Documents%\ShareX\Screenshots|*.*|RECURSE
 
 [SMPlayer Screenshots *]
 Section=Dangerous Multimedia
 DetectFile=%UserProfile%\.smplayer\smplayer.ini
-Default=False
 FileKey1=%Pictures%\smplayer_screenshots|*.*|RECURSE
 FileKey2=%UserProfile%\.smplayer\screenshots|*.*|RECURSE
 
 [Software Protection Platform Cache *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft
-Default=False
 FileKey1=%SystemDrive%\Documents and Settings\NetworkService\Application Data\Microsoft\SoftwareProtectionPlatform\Cache|*.*|RECURSE
 FileKey2=%WinDir%\ServiceProfiles\NetworkService\AppData\Roaming\Microsoft\SoftwareProtectionPlatform\Cache|*.*|RECURSE
 
 [Speccy 32-bit Removal *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\Piriform\Speccy
-Default=False
 Warning=Only use if you use the 64-bit version.
 FileKey1=%ProgramFiles%\Speccy|Speccy.exe
 
 [Speccy 64-bit Removal *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\Piriform\Speccy
-Default=False
 Warning=Only use if you use the 32-bit version.
 FileKey1=%ProgramFiles%\Speccy|Speccy64.exe
 
 [Sticky Notes *]
 Section=Dangerous Applications
 Detect=HKLM\Software\Classes\StickyNotes
-Default=False
 Warning=Selecting this will also delete all sticky notes currently in use.
 FileKey1=%AppData%\Microsoft\Sticky Notes|*.snt
 FileKey2=%UserProfile%\Searches|Sticky Notes (Windows Sticky Notes).searchconnector-ms
@@ -1299,46 +1138,39 @@ FileKey2=%UserProfile%\Searches|Sticky Notes (Windows Sticky Notes).searchconnec
 [Task Scheduler Job Files *]
 Section=Dangerous Windows
 DetectFile=%WinDir%\Tasks
-Default=False
 FileKey1=%WinDir%\Tasks|*.JOB|RECURSE
 
 [Technic Launcher Screenshots *]
 Section=Dangerous Games
 DetectFile=%AppData%\.technic*
-Default=False
 FileKey1=%AppData%\.technic*\*\Screenshots|*.*
 
 [Teeworlds Demos/Screenshots *]
 Section=Dangerous Games
 DetectFile=%AppData%\Teeworlds
-Default=False
 FileKey1=%AppData%\Teeworlds\demos|*.*|REMOVESELF
 FileKey2=%AppData%\Teeworlds\Screenshots|*.*|REMOVESELF
 
 [Temp Folder *]
 Section=Dangerous Windows
 DetectFile=%CommonAppData%\TEMP
-Default=False
 FileKey1=%CommonAppData%\TEMP|*.*|RECURSE
 
 [Twain Temp Files *]
 Section=Dangerous Windows
 DetectFile=%WinDir%\twain_32
-Default=False
 FileKey1=%WinDir%\twain_32|*.tmp
 
 [Windows 7 DVD Maker *]
 DetectOS=6.1|6.1
 Section=Dangerous Multimedia
 Detect=HKLM\Software\Microsoft
-Default=False
 FileKey1=%ProgramFiles%\DVD Maker\Shared\DvdStyles|*.*|RECURSE
 
 [Windows 7/8 Transcoded Wallpaper Cache *]
 DetectOS=6.1|6.3
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft
-Default=False
 Warning=This will delete your current desktop wallpaper, allowing you to change it if you were unable to before.
 FileKey1=%AppData%\Microsoft\Windows\Themes|TranscodedWallpaper.jpg
 
@@ -1346,7 +1178,6 @@ FileKey1=%AppData%\Microsoft\Windows\Themes|TranscodedWallpaper.jpg
 DetectOS=6.2|
 Section=Dangerous Windows Store
 Detect=HKLM\Software\Microsoft
-Default=False
 Warning=This will delete the Windows Apps "Deleted" folders forever. Just use with care.
 FileKey1=%ProgramFiles%\WindowsApps\Deleted|*.*|REMOVESELF
 FileKey2=%ProgramFiles%\WindowsApps\DeletedAllUserPackages|*.*|REMOVESELF
@@ -1355,14 +1186,12 @@ FileKey2=%ProgramFiles%\WindowsApps\DeletedAllUserPackages|*.*|REMOVESELF
 DetectOS=10.0|
 Section=Dangerous Windows Store
 Detect=HKLM\Software\Microsoft
-Default=False
 FileKey1=%ProgramFiles%\WindowsApps\Microsoft.WindowsCamera_*\Assets\LivingImagesFtu|*.mp4
 FileKey2=%WinDir%\SystemApps\Microsoft.Windows.CloudExperienceHost_*\media|*.mp4
 
 [Windows Defender Backups *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\Microsoft\Windows Defender
-Default=False
 Warning=This will make it impossible to rollback to a previous definition file.
 FileKey1=%CommonAppData%\Microsoft\Windows Defender\Definition Updates\*Backup|*.*|RECURSE
 FileKey2=%CommonAppData%\Microsoft\Windows Defender\LocalCopy|*.*|RECURSE
@@ -1371,32 +1200,27 @@ FileKey2=%CommonAppData%\Microsoft\Windows Defender\LocalCopy|*.*|RECURSE
 Section=Dangerous Windows
 DetectFile1=%WinDir%\System32\Performance
 DetectFile2=%WinDir%\System32\WDI
-Default=False
 FileKey1=%WinDir%\System32\Performance|*.ETL*|RECURSE
 FileKey2=%WinDir%\System32\WDI|*.ETL*|RECURSE
 
 [Windows Event Viewer Log Files *]
 Section=Dangerous Windows
 DetectFile=%WinDir%\System32\winevt\Logs
-Default=False
 FileKey1=%WinDir%\System32\winevt\Logs|*.EVT*
 
 [Windows Help Files *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft
-Default=False
 FileKey1=%WinDir%\help|*.*|RECURSE
 
 [Windows Icon/Thumbnail Cache Extended *]
 Section=Dangerous Windows
 DetectFile=%LocalAppData%\Microsoft\Windows\Explorer
-Default=False
 FileKey1=%LocalAppData%\Microsoft\Windows\Explorer|*.db
 
 [Windows Installer Baseline Cache *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft
-Default=False
 FileKey1=%WinDir%\Installer\$PatchCache$|*.*|RECURSE
 FileKey2=%WinDir%\winsxs\backup|*.*|RECURSE
 
@@ -1404,13 +1228,11 @@ FileKey2=%WinDir%\winsxs\backup|*.*|RECURSE
 DetectOS=10.0|
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft
-Default=False
 FileKey1=%WinDir%\servicing\LCU|*.*|RECURSE
 
 [Windows Media Player Databases *]
 Section=Dangerous Multimedia
 Detect=HKCU\Software\Microsoft\MediaPlayer
-Default=False
 Warning=This will remove ratings, play counts, last played, etc.
 FileKey1=%LocalAppData%\Microsoft\Media Player|*.wmdb;wmdbexport.xml
 FileKey2=%SystemDrive%\Documents and Settings\*\Local Settings\Application Data\Microsoft\Media Player|*.wmdb
@@ -1425,7 +1247,6 @@ ExcludeKey2=PATH|%SystemDrive%\Documents and Settings\*\Local Settings\Applicati
 DetectOS=10.0|
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft\Windows
-Default=False
 Warning=Use only in Windows Safe Mode.
 FileKey1=%CommonAppData%\Microsoft\Windows\Caches|*.*|RECURSE
 FileKey2=%LocalAppData%\Microsoft\Windows\Caches|*.*|RECURSE
@@ -1434,7 +1255,6 @@ FileKey3=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows\C
 [Windows System Volume Tracking Logs *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft
-Default=False
 FileKey1=%SystemDrive%\System Volume Information|tracking.log
 FileKey2=C:\System Volume Information|tracking.log
 FileKey3=D:\System Volume Information|tracking.log
@@ -1464,20 +1284,17 @@ FileKey25=Z:\System Volume Information|tracking.log
 [Windows Tracing *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft
-Default=False
 FileKey1=%WinDir%\tracing|*.log;*.old|RECURSE
 
 [Windows Update Uninstalling Packages *]
 Section=Dangerous Windows
 DetectFile=%WinDir%\SoftwareDistribution\Download
-Default=False
 Warning=After deleting the files, you are not going to be able to uninstall any update package.
 FileKey1=%WinDir%\SoftwareDistribution\Download|*.*|RECURSE
 
 [Windows Wallpapers *]
 Section=Dangerous Windows
 Detect=HKLM\Software\Microsoft
-Default=False
 Warning=This will delete your Wallpapers.
 FileKey1=%WinDir%\Web\4K|*.*|RECURSE
 FileKey2=%WinDir%\Web\Screen|*.*|RECURSE
@@ -1487,13 +1304,11 @@ FileKey3=%WinDir%\Web\Wallpaper|*.*|RECURSE
 DetectOS=|6.2
 Section=Dangerous Windows
 DetectFile=%WinDir%\Performance\WinSAT
-Default=False
 FileKey1=%WinDir%\Performance\WinSAT|*.MP4;*.WMV
 
 [Wise Care 365 Backups *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\WiseCleaner\WiseCare365
-Default=False
 FileKey1=%AppData%\Wise Care 365\Backup|*.rbk
 
 ; End of Dangerous entries


### PR DESCRIPTION
The next part in my refactor of Winapp3. This includes https://github.com/MoscaDotTo/Winapp2/pull/415

- Default=False is now completely removed. The current stable version of Winapp2ool will throw a ton of errors because of this, but the next version will not.

- Renamed Useless File Extensions to Junk File Extensions.

- I decided to combine all the log cleaning entries into the Junk File Extension as I didn't really see a reason why they needed to be separated anyways.

Previous Winapp3 was 62.8KB with 161 entries. The new one is now 59.9KB with 155 entries.