### PR TITLE
Update Archived entries.ini

### DIFF
--- a/Winapp3/Archived entries.ini
+++ b/Winapp3/Archived entries.ini
@@ -1,5 +1,5 @@
 ; Version: 200113
-; # of archived entries: 28
+; # of archived entries: 72
 ;
 ; Archived entries.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Archived entries.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/Winapp3/License.md
 ; If you plan on modifying, distributing, and/or hosting Archived entries.ini for your own program or website, please ask first.
@@ -8,6 +8,165 @@
 ; You should NOT use this file as it is for archiving purposes only.
 
 ; Winapp2.ini
+;
+; Chrome/Chromium based browsers
+
+[Blob Storage *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\blob_storage|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Bookmarks Backup *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|*Bookmarks.bak
+; Brave Muon discontinued (since 2018).
+
+[Browser Metrics *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|BrowserMetrics-spare.pma
+FileKey2=%AppData%\brave\BrowserMetrics|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Budget Database *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\BudgetDatabase|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Code Cache *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Code Cache|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Crash Reports *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|CrashpadMetrics*.pma
+FileKey2=%AppData%\brave\Crashpad|metadata
+FileKey3=%AppData%\brave\Crashpad\reports|*.*
+; Brave Muon discontinued (since 2018).
+
+[Data Reduction Proxy *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\data_reduction_proxy_leveldb|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Download History *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|*.ldb;*.log;CURRENT;LOCK;MANIFEST-*
+; Brave Muon discontinued (since 2018).
+
+[Extension Cookies *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|Extension Cookies
+; Brave Muon discontinued (since 2018).
+
+[Feature Engagement Tracker *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Feature Engagement Tracker|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Flash Player Cache *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Pepper Data\Shockwave Flash\CacheWritableAdobeRoot\AssetCache|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Google Cloud Messaging *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\GCM Store|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Jump List Icons *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\JumpListIcons*|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Logs *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|LOG;LOG.old|RECURSE
+FileKey2=%LocalAppData%\Brave|debug.log
+; Brave Muon discontinued (since 2018).
+
+[Network Persistent State *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|Network Persistent State
+; Brave Muon discontinued (since 2018).
+
+[Platform Notifications *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Platform Notifications|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[PNaCl Translation Cache *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\PnaclTranslationCache|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Search Engines Data *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+Warning=This also removes all AutoFill data ("Saved Form Information").
+FileKey1=%AppData%\brave|Web Data
+; Brave Muon discontinued (since 2018).
+
+[Site Characteristics Database *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Site Characteristics Database|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Stability *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Stability|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Sync Data *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Sync Data|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[TLS Certificates *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|Origin Bound Certs
+; Brave Muon discontinued (since 2018).
+
+[Video Decode Statistics *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\VideoDecodeStats|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Web Applications *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Web Applications|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[WebRTC Identity Storage *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|WebRTCIdentityStore
+; Brave Muon discontinued (since 2018).
+
+; End of Chrome/Chromium based browsers
 ;
 ; Firefox/Mozilla based browsers
 
@@ -233,9 +392,135 @@ FileKey1=%AppData%\Yahoo Messenger\Cache|*.*|RECURSE
 
 ; End of Winapp2.ini
 ;
+; Removed entries.ini
+;
+; Chrome/Chromium based browsers
+
+[Application Cache Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Application Cache|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Bookmarks Icons Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+Warning=This will delete all the icons of your bookmarks. The icons will be rebuilt as websites are manually re-visited.
+FileKey1=%AppData%\brave|Favicons
+; Brave Muon discontinued (since 2018).
+
+[Cookies Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|Cookies
+; Brave Muon discontinued (since 2018).
+
+[Extension State Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Extension State|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Flash Player Cookies Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Pepper Data\Shockwave Flash\WritableRoot\#SharedObjects|*.*|RECURSE
+ExcludeKey1=FILE|%AppData%\brave\Pepper Data\Shockwave Flash\WritableRoot\#SharedObjects\*\macromedia.com\support\flashplayer\sys\|settings.sol
+; Brave Muon discontinued (since 2018).
+
+[GPU Cache Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\GPUCache|*.*
+; Brave Muon discontinued (since 2018).
+
+[HTML5 Storage Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\File System|*.*|REMOVESELF
+; Brave Muon discontinued (since 2018).
+
+[Indexed Database Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\IndexedDB\http*_*.indexeddb.*|*.*|REMOVESELF
+; Brave Muon discontinued (since 2018).
+
+[Internet Cache Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Cache|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Internet History Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|*History*;Top Sites*;Visited Links
+; Brave Muon discontinued (since 2018).
+
+[Local Storage Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Local Storage|http*_*.localstorage*
+; Brave Muon discontinued (since 2018).
+
+[Login Data Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|Login Data*
+; Brave Muon discontinued (since 2018).
+
+[Omnibox Shortcuts Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|Shortcuts
+; Brave Muon discontinued (since 2018).
+
+[Quota Manager Data Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|QuotaManager
+; Brave Muon discontinued (since 2018).
+
+[Session Restore Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|Current *;Last *
+; Brave Muon discontinued (since 2018).
+
+[Session Storage Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave\Session Storage|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Temps Extras *]
+LangSecRef=3029
+DetectFile=%AppData%\brave
+FileKey1=%AppData%\brave|*.tmp|RECURSE
+; Brave Muon discontinued (since 2018).
+
+; End of Chrome/Chromium based browsers
+;
+; End of Removed entries.ini
+;
 ; Winapp3.ini
 ;
 ; Dangerous entries
+
+[Chrome Indexed Database Extended *]
+Section=Dangerous Google Chrome
+DetectFile=%AppData%\brave
+Warning=This may cause some extensions to not work as intended.
+FileKey1=%AppData%\brave\IndexedDB|*.*|RECURSE
+; Brave Muon discontinued (since 2018).
+
+[Chrome Local Storage Extended *]
+Section=Dangerous Google Chrome
+DetectFile=%AppData%\brave
+Warning=This may cause some extensions to not work as intended.
+FileKey1=%AppData%\brave\Local Storage\leveldb|*.*
+; Brave Muon discontinued (since 2018).
 
 [SMPlayer2 Screenshots *]
 Section=Dangerous Multimedia

--- a/Winapp3/Archived entries.ini
+++ b/Winapp3/Archived entries.ini
@@ -1,4 +1,4 @@
-; Version: 200113
+; Version: 200504
 ; # of archived entries: 72
 ;
 ; Archived entries.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Archived entries.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/Winapp3/License.md


### PR DESCRIPTION
- Added entries for Chromium-based browser Brave Muon (previous pre-beta of Brave, discontinued since 2018).