### PR TITLE
Update Winapp2.ini

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,4 +1,4 @@
-; Version: 200810
+; Version: 200813
 ; # of entries: 2,491
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
 ; Version: 200810
-; # of entries: 2,493
+; # of entries: 2,491
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -6957,13 +6957,6 @@ LangSecRef=3024
 DetectFile=%ProgramFiles%\Diagnose Windows\Diagnose.exe
 FileKey1=%ProgramFiles%\Diagnose Windows|*.log
 
-[Dialog Box Traces *]
-LangSecRef=3025
-Detect=HKCU\Software\Microsoft\Windows
-RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32\CIDSizeMRU
-RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32\LastVisitedPidlMRU
-RegKey3=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32\OpenSavePidlMRU
-
 [Digi Net Mobile *]
 LangSecRef=3021
 DetectFile=%CommonAppData%\Digi Net Mobile
@@ -9842,12 +9835,6 @@ LangSecRef=3024
 Detect=HKCU\Software\MetaGeek, LLC\inSSIDer Home
 FileKey1=%LocalAppData%\MetaGeek,_LLC|ConnectionErrorLog;MetaGeek-OUI.backup
 
-[InstallService *]
-DetectOS=10.0|
-LangSecRef=3025
-Detect=HKCU\Software\Microsoft\Windows
-FileKey1=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\InstallService|*.*|RECURSE
-
 [InstallShield *]
 LangSecRef=3024
 Detect=HKCU\Software\InstallShield
@@ -12016,15 +12003,14 @@ FileKey4=%AppData%\Microsoft\UProof|*.bin;*.XML
 FileKey5=%Documents%|~*.ppt;~*.pptx;~*.doc;~*.docx|RECURSE
 FileKey6=%LocalAppData%\Microsoft Help|*.*
 FileKey7=%LocalAppData%\Microsoft\Office\*|OneNoteOfflineCache.onecache
-FileKey8=%LocalAppData%\Microsoft\Office\*\WebServiceCache\AllUsers\officeclient.microsoft.com|*.*|RECURSE
-FileKey9=%LocalAppData%\Microsoft\Office\OTele|*.*|RECURSE
-FileKey10=%LocalAppData%\Microsoft\OneNote\*|OneNoteOfflineCache.onecache
-FileKey11=%LocalAppData%\Microsoft\OneNote\*\cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Microsoft\OneNote\*\OneNoteOfflineCache_Files|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\oice_*\AC\Temp|*.*|RECURSE
-FileKey14=%SystemDrive%|propfix.log
-FileKey15=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Office\OTele|*.*|RECURSE
-FileKey16=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Office\OTele|*.*|RECURSE
+FileKey8=%LocalAppData%\Microsoft\Office\OTele|*.*|RECURSE
+FileKey9=%LocalAppData%\Microsoft\OneNote\*|OneNoteOfflineCache.onecache
+FileKey10=%LocalAppData%\Microsoft\OneNote\*\cache|*.*|RECURSE
+FileKey11=%LocalAppData%\Microsoft\OneNote\*\OneNoteOfflineCache_Files|*.*|RECURSE
+FileKey12=%LocalAppData%\Packages\oice_*\AC\Temp|*.*|RECURSE
+FileKey13=%SystemDrive%|propfix.log
+FileKey14=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Office\OTele|*.*|RECURSE
+FileKey15=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Office\OTele|*.*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Office\11.0\MSE|LastLoadedSolution
 RegKey2=HKCU\Software\Microsoft\Office\11.0\MSE\FileMRUList
 RegKey3=HKCU\Software\Microsoft\Office\11.0\MSE\ProjectMRUList


### PR DESCRIPTION
- [Dialog Box Traces *] is already covered by CCleaner (winsys.ini: [Other Explorer MRUs]).
- [InstallService *] is a duplicate of [Store Install Service Cache *].
- Newly added FileKey was removed from [MS Office *] because it is already covered by CCleaner (winapp.ini: [Office 2016]).