### PR TITLE
Adds 'Aero Glass' Cleaning

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -3525,7 +3525,7 @@ FileKey2=%AppData%\Aegisub\autosave|*.*|REMOVESELF
 DetectOS=6.2|
 LangSecRef=3021
 DetectFile=%SystemDrive%\AeroGlass
-FileKey1=%SystemDrive%\AeroGlass|debug.log;*.dmp
+FileKey1=%SystemDrive%\AeroGlass|*.dmp;debug.log
 
 [Age of Conan *]
 Section=Games

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -3524,8 +3524,8 @@ FileKey2=%AppData%\Aegisub\autosave|*.*|REMOVESELF
 [Aero Glass *]
 DetectOS=6.2|
 LangSecRef=3021
-DetectFile=C:\AeroGlass
-FileKey1=C:\AeroGlass|debug.log;*.dmp
+DetectFile=%SystemDrive%\AeroGlass
+FileKey1=%SystemDrive%\AeroGlass|debug.log;*.dmp
 
 [Age of Conan *]
 Section=Games

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
 ; Version: 210920
-; # of entries: 2,928
+; # of entries: 2,929
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -3520,6 +3520,12 @@ Detect=HKLM\Software\Aegisub
 Warning=Aegisub automatically saves a backup copy of each script you open. This will delete them.
 FileKey1=%AppData%\Aegisub\autoback|*.*|REMOVESELF
 FileKey2=%AppData%\Aegisub\autosave|*.*|REMOVESELF
+
+[Aero Glass *]
+DetectOS=6.2|
+LangSecRef=3021
+DetectFile=C:\AeroGlass
+FileKey1=C:\AeroGlass|debug.log;*.dmp
 
 [Age of Conan *]
 Section=Games


### PR DESCRIPTION
Minimum OS: Windows 8 ( 6.2 )
Section: Applications

The second entry '*.dmp' is added because Aero Glass sometimes produces some files with the extension 'dmp'.