### PR TITLE
update winapp2.ini

### DIFF
--- a/Non-CCleaner/Winapp2.ini
+++ b/Non-CCleaner/Winapp2.ini
@@ -1,5 +1,5 @@
-; Version: 230217
-; # of entries: 2,681 + 149 removed entries
+; Version: 2302224
+; # of entries: 2,676 + 149 removed entries
 ;
 ; Winapp2.ini (non-CCleaner version) is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini (non-CCleaner version): https://github.com/MoscaDotTo/Winapp2/blob/master/Non-CCleaner/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini (non-CCleaner version) for your own program or website, please ask first.
@@ -41,6 +41,25 @@ FileKey13=%LocalAppData%\Slimjet\User Data\*|Web Data
 FileKey14=%LocalAppData%\Slimjet\User Data\*\Autofill*|Web Data
 FileKey15=%LocalAppData%\Yandex\YandexBrowser\User Data\*|Web Data;Ya Autofill Data*;Ya Credit Cards*;Ya Passman Data*
 FileKey16=%LocalAppData%\Yandex\YandexBrowser\User Data\*\Autofill*|*
+
+[Chromium Bookbark Favicons *]
+LangSecRef=3029
+Detect1=HKCU\Software\Chromium\PreferenceMACs
+Detect2=HKCU\Software\CocCoc\Browser
+Detect3=HKCU\Software\Comodo\Dragon
+Detect4=HKCU\Software\Epic Privacy Browser
+Detect5=HKCU\Software\Iridium
+Detect6=HKCU\Software\Slimjet
+Detect7=HKCU\Software\Yandex\YandexBrowser
+DetectFile=%LocalAppData%\Google\Chrome*
+FileKey1=%LocalAppData%\Chromium\User Data\*|favicons*
+FileKey2=%LocalAppData%\CocCoc\Browser\User Data\*|favicons*
+FileKey3=%LocalAppData%\Comodo\Dragon\User Data\*|favicons*
+FileKey4=%LocalAppData%\Epic Privacy Browser\User Data\*|favicons*
+FileKey5=%LocalAppData%\Google\Chrome*\User Data\*|favicons*
+FileKey6=%LocalAppData%\Iridium\User Data\*|favicons*
+FileKey7=%LocalAppData%\Slimjet\User Data\*|favicons*
+FileKey8=%LocalAppData%\Yandex\YandexBrowser\User Data\*|favicons*
 
 [Chromium Bookmarks Backup *]
 LangSecRef=3029
@@ -229,14 +248,14 @@ Detect5=HKCU\Software\Iridium
 Detect6=HKCU\Software\Slimjet
 Detect7=HKCU\Software\Yandex\YandexBrowser
 DetectFile=%LocalAppData%\Google\Chrome*
-FileKey1=%LocalAppData%\Chromium\User Data\*|History*;Favicons*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
-FileKey2=%LocalAppData%\CocCoc\Browser\User Data\*|History*;Favicons*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
-FileKey3=%LocalAppData%\Comodo\Dragon\User Data\*|History*;Favicons*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
-FileKey4=%LocalAppData%\Epic Privacy Browser\User Data\*|History*;Favicons*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
-FileKey5=%LocalAppData%\Google\Chrome*\User Data\*|History*;Favicons*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
-FileKey6=%LocalAppData%\Iridium\User Data\*|History*;Favicons*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
-FileKey7=%LocalAppData%\Slimjet\User Data\*|History*;Favicons*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
-FileKey8=%LocalAppData%\Yandex\YandexBrowser\User Data\*|History*;Favicons*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
+FileKey1=%LocalAppData%\Chromium\User Data\*|History*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
+FileKey2=%LocalAppData%\CocCoc\Browser\User Data\*|History*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
+FileKey3=%LocalAppData%\Comodo\Dragon\User Data\*|History*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
+FileKey4=%LocalAppData%\Epic Privacy Browser\User Data\*|History*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
+FileKey5=%LocalAppData%\Google\Chrome*\User Data\*|History*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
+FileKey6=%LocalAppData%\Iridium\User Data\*|History*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
+FileKey7=%LocalAppData%\Slimjet\User Data\*|History*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
+FileKey8=%LocalAppData%\Yandex\YandexBrowser\User Data\*|History*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
 
 [Chromium Session *]
 LangSecRef=3029
@@ -291,7 +310,7 @@ FileKey2=%CommonAppData%\Yandex\YandexBrowser|service_update.log
 FileKey3=%LocalAppData%\Chromium\Application|debug.log
 FileKey4=%LocalAppData%\Chromium\Application\SetupMetrics|*|REMOVESELF
 FileKey5=%LocalAppData%\Chromium\User Data|*.pma;LOG;LOG.old|RECURSE
-FileKey6=%LocalAppData%\Chromium\User Data|chrome_shutdown_ms.txt;last*;first*
+FileKey6=%LocalAppData%\Chromium\User Data|chrome_shutdown_ms.txt;last*
 FileKey7=%LocalAppData%\Chromium\User Data\*\BrowserMetrics|*|REMOVESELF
 FileKey8=%LocalAppData%\Chromium\User Data\*\Feature Engagement Tracker|*|REMOVESELF
 FileKey9=%LocalAppData%\Chromium\User Data\*\Network|Media History;Network*;Reporting*;Transport*
@@ -303,7 +322,7 @@ FileKey14=%LocalAppData%\Chromium\User Data\Stability|*|REMOVESELF
 FileKey15=%LocalAppData%\CocCoc\Browser\Application|debug.log
 FileKey16=%LocalAppData%\CocCoc\Browser\Application\SetupMetrics|*|REMOVESELF
 FileKey17=%LocalAppData%\CocCoc\Browser\User Data|*.pma;LOG;LOG.old|RECURSE
-FileKey18=%LocalAppData%\CocCoc\Browser\User Data|chrome_shutdown_ms.txt;last*;first*
+FileKey18=%LocalAppData%\CocCoc\Browser\User Data|chrome_shutdown_ms.txt;last*
 FileKey19=%LocalAppData%\CocCoc\Browser\User Data\*\BrowserMetrics|*|REMOVESELF
 FileKey20=%LocalAppData%\CocCoc\Browser\User Data\*\Feature Engagement Tracker|*|REMOVESELF
 FileKey21=%LocalAppData%\CocCoc\Browser\User Data\*\Network|Media History;Network*;Reporting*;Transport*
@@ -314,7 +333,7 @@ FileKey25=%LocalAppData%\CocCoc\Browser\User Data\Crashpad\reports|*
 FileKey26=%LocalAppData%\CocCoc\Browser\User Data\Stability|*|REMOVESELF
 FileKey27=%LocalAppData%\CocCoc\CrashReports|*
 FileKey28=%LocalAppData%\Comodo\Dragon\User Data|*.pma;LOG;LOG.old|RECURSE
-FileKey29=%LocalAppData%\Comodo\Dragon\User Data|chrome_shutdown_ms.txt;last*;first*
+FileKey29=%LocalAppData%\Comodo\Dragon\User Data|chrome_shutdown_ms.txt;last*
 FileKey30=%LocalAppData%\Comodo\Dragon\User Data\*\BrowserMetrics|*|REMOVESELF
 FileKey31=%LocalAppData%\Comodo\Dragon\User Data\*\Feature Engagement Tracker|*|REMOVESELF
 FileKey32=%LocalAppData%\Comodo\Dragon\User Data\*\Network|Media History;Network*;Reporting*;Transport*
@@ -351,7 +370,7 @@ FileKey62=%LocalAppData%\Google\Chrome*\User Data\Crashpad\reports|*
 FileKey63=%LocalAppData%\Google\Chrome*\User Data\Stability|*|REMOVESELF
 FileKey64=%LocalAppData%\Google\CrashReports|*
 FileKey65=%LocalAppData%\Iridium\User Data|*.pma;LOG;LOG.old|RECURSE
-FileKey66=%LocalAppData%\Iridium\User Data|chrome_shutdown_ms.txt;last*;first*
+FileKey66=%LocalAppData%\Iridium\User Data|chrome_shutdown_ms.txt;last*
 FileKey67=%LocalAppData%\Iridium\User Data\*\BrowserMetrics|*|REMOVESELF
 FileKey68=%LocalAppData%\Iridium\User Data\*\Feature Engagement Tracker|*|REMOVESELF
 FileKey69=%LocalAppData%\Iridium\User Data\*\Network|Media History;Network*;Reporting*;Transport*
@@ -361,7 +380,7 @@ FileKey72=%LocalAppData%\Iridium\User Data\Crashpad|metadata
 FileKey73=%LocalAppData%\Iridium\User Data\Crashpad\reports|*
 FileKey74=%LocalAppData%\Iridium\User Data\Stability|*|REMOVESELF
 FileKey75=%LocalAppData%\Slimjet\User Data|*.pma;LOG;LOG.old|RECURSE
-FileKey76=%LocalAppData%\Slimjet\User Data|chrome_shutdown_ms.txt;last*;first*
+FileKey76=%LocalAppData%\Slimjet\User Data|chrome_shutdown_ms.txt;last*
 FileKey77=%LocalAppData%\Slimjet\User Data\*\BrowserMetrics|*|REMOVESELF
 FileKey78=%LocalAppData%\Slimjet\User Data\*\Feature Engagement Tracker|*|REMOVESELF
 FileKey79=%LocalAppData%\Slimjet\User Data\*\Network|Media History;Network*;Reporting*;Transport*
@@ -374,7 +393,7 @@ FileKey85=%LocalAppData%\Yandex\SearchBand|*.log
 FileKey86=%LocalAppData%\Yandex\YandexBrowser\Application|debug.log
 FileKey87=%LocalAppData%\Yandex\YandexBrowser\Application\SetupMetrics|*|REMOVESELF
 FileKey88=%LocalAppData%\Yandex\YandexBrowser\User Data|*.pma;LOG;LOG.old|RECURSE
-FileKey89=%LocalAppData%\Yandex\YandexBrowser\User Data|First*;Last*;Local State;Tab Lifetime;update*.rss;Variations;chrome_shutdown_ms.txt
+FileKey89=%LocalAppData%\Yandex\YandexBrowser\User Data|Last*;Local State;Tab Lifetime;update*.rss;Variations;chrome_shutdown_ms.txt
 FileKey90=%LocalAppData%\Yandex\YandexBrowser\User Data\*|Bookmarks Log;Passman Logs;Session Log;Tabs Log;Ya Autofill Logs;WebApp Logs
 FileKey91=%LocalAppData%\Yandex\YandexBrowser\User Data\*\BrowserMetrics|*|REMOVESELF
 FileKey92=%LocalAppData%\Yandex\YandexBrowser\User Data\*\Feature Engagement Tracker|*|REMOVESELF
@@ -477,6 +496,11 @@ LangSecRef=3006
 DetectFile=%LocalAppData%\Microsoft\Edge*
 FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|Web Data
 
+[Microsoft Edge Bookmark Favicons *]
+LangSecRef=3006
+DetectFile=%LocalAppData%\Microsoft\Edge*
+FileKey1=%LocalAppData%\Micrsoft\Edge*\User Data\*|favicons*
+
 [Microsoft Edge Bookmarks Backup *]
 LangSecRef=3006
 DetectFile=%LocalAppData%\Microsoft\Edge*
@@ -544,10 +568,6 @@ FileKey11=%LocalAppData%\Microsoft\Edge*\User Data\Crashpad\reports|*
 FileKey12=%LocalAppData%\Microsoft\Edge*\User Data\Stability|*|REMOVESELF
 FileKey13=%ProgramFiles%\Microsoft\CrashReports|*
 FileKey14=%ProgramFiles%\Microsoft\Edge*\Application\SetupMetrics|*|REMOVESELF
-RegKey1=HKCU\Software\Microsoft\Edge Beta\BrowserExitCodes
-RegKey2=HKCU\Software\Microsoft\Edge Dev\BrowserExitCodes
-RegKey3=HKCU\Software\Microsoft\Edge SxS\BrowserExitCodes
-RegKey4=HKCU\Software\Microsoft\Edge\BrowserExitCodes
 
 [Microsoft Edge Updates *]
 LangSecRef=3006
@@ -569,7 +589,12 @@ LangSecRef=3033
 Detect=HKCU\Software\Vivaldi
 FileKey1=%LocalAppData%\Vivaldi\User Data\*|Web Data
 
-[Vivaldi Bookmark Backups *]
+[Vivaldi Bookmark Favicons *]
+LangSecRef=3033
+Detect=HKCU\Software\Vivaldi
+FileKey1=%LocalAppData%\Vivaldi\User Data\*|favicons*
+
+[Vivaldi Bookmarks Backup *]
 LangSecRef=3033
 Detect=HKCU\Software\Vivaldi
 FileKey1=%LocalAppData%\Vivaldi\User Data\*|*Bookmarks.bak
@@ -601,7 +626,7 @@ FileKey1=%LocalAppData%\Vivaldi\User Data\*\Network|Cookies
 [Vivaldi History *]
 LangSecRef=3033
 Detect=HKCU\Software\Vivaldi
-FileKey1=%LocalAppData%\Vivaldi\User Data\*|History*;Favicons*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
+FileKey1=%LocalAppData%\Vivaldi\User Data\*|History*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
 
 [Vivaldi Logs *]
 LangSecRef=3033
@@ -618,18 +643,23 @@ FileKey1=%LocalAppData%\Vivaldi\User Data\*\Sync Data|*|REMOVESELF
 [Vivaldi Telemetry *]
 LangSecRef=3033
 Detect=HKCU\Software\Vivaldi
-FileKey1=%LocalAppData%\Vivaldi\Application\SetupMetrics|*|REMOVESELF
-FileKey2=%LocalAppData%\Vivaldi\User Data\*|Media History
-FileKey3=%LocalAppData%\Vivaldi\User Data\*|Network Persistent State
-FileKey4=%LocalAppData%\Vivaldi\User Data\*\Feature Engagement Tracker|*|REMOVESELF
-FileKey5=%LocalAppData%\Vivaldi\User Data\*\Network|Network Persistent State
-FileKey6=%LocalAppData%\Vivaldi\User Data\*\Site Characteristics Database|*|REMOVESELF
-FileKey7=%LocalAppData%\Vivaldi\User Data\*\VideoDecodeStats|*|REMOVESELF
-FileKey8=%LocalAppData%\Vivaldi\User Data\BrowserMetrics|*|REMOVESELF
-FileKey9=%LocalAppData%\Vivaldi\User Data\Crashpad|metadata
-FileKey10=%LocalAppData%\Vivaldi\User Data\Crashpad\reports|*
-FileKey11=%ProgramFiles%\Vivaldi\Application\SetupMetrics|*|REMOVESELF
-RegKey1=HKCU\Software\Vivaldi\BrowserExitCodes
+FileKey1=%LocalAppData%\Vivaldi\Application|debug.log
+FileKey2=%LocalAppData%\Vivaldi\Application\SetupMetrics|*|REMOVESELF
+FileKey3=%LocalAppData%\Vivaldi\User Data\*|*.pma;LOG;LOG.old|RECURSE
+FileKey4=%LocalAppData%\Vivaldi\User Data\*|chrome_shutdown_ms.txt;last*;Affiliation Database*;BrowsingTopics*;DIPS;InterestGroups
+FileKey5=%LocalAppData%\Vivaldi\User Data\*\Feature Engagement Tracker|*|REMOVESELF
+FileKey6=%LocalAppData%\Vivaldi\User Data\*\Network|Media History;Network*;Reporting*;Transport*
+FileKey7=%LocalAppData%\Vivaldi\User Data\*\Site Characteristics Database|*|REMOVESELF
+FileKey8=%LocalAppData%\Vivaldi\User Data\*\VideoDecodeStats|*|REMOVESELF
+FileKey9=%LocalAppData%\Vivaldi\User Data\BrowserMetrics|*|REMOVESELF
+FileKey10=%LocalAppData%\Vivaldi\User Data\Crashpad|metadata
+FileKey11=%LocalAppData%\Vivaldi\User Data\Crashpad\reports|*
+FileKey12=%LocalAppData%\Vivaldi\User Data\Stability|*|REMOVESELF
+FileKey13=%ProgramFiles%\Vivaldi\Application\SetupMetrics|*|REMOVESELF
+FileKey14=%UserProfile%|.vivaldi_reporting_data
+RegKey1=HKCU\Software\Yandex\YandexBrowser\BlBeacon|failed_count
+RegKey2=HKCU\Software\Yandex\YandexBrowser\BlBeacon|state
+RegKey3=HKCU\Software\Yandex\YandexBrowser\StabilityMetrics
 
 [Vivaldi Updates *]
 LangSecRef=3033
@@ -646,6 +676,11 @@ FileKey3=%LocalAppData%\Vivaldi\Installer\Offline|*|RECURSE
 LangSecRef=3034
 Detect=HKCU\Software\BraveSoftware
 FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*|Web Data
+
+[Brave Bookmark Favicons *]
+LangSecRef=3034
+Detect=HKCU\Software\BraveSoftware
+FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*|Favicons*
 
 [Brave Bookmarks Backup *]
 LangSecRef=3034
@@ -679,7 +714,7 @@ FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*\Network|Cookies
 [Brave History *]
 LangSecRef=3034
 Detect=HKCU\Software\BraveSoftware
-FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*|History*;Favicons*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
+FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*|History*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
 
 [Brave Logs *]
 LangSecRef=3034
@@ -697,7 +732,7 @@ FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*\Sync Data|*|REM
 [Brave Telemetry *]
 LangSecRef=3034
 Detect=HKCU\Software\BraveSoftware
-FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data|chrome_shutdown_ms.txt;last*;first*
+FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data|chrome_shutdown_ms.txt;last*
 FileKey2=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*|Media History;Network Persistent State
 FileKey3=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*\Feature Engagement Tracker|*|REMOVESELF
 FileKey4=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*\Network|Network Persistent State
@@ -708,10 +743,6 @@ FileKey8=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\Crashpad\reports|
 FileKey9=%LocalAppData%\BraveSoftware\CrashReports|*
 FileKey10=%ProgramFiles%\BraveSoftware\Brave-Browser*\Application\SetupMetrics|*|REMOVESELF
 FileKey11=%ProgramFiles%\BraveSoftware\CrashReports|*
-RegKey1=HKCU\Software\BraveSoftware\Brave-Browser\BrowserExitCodes
-RegKey2=HKCU\Software\BraveSoftware\Brave-Browser-Beta\BrowserExitCodes
-RegKey3=HKCU\Software\BraveSoftware\Brave-Browser-Dev\BrowserExitCodes
-RegKey4=HKCU\Software\BraveSoftware\Brave-Browser-Nightly\BrowserExitCodes
 
 [Brave Updates *]
 LangSecRef=3034
@@ -734,6 +765,16 @@ FileKey2=%ProgramFiles%\Opera 9\profile\cache*|*
 LangSecRef=3027
 DetectFile=%AppData%\Opera Software\Opera*
 FileKey1=%AppData%\Opera Software\Opera*\*|Web Data
+
+[Opera Bookmark Favicons *]
+LangSecRef=3027
+DetectFile=%AppData%\Opera Software\Opera*
+FileKey1=%AppData%\Opera Software\Opera*|favicons*
+
+[Opera Bookmarks Backup *]
+LangSecRef=3027
+DetectFile=%AppData%\Opera Software\Opera*
+FileKey1=%AppData%\Opera Software\Opera*|bookmarks.bak
 
 [Opera Caches *]
 LangSecRef=3027
@@ -761,6 +802,11 @@ LangSecRef=3027
 DetectFile=%AppData%\Opera Software\Opera*
 FileKey1=%AppData%\Opera Software\Opera*\*\Network|Cookies
 
+[Opera History *]
+LangSecRef=3027
+DetectFile=%AppData%\Opera Software\Opera*
+FileKey1=%AppData%\Opera Software\Opera*\*|History*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
+
 [Opera Logs *]
 LangSecRef=3027
 DetectFile=%AppData%\Opera Software\Opera*
@@ -769,6 +815,22 @@ FileKey2=%AppData%\Opera Software\Opera*\Application|debug.log
 FileKey3=%LocalAppData%\Programs\Opera*|*.log|REMOVESELF
 FileKey4=%ProgramFiles%\Opera*|*.log|RECURSE
 FileKey5=%WinDir%\System32\config\systemprofile\AppData\Local\Opera Software\Opera*\*|LOG;LOG.old|RECURSE
+
+[Opera Presto *]
+LangSecRef=3027
+DetectFile=%LocalAppData%\Opera\Opera*
+FileKey1=%LocalAppData%\Opera\Opera*|*.log
+FileKey2=%LocalAppData%\Opera\Opera*\application_cache|*|REMOVESELF
+FileKey3=%LocalAppData%\Opera\Opera*\icons|*|REMOVESELF
+FileKey4=%LocalAppData%\Opera\Opera*\logs|*|REMOVESELF
+FileKey5=%LocalAppData%\Opera\Opera*\temporary_downloads|*|REMOVESELF
+FileKey6=%LocalAppData%\Opera\Opera*\thumbnails|*|REMOVESELF
+FileKey7=%LocalAppData%\Opera\Opera*\vps|*|REMOVESELF
+FileKey8=%UserProfile%\.opera|*|REMOVESELF
+FileKey9=%UserProfile%\Downloads\.opera|*|REMOVESELF
+FileKey10=%UserProfile%\Downloads\Opera Autoupdate|*.log
+FileKey11=%UserProfile%\Opera Autoupdate|*.log
+RegKey1=HKCU\Software\Opera Software|Last CommandLine v2
 
 [Opera Sync Data *]
 LangSecRef=3027
@@ -792,10 +854,6 @@ FileKey11=%AppData%\Opera Software\Opera*\VideoDecodeStats|*|REMOVESELF
 FileKey12=%LocalAppData%\Opera\CrashReports|*
 FileKey13=%ProgramFiles%\Opera\CrashReports|*
 FileKey14=%ProgramFiles%\Opera\Opera*\Application\SetupMetrics|*|REMOVESELF
-RegKey1=HKCU\Software\Opera\Opera Dev\BrowserExitCodes
-RegKey2=HKCU\Software\Opera\Opera Stable\BrowserExitCodes
-RegKey3=HKCU\Software\Opera\Opera SxS\BrowserExitCodes
-RegKey4=HKCU\Software\Opera\Opera\BrowserExitCodes
 
 [Opera Update *]
 LangSecRef=3027
@@ -807,6 +865,42 @@ FileKey3=%LocalAppData%\Programs\Opera*|*.backup;*.old;*.tmp|RECURSE
 ; End of Opera
 ;
 ; Firefox/Mozilla based browsers
+
+[Firefox Autocomplete History *]
+LangSecRef=3026
+Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Mozilla.Firefox_n80bbvh6b1yt2
+Detect2=HKCU\Software\LibreWolf
+Detect3=HKLM\Software\FlashPeak\SlimBrowser
+Detect4=HKLM\Software\Mozilla\Basilisk
+Detect5=HKLM\Software\Mozilla\Pale Moon
+Detect6=HKLM\Software\Mozilla\SeaMonkey
+Detect7=HKLM\Software\Mozilla\Waterfox
+DetectFile=%AppData%\Mozilla\Firefox
+FileKey1=%AppData%\Basilisk-Dev\Basilisk\Profiles\*|formhistory*
+FileKey2=%AppData%\FlashPeak\SlimBrowser\Profiles\*|formhistory*
+FileKey3=%AppData%\LibreWolf\Profiles\*|formhistory*
+FileKey4=%AppData%\Moonchild Productions\*\Profiles\*|formhistory*
+FileKey5=%AppData%\Mozilla\*\Profiles\*|formhistory*
+FileKey6=%AppData%\Waterfox\Profiles\*|formhistory*
+FileKey7=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*|formhistory*
+
+[Firefox Bookmark Favicons *]
+LangSecRef=3026
+Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Mozilla.Firefox_n80bbvh6b1yt2
+Detect2=HKCU\Software\LibreWolf
+Detect3=HKLM\Software\FlashPeak\SlimBrowser
+Detect4=HKLM\Software\Mozilla\Basilisk
+Detect5=HKLM\Software\Mozilla\Pale Moon
+Detect6=HKLM\Software\Mozilla\SeaMonkey
+Detect7=HKLM\Software\Mozilla\Waterfox
+DetectFile=%AppData%\Mozilla\Firefox
+FileKey1=%AppData%\Basilisk-Dev\Basilisk\Profiles\*|favicons*
+FileKey2=%AppData%\FlashPeak\SlimBrowser\Profiles\*|favicons*
+FileKey3=%AppData%\LibreWolf\Profiles\*|favicons*
+FileKey4=%AppData%\Moonchild Productions\*\Profiles\*|favicons*
+FileKey5=%AppData%\Mozilla\*\Profiles\*|favicons*
+FileKey6=%AppData%\Waterfox\Profiles\*|favicons*
+FileKey7=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*|favicons*
 
 [Firefox Caches *]
 LangSecRef=3026
@@ -823,7 +917,7 @@ FileKey1=%AppData%\ArtistScope\ArtisBrowser\Profiles\*|*.corrupt|RECURSE
 FileKey2=%AppData%\ArtistScope\ArtisBrowser\Profiles\*|AlternateServices.txt;notificationstore.json;parent.lock;serviceworker.txt;webappsstore.sqlite;cert9.db
 FileKey3=%AppData%\ArtistScope\ArtisBrowser\Profiles\*\storage\temporary|*|RECURSE
 FileKey4=%AppData%\Comodo\IceDragon\Profiles\*|*.corrupt|RECURSE
-FileKey5=%AppData%\Comodo\IceDragon\Profiles\*|AlternateServices.txt;notificationstore.json;parent.lock;serviceworker.txt;webappsstore.sqlite;favicons*
+FileKey5=%AppData%\Comodo\IceDragon\Profiles\*|AlternateServices.txt;notificationstore.json;parent.lock;serviceworker.txt;webappsstore.sqlite
 FileKey6=%AppData%\Comodo\IceDragon\Profiles\*\storage\temporary|*|RECURSE
 FileKey7=%AppData%\FlashPeak\SlimBrowser\Profiles\*|*.corrupt|RECURSE
 FileKey8=%AppData%\FlashPeak\SlimBrowser\Profiles\*|AlternateServices.txt;notificationstore.json;parent.lock;serviceworker.txt;webappsstore.sqlite
@@ -958,6 +1052,31 @@ FileKey30=%ProgramFiles%\SlimBrowser|*.log
 FileKey31=%ProgramFiles%\Waterfox|*.log
 FileKey32=%ProgramFiles%\WindowsApps\Mozilla.Firefox_*\VFS\ProgramFiles\Firefox Package Root|*.log
 
+[Firefox Sessions *]
+LangSecRef=3026
+Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Mozilla.Firefox_n80bbvh6b1yt2
+Detect2=HKCU\Software\LibreWolf
+Detect3=HKLM\Software\FlashPeak\SlimBrowser
+Detect4=HKLM\Software\Mozilla\Basilisk
+Detect5=HKLM\Software\Mozilla\Pale Moon
+Detect6=HKLM\Software\Mozilla\SeaMonkey
+Detect7=HKLM\Software\Mozilla\Waterfox
+DetectFile=%AppData%\Mozilla\Firefox
+FileKey1=%AppData%\Basilisk-Dev\Basilisk\Profiles\*|session*.json*
+FileKey2=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\sessionstore-backups|*
+FileKey3=%AppData%\FlashPeak\SlimBrowser\Profiles\*|session*.json*
+FileKey4=%AppData%\FlashPeak\SlimBrowser\Profiles\*\sessionstore-backups|*
+FileKey5=%AppData%\LibreWolf\Profiles\*|session*.json*
+FileKey6=%AppData%\LibreWolf\Profiles\*\sessionstore-backups|*
+FileKey7=%AppData%\Moonchild Productions\*\Profiles\*|session*.json*
+FileKey8=%AppData%\Moonchild Productions\*\Profiles\*\sessionstore-backups|*
+FileKey9=%AppData%\Mozilla\*\Profiles\*|session*.json*
+FileKey10=%AppData%\Mozilla\*\Profiles\*\sessionstore-backups|*
+FileKey11=%AppData%\Waterfox\Profiles\*|session*.json*
+FileKey12=%AppData%\Waterfox\Profiles\*\sessionstore-backups|*
+FileKey13=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*|session*.json*
+FileKey14=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\sessionstore-backups|*
+
 [Firefox Telemetry *]
 LangSecRef=3026
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Mozilla.Firefox_n80bbvh6b1yt2
@@ -971,49 +1090,55 @@ Detect8=HKLM\Software\Mozilla\Waterfox
 DetectFile=%AppData%\Mozilla\Firefox
 FileKey1=%AppData%\Basilisk-Dev\Basilisk\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
 FileKey2=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\Crash Reports|*|RECURSE
-FileKey3=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\datareporting|*|REMOVESELF
-FileKey4=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\minidumps|*
-FileKey5=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\saved-telemetry-pings|*
-FileKey6=%AppData%\FlashPeak\SlimBrowser\Crash Reports|*|RECURSE
-FileKey7=%AppData%\FlashPeak\SlimBrowser\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
-FileKey8=%AppData%\FlashPeak\SlimBrowser\Profiles\*\datareporting|*|REMOVESELF
-FileKey9=%AppData%\FlashPeak\SlimBrowser\Profiles\*\minidumps|*
-FileKey10=%AppData%\FlashPeak\SlimBrowser\Profiles\*\saved-telemetry-pings|*
-FileKey11=%AppData%\LibreWolf\Crash Reports|*|RECURSE
-FileKey12=%AppData%\LibreWolf\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
-FileKey13=%AppData%\LibreWolf\Profiles\*\datareporting|*|REMOVESELF
-FileKey14=%AppData%\LibreWolf\Profiles\*\minidumps|*
-FileKey15=%AppData%\LibreWolf\Profiles\*\saved-telemetry-pings|*
-FileKey16=%AppData%\Moonchild Productions\*\Crash Reports|*|RECURSE
-FileKey17=%AppData%\Moonchild Productions\*\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
-FileKey18=%AppData%\Moonchild Productions\*\Profiles\*\datareporting|*|REMOVESELF
-FileKey19=%AppData%\Moonchild Productions\*\Profiles\*\minidumps|*
-FileKey20=%AppData%\Moonchild Productions\*\Profiles\*\saved-telemetry-pings|*
-FileKey21=%AppData%\Mozilla\*\Crash Reports|*|RECURSE
-FileKey22=%AppData%\Mozilla\*\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
-FileKey23=%AppData%\Mozilla\*\Profiles\*\datareporting|*|REMOVESELF
-FileKey24=%AppData%\Mozilla\*\Profiles\*\minidumps|*
-FileKey25=%AppData%\Mozilla\*\Profiles\*\saved-telemetry-pings|*
-FileKey26=%AppData%\Talkback\MozillaOrg\Firefox*|*|RECURSE
-FileKey27=%AppData%\Talkback\MozillaOrg\Thunderbird*|*|RECURSE
-FileKey28=%AppData%\Waterfox\Crash Reports|*|RECURSE
-FileKey29=%AppData%\Waterfox\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
-FileKey30=%AppData%\Waterfox\Profiles\*\datareporting|*|REMOVESELF
-FileKey31=%AppData%\Waterfox\Profiles\*\minidumps|*
-FileKey32=%AppData%\Waterfox\Profiles\*\saved-telemetry-pings|*
-FileKey33=%CommonAppData%\Mozilla*|profile_count_*.json
-FileKey34=%LocalAppData%\Basilisk-Dev\Basilisk\Profiles\*|ShutdownDuration.*
-FileKey35=%LocalAppData%\FlashPeak\SlimBrowser\Profiles\*|ShutdownDuration.*
-FileKey36=%LocalAppData%\LibreWolf\Profiles\*|ShutdownDuration.*
-FileKey37=%LocalAppData%\Moonchild Productions\*\Profiles\*|ShutdownDuration.*
-FileKey38=%LocalAppData%\Mozilla\*\Profiles\*|ShutdownDuration.*
-FileKey39=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Local\Mozilla\Firefox\Profiles\*|ShutdownDuration.*
-FileKey40=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Crash Reports|*|RECURSE
-FileKey41=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
-FileKey42=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\datareporting|*|REMOVESELF
-FileKey43=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\minidumps|*
-FileKey44=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\saved-telemetry-pings|*
-FileKey45=%LocalAppData%\Waterfox\Profiles\*|ShutdownDuration.*
+FileKey3=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\crashes|*
+FileKey4=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\datareporting|*|REMOVESELF
+FileKey5=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\minidumps|*
+FileKey6=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\saved-telemetry-pings|*
+FileKey7=%AppData%\FlashPeak\SlimBrowser\Crash Reports|*|RECURSE
+FileKey8=%AppData%\FlashPeak\SlimBrowser\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
+FileKey9=%AppData%\FlashPeak\SlimBrowser\Profiles\*\crashes|*
+FileKey10=%AppData%\FlashPeak\SlimBrowser\Profiles\*\datareporting|*|REMOVESELF
+FileKey11=%AppData%\FlashPeak\SlimBrowser\Profiles\*\minidumps|*
+FileKey12=%AppData%\FlashPeak\SlimBrowser\Profiles\*\saved-telemetry-pings|*
+FileKey13=%AppData%\LibreWolf\Crash Reports|*|RECURSE
+FileKey14=%AppData%\LibreWolf\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
+FileKey15=%AppData%\LibreWolf\Profiles\*\crashes|*
+FileKey16=%AppData%\LibreWolf\Profiles\*\datareporting|*|REMOVESELF
+FileKey17=%AppData%\LibreWolf\Profiles\*\minidumps|*
+FileKey18=%AppData%\LibreWolf\Profiles\*\saved-telemetry-pings|*
+FileKey19=%AppData%\Moonchild Productions\*\Crash Reports|*|RECURSE
+FileKey20=%AppData%\Moonchild Productions\*\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
+FileKey21=%AppData%\Moonchild Productions\*\Profiles\*\crashes|*
+FileKey22=%AppData%\Moonchild Productions\*\Profiles\*\datareporting|*|REMOVESELF
+FileKey23=%AppData%\Moonchild Productions\*\Profiles\*\minidumps|*
+FileKey24=%AppData%\Moonchild Productions\*\Profiles\*\saved-telemetry-pings|*
+FileKey25=%AppData%\Mozilla\*\Crash Reports|*|RECURSE
+FileKey26=%AppData%\Mozilla\*\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
+FileKey27=%AppData%\Mozilla\*\Profiles\*\crashes|*
+FileKey28=%AppData%\Mozilla\*\Profiles\*\datareporting|*|REMOVESELF
+FileKey29=%AppData%\Mozilla\*\Profiles\*\minidumps|*
+FileKey30=%AppData%\Mozilla\*\Profiles\*\saved-telemetry-pings|*
+FileKey31=%AppData%\Talkback\MozillaOrg\Firefox*|*|RECURSE
+FileKey32=%AppData%\Talkback\MozillaOrg\Thunderbird*|*|RECURSE
+FileKey33=%AppData%\Waterfox\Crash Reports|*|RECURSE
+FileKey34=%AppData%\Waterfox\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
+FileKey35=%AppData%\Waterfox\Profiles\*\crashes|*
+FileKey36=%AppData%\Waterfox\Profiles\*\datareporting|*|REMOVESELF
+FileKey37=%AppData%\Waterfox\Profiles\*\minidumps|*
+FileKey38=%AppData%\Waterfox\Profiles\*\saved-telemetry-pings|*
+FileKey39=%CommonAppData%\Mozilla*|profile_count_*.json
+FileKey40=%LocalAppData%\Basilisk-Dev\Basilisk\Profiles\*|ShutdownDuration.*
+FileKey41=%LocalAppData%\FlashPeak\SlimBrowser\Profiles\*|ShutdownDuration.*
+FileKey42=%LocalAppData%\LibreWolf\Profiles\*|ShutdownDuration.*
+FileKey43=%LocalAppData%\Moonchild Productions\*\Profiles\*|ShutdownDuration.*
+FileKey44=%LocalAppData%\Mozilla\*\Profiles\*|ShutdownDuration.*
+FileKey45=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Local\Mozilla\Firefox\Profiles\*|ShutdownDuration.*
+FileKey46=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Crash Reports|*|RECURSE
+FileKey47=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
+FileKey48=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\datareporting|*|REMOVESELF
+FileKey49=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\minidumps|*
+FileKey50=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\saved-telemetry-pings|*
+FileKey51=%LocalAppData%\Waterfox\Profiles\*|ShutdownDuration.*
 RegKey1=HKLM\Software\FullCircle\TalkBack
 
 [Firefox Updates *]
@@ -1099,41 +1224,42 @@ Detect=HKCU\Software\Microsoft\Internet Explorer
 FileKey1=%AppData%\Microsoft\Internet Explorer\UserData|*|RECURSE
 FileKey2=%LocalAppData%\Microsoft\Internet Explorer|*.log;*.txt|RECURSE
 FileKey3=%LocalAppData%\Microsoft\Internet Explorer\CacheStorage|*|RECURSE
-FileKey4=%LocalAppData%\Microsoft\Windows\*Cache*|*|RECURSE
-FileKey5=%LocalAppData%\Microsoft\Windows\INetCookies|*|RECURSE
-FileKey6=%LocalAppData%\Packages\windows_ie_ac_*\AC\AppCache|*|RECURSE
-FileKey7=%LocalAppData%\Packages\windows_ie_ac_*\AC\IECompat*Cache|*|RECURSE
-FileKey8=%LocalAppData%\Packages\windows_ie_ac_*\AC\IEDownloadHistory|*|RECURSE
-FileKey9=%LocalAppData%\Packages\windows_ie_ac_*\AC\INet*|*|RECURSE
-FileKey10=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
-FileKey11=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CryptnetUrlCache\*|*
-FileKey12=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
-FileKey13=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\Internet Explorer\Emie*List|*|RECURSE
-FileKey14=%LocalAppData%\Packages\windows_ie_ac_*\AC\PRICache|*|RECURSE
-FileKey15=%LocalAppData%\Packages\windows_ie_ac_*\AC\Temp|*|RECURSE
-FileKey16=%LocalAppData%\Packages\windows_ie_ac_*\LocalState\Cache|*|RECURSE
-FileKey17=%LocalAppData%\Packages\windows_ie_ac_*\LocalState\navigationHistory|*|RECURSE
-FileKey18=%LocalAppData%\Packages\windows_ie_ac_*\TempState|*|RECURSE
-FileKey19=%SystemDrive%\Documents and Settings\LocalService*\Cookies|*|RECURSE
-FileKey20=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\History|*|RECURSE
-FileKey21=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\Temporary Internet Files|*|RECURSE
-FileKey22=%SystemDrive%\Documents and Settings\NetworkService*\Cookies|*|RECURSE
-FileKey23=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\History|*|RECURSE
-FileKey24=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\Temporary Internet Files|*|RECURSE
-FileKey25=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\History|*|RECURSE
-FileKey26=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
-FileKey27=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
-FileKey28=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\History|*|RECURSE
-FileKey29=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
-FileKey30=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
-FileKey31=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache|*|RECURSE
-FileKey32=%WinDir%\System32\config\systemprofile\Cookies|*|RECURSE
-FileKey33=%WinDir%\System32\config\systemprofile\History|*|RECURSE
-FileKey34=%WinDir%\System32\config\systemprofile\Local Settings\Temporary Internet Files|*|RECURSE
-FileKey35=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\History|*|RECURSE
-FileKey36=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
-FileKey37=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
-FileKey38=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache|*|RECURSE
+FileKey4=%LocalAppData%\Microsoft\Windows\AppCache|*|RECURSE
+FileKey5=%LocalAppData%\Microsoft\Windows\INetCache|*|RECURSE
+FileKey6=%LocalAppData%\Microsoft\Windows\INetCookies|*|RECURSE
+FileKey7=%LocalAppData%\Microsoft\Windows\WebCache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\windows_ie_*\AC\*Cache|*|RECURSE
+FileKey9=%LocalAppData%\Packages\windows_ie_*\AC\IECompat*Cache|*|RECURSE
+FileKey10=%LocalAppData%\Packages\windows_ie_*\AC\IEDownloadHistory|*|RECURSE
+FileKey11=%LocalAppData%\Packages\windows_ie_*\AC\INet*|*|RECURSE
+FileKey12=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey13=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey14=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey15=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\Internet Explorer\Emie*List|*|RECURSE
+FileKey16=%LocalAppData%\Packages\windows_ie_*\AC\Temp|*|RECURSE
+FileKey17=%LocalAppData%\Packages\windows_ie_*\LocalState\Cache|*|RECURSE
+FileKey18=%LocalAppData%\Packages\windows_ie_*\LocalState\navigationHistory|*|RECURSE
+FileKey19=%LocalAppData%\Packages\windows_ie_*\TempState|*|RECURSE
+FileKey20=%SystemDrive%\Documents and Settings\LocalService*\Cookies|*|RECURSE
+FileKey21=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\History|*|RECURSE
+FileKey22=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\Temporary Internet Files|*|RECURSE
+FileKey23=%SystemDrive%\Documents and Settings\NetworkService*\Cookies|*|RECURSE
+FileKey24=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\History|*|RECURSE
+FileKey25=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\Temporary Internet Files|*|RECURSE
+FileKey26=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\History|*|RECURSE
+FileKey27=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
+FileKey28=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
+FileKey29=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\History|*|RECURSE
+FileKey30=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
+FileKey31=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
+FileKey32=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache|*|RECURSE
+FileKey33=%WinDir%\System32\config\systemprofile\Cookies|*|RECURSE
+FileKey34=%WinDir%\System32\config\systemprofile\History|*|RECURSE
+FileKey35=%WinDir%\System32\config\systemprofile\Local Settings\Temporary Internet Files|*|RECURSE
+FileKey36=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\History|*|RECURSE
+FileKey37=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
+FileKey38=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
+FileKey39=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\windows_ie_ac_001\Internet Explorer\DOMStorage
 RegKey2=HKCU\Software\Microsoft\Internet Explorer\DOMStorage
 RegKey3=HKCU\Software\Microsoft\Internet Explorer\LowRegistry\DOMStorage
@@ -1527,12 +1653,7 @@ LangSecRef=3024
 DetectFile=%LocalAppData%\Abelssoft\AntiBrowserSpy
 FileKey1=%LocalAppData%\Abelssoft\AntiBrowserSpy|*.log
 
-[Abelssoft CCFinder *]
-LangSecRef=3024
-DetectFile=%LocalAppData%\Abelssoft\CCfinder
-FileKey1=%LocalAppData%\FlickrNet|responseCache.dat
-
-[Abelssoft GoogleClean *]
+[Abelssoft GClean *]
 LangSecRef=3024
 DetectFile1=%LocalAppData%\Abelssoft\GClean
 DetectFile2=%LocalAppData%\Abelssoft\GoogleClean
@@ -2418,13 +2539,12 @@ FileKey1=%LocalAppData%\Akamai\Logs|*.log
 [Al Quran *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\57100Goheer.TheQuran_s6gg0ptmhrgye
-FileKey1=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\INet*|*|RECURSE
 FileKey3=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey4=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\PRICache|*.*
-FileKey6=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\Temp|*.*
-FileKey7=%LocalAppData%\Packages\*Goheer.TheQuran_*\LocalState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\Temp|*
+FileKey6=%LocalAppData%\Packages\*Goheer.TheQuran_*\LocalState|*|RECURSE
 
 [AlbumPlayer *]
 LangSecRef=3023
@@ -2932,19 +3052,6 @@ FileKey1=%LocalAppData%\AnyMusic\Cache\QtWebEngine\Default\Cache|*.*
 FileKey2=%LocalAppData%\AnyMusic\QtWebEngine\Default|*-journal;*.old;LOG;Network Persistent State;Visited Links|RECURSE
 FileKey3=%LocalAppData%\AnyMusic\QtWebEngine\Default\blob_storage|*.*|RECURSE
 FileKey4=%LocalAppData%\AnyMusic\QtWebEngine\Default\GPUCache|*.*
-
-[AOL *]
-LangSecRef=3022
-Detect=HKCU\Software\America Online
-FileKey1=%AppData%\AOL\C_AOL*|*.tmp|RECURSE
-FileKey2=%CommonAppData%\AOL Downloads|*.*|RECURSE
-FileKey3=%CommonAppData%\AOL\C_AOL*|*.tmp|RECURSE
-FileKey4=%CommonAppData%\AOL\C_AOL*\bart|*.*|RECURSE
-FileKey5=%CommonAppData%\AOL\C_AOL*\spool|*.*|RECURSE
-FileKey6=%LocalAppData%\AOL\C_AOL*|*-journal;*.tmp|RECURSE
-FileKey7=%LocalAppData%\AOL\C_AOL*\BrowserCache|*.*|RECURSE
-FileKey8=%LocalAppData%\AOL\C_AOL*\ToolbarCache|data_*;f_*;index;VisitedLinks
-FileKey9=%LocalAppData%\AOL\C_AOL*\ToolbarCache\AppCache\Cache|*.*
 
 [AOMEI Backupper *]
 LangSecRef=3024
@@ -3882,11 +3989,6 @@ FileKey14=%ProgramFiles%\Alwil Software\Avast*\Setup|*.log
 FileKey15=%ProgramFiles%\AVAST Software\Avast|*.tmp
 RegKey1=HKCU\Software\AVAST Software\Avast Browser Cleanup
 
-[Avast EasyPass *]
-LangSecRef=3022
-DetectFile=%Documents%\My Avast EasyPass Data
-FileKey1=%Documents%\My Avast EasyPass Data\Default Profile|mru.rfo;cache.rfo|RECURSE
-
 [Avast TuneUp *]
 LangSecRef=3024
 Detect=HKCU\Software\AVAST Software\Tuneup
@@ -3976,17 +4078,6 @@ FileKey1=%ProgramFiles%\AVIMuxGUI|AVI-Mux GUI - Logfile*.*;*.dmp
 LangSecRef=3023
 Detect=HKCU\Software\KC Softwares\AVIToolbox
 FileKey1=%AppData%\KC Softwares\AVI Toolbox|*.log
-
-[Aviary Photo Editor *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\57AB5DD0.PhotoEditor_6hb943tstq5q8
-FileKey1=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
-FileKey4=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Temp|*.*
-FileKey6=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\LocalState|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\TempState|*.*|RECURSE
 
 [AVIcodec *]
 LangSecRef=3023
@@ -4332,13 +4423,7 @@ FileKey1=%Documents%\my games\BioShock Infinite\Benchmarks|*.*
 
 [BIT.TRIP *]
 Section=Games
-Detect1=HKCU\Software\Valve\Steam\Apps\63700
-Detect2=HKCU\Software\Valve\Steam\Apps\63710
-Detect3=HKCU\Software\Valve\Steam\Apps\205060
-Detect4=HKCU\Software\Valve\Steam\Apps\205070
-Detect5=HKCU\Software\Valve\Steam\Apps\205080
-Detect6=HKCU\Software\Valve\Steam\Apps\205090
-Detect7=HKCU\Software\Valve\Steam\Apps\218060
+DetectFile=%LocalAppData%\BIT.TRIP *
 FileKey1=%LocalAppData%\BIT.TRIP *|*.txt
 
 [Bitcoin *]
@@ -4539,19 +4624,10 @@ Section=Games
 DetectFile=%SystemDrive%\BOSS
 FileKey1=%SystemDrive%\BOSS\*|BOSSlog.*
 
-[Box *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\134D4F5B.Box_2qk4zy5s3qmee
+[Box For Office *]
+LangSecRef=3021
 DetectFile=%LocalAppData%\Box\BoxforOffice*
 FileKey1=%LocalAppData%\Box\BoxforOfficeLogs|*.*
-FileKey2=%LocalAppData%\Packages\134D4F5B.Box_*\AC\AppCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\134D4F5B.Box_*\AC\INet*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
-FileKey5=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey7=%LocalAppData%\Packages\134D4F5B.Box_*\AC\PRICache|*.*
-FileKey8=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Temp|*.*
-FileKey9=%LocalAppData%\Packages\134D4F5B.Box_*\LocalState|*.*|RECURSE
 
 [Breevy *]
 LangSecRef=3021
@@ -5044,13 +5120,6 @@ DetectFile=%LocalLowAppData%\Behold Studios\Chroma Squad
 FileKey1=%LocalLowAppData%\Behold Studios\Chroma Squad|*txt
 FileKey2=%LocalLowAppData%\Behold Studios\Chroma Squad\Crashes|*
 
-[Chrome Sandbox *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\chrome.sandbox.mfcdmec0b66bbd70f841470aa70f965aa4fb831f77b7f
-FileKey1=%LocalAppData%\Packages\chrome.sandbox.*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\chrome.sandbox.*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\chrome.sandbox.*\AC\Temp|*.*|RECURSE
-
 [Chromium Embedded Framework *]
 LangSecRef=3022
 DetectFile=%LocalAppData%\CEF\User Data
@@ -5069,10 +5138,7 @@ FileKey1=%ProgramFiles%\HP Games\Chuzzle Deluxe|DEBUG.TXT
 
 [Cinema Tycoon *]
 Section=Games
-Detect1=HKCU\Software\TikGames\Cinema Tycoon Gold
-Detect2=HKLM\Software\Big Fish Games\Persistence\GameDB\Cinema Tycoon Gold
-Detect3=HKLM\Software\Big Fish Games\Persistence\Install\F2676T1L1
-Detect4=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Cinema Tycoon 2  Movie Mania1.0
+DetectFile=%ProgramFiles%\Cinema Tycoon*
 FileKey1=%ProgramFiles%\Cinema Tycoon*|flashplayer7_winax.exe;*.txt
 
 [Cisco Connect *]
@@ -5638,7 +5704,7 @@ FileKey2=%CommonAppData%\Corsair\CUE\Service logs|Service_Trace*.log
 FileKey3=%LocalAppData%\Corsair\CUE\logs|*.log
 
 [Cortana *]
-LangSecRef=3031
+LangSecRef=3025
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.549981C3F5F10_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Cortana_8wekyb3d8bbwe
 Detect3=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.CortanaFollowMe_8wekyb3d8bbwe
@@ -5749,11 +5815,11 @@ RegKey1=HKCU\Software\CrypTool2.0|recentFileList
 
 [Crysis *]
 Section=Games
-DetectFile1=%ProgramFiles%\Origin Games\Crysis*
+DetectFile1=%ProgramFiles%\EA Games\Crysis*
 DetectFile2=%ProgramFiles%\Steam\Steamapps\common\Crysis*
 FileKey1=%Documents%\My Games\Crysis*\Shaders\Cache|*.*|RECURSE
-FileKey2=%ProgramFiles%\Origin Games\Crysis *|*.log
-FileKey3=%ProgramFiles%\Origin Games\Crysis *\LogBackups|*.*
+FileKey2=%ProgramFiles%\EA Games\Crysis *|*.log
+FileKey3=%ProgramFiles%\EA Games\Crysis *\LogBackups|*.*
 FileKey4=%ProgramFiles%\Steam\Steamapps\common\Crysis *|*.log
 FileKey5=%ProgramFiles%\Steam\Steamapps\common\Crysis *\LogBackups|*.*
 FileKey6=%UserProfile%\Saved Games\Crysis*\Shaders\Cache|*.*|RECURSE
@@ -7279,39 +7345,12 @@ Section=Games
 DetectFile=%Documents%\Battlefield 2042
 FileKey1=%Documents%\Battlefield 2042\Screenshots|*|RECURSE
 
-[EA Origin *]
-Section=Games
-Detect=HKLM\Software\Classes\Origin
-DetectFile=%AppData%\Origin
-FileKey1=%AppData%\Origin\*Cache|*.*
-FileKey2=%AppData%\Origin\Logs|*.*
-FileKey3=%AppData%\Origin\Telemetry|*.*
-FileKey4=%CommonAppData%\Origin\*Cache|*.*|RECURSE
-FileKey5=%CommonAppData%\Origin\*Logs|*.*
-FileKey6=%CommonAppData%\Origin\SelfUpdate\Staged|*.log
-FileKey7=%CommonAppData%\Origin\Telemetry|*.*
-FileKey8=%LocalAppData%\Origin\*Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Origin\Logs|*.txt
-FileKey10=%LocalAppData%\Origin\Origin\cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Origin\Origin\QtWebEngine\Default\Application Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Origin\Origin\QtWebEngine\Default\Service Worker\*Cache*|*.*|RECURSE
-FileKey13=%LocalAppData%\Origin\ThinSetup|*_Log.txt
-FileKey14=%ProgramFiles%\Origin|*.log
-FileKey15=%SystemDrive%|shared.log
-
-[EA Origin Installers *]
-Section=Games
-Detect=HKLM\Software\Classes\Origin
-FileKey1=%LocalAppData%\Origin\ThinSetup|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Origin|vc*redist*.exe
-FileKey3=%ProgramFiles%\Origin Games|*.cab;dotnetfx3setup;dotNetFx*.exe;dsetup*.dll;DXSETUP.EXE;dxwebsetup.exe;eula.*.txt;GamesExplorerIntegrationTool.exe;gfwlivesetup.exe;globdata.ini;install.exe;install.ini;install.res.*.dll;oalinst.exe;vc_red.exe;vc_red.msi;vcredist.bmp;vc*redist*x*.exe;xnafx*_redist.msi|RECURSE
-
 [EA Sports FIFA *]
 Section=Games
-DetectFile=%ProgramFiles%\Origin Games\FIFA*
-FileKey1=%ProgramFiles%\Origin Games\FIFA*\__Installer|InstallLog.txt
-FileKey2=%ProgramFiles%\Origin Games\FIFA*\__Installer\dotnet|*.*|REMOVESELF
-FileKey3=%ProgramFiles%\Origin Games\FIFA*\__Installer\vc|*.*|REMOVESELF
+DetectFile=%ProgramFiles%\EA Games\FIFA*
+FileKey1=%ProgramFiles%\EA Games\FIFA*\__Installer|InstallLog.txt
+FileKey2=%ProgramFiles%\EA Games\FIFA*\__Installer\dotnet|*.*|REMOVESELF
+FileKey3=%ProgramFiles%\EA Games\FIFA*\__Installer\vc|*.*|REMOVESELF
 
 [Earth 2160 *]
 Section=Games
@@ -7640,19 +7679,6 @@ FileKey1=%AppData%\Indenova\eSigna Desktop\log|*.*
 LangSecRef=3022
 DetectFile=%AppData%\eSobi
 FileKey1=%AppData%\eSobi\*\temp|*.*|RECURSE
-
-[ESPN Cricinfo *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma
-FileKey1=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey3=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey5=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\PRICache|*.*
-FileKey7=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Temp|*.*
-FileKey8=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\LocalState|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\TempState|*.*|RECURSE
 
 [Essential NetTools 3 *]
 LangSecRef=3022
@@ -8080,15 +8106,6 @@ RegKey3=HKCU\Software\GOFF Concepts\FileSearchEX|Sys_SearchHistory
 LangSecRef=3022
 Detect=HKLM\Software\FileZilla Client
 FileKey1=%ProgramFiles%\FileZilla FTP Client|*.tmp
-
-[FilmOn TV *]
-LangSecRef=3031
-DetectFile=%LocalAppData%\Packages\FilmOnLiveTVFree.*_zx03kxexxb716
-FileKey1=%LocalAppData%\Packages\FilmOnLiveTVFree.*_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\FilmOnLiveTVFree.*_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\FilmOnLiveTVFree.*_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey4=%LocalAppData%\Packages\FilmOnLiveTVFree.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\FilmOnLiveTVFree.FilmOnLiveTVFree_zx03kxexxb716\SearchHistory
 
 [FINAM Forex Terminal *]
 LangSecRef=3021
@@ -8656,16 +8673,6 @@ Section=Games
 DetectFile=%ProgramFiles%\Steam\steamapps\common\GarrysMod
 FileKey1=%ProgramFiles%\Steam\steamapps\common\GarrysMod|*.cache|RECURSE
 
-[GasBuddy *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\45351D82.GasBuddy-FindCheapGasPrices_932xwky9axss4
-FileKey1=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\PRICache|*.*
-FileKey5=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Temp|*.*
-FileKey6=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\TempState|*.*|RECURSE
-
 [Gatewatch *]
 Section=Games
 DetectFile=%Documents%\Gatewatch_Logs
@@ -9077,24 +9084,23 @@ FileKey1=%AppData%\Elephant Games\Grim Tales The Wishes CE|logfile.txt
 [Groove Media Player *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneMusic_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\AppCache|*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\*Cache|*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\INet*|*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\PRICache|*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Temp|*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\TokenBroker\Cache|*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalCache\Image|*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalCache\PlayReady|*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState|*.tmp;AppState.json*;*.db*
-FileKey12=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\Database\*|*.log
-FileKey13=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageCache|*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageRetrievalFailure|*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageStore|*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\navigationHistory|*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\PlayReady|*|RECURSE
-FileKey18=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\TempState|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Temp|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalCache\Image|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalCache\PlayReady|*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState|*.tmp;AppState.json*;*.db*
+FileKey11=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\Database\*|*.log
+FileKey12=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageCache|*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageRetrievalFailure|*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageStore|*|RECURSE
+FileKey15=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\navigationHistory|*|RECURSE
+FileKey16=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\PlayReady|*|RECURSE
+FileKey17=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneMusic_8wekyb3d8bbwe\SearchHistory
 
 [GroupWise Messenger *]
@@ -9624,13 +9630,12 @@ FileKey2=%LocalAppData%\Hewlett-Packard\MediaSmart\Photo\tm*Cache|*.*|REMOVESELF
 [HP Scan and Capture *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\AD2F1837.HPScanandCapture_v10z8vjag6ke6
-FileKey1=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\INet*|*|RECURSE
 FileKey3=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
-FileKey4=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey5=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\PRICache|*.*
-FileKey6=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\Temp|*.*
-FileKey7=%LocalAppData%\Packages\*.HPScanandCapture_*\LocalState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey5=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\Temp|*
+FileKey6=%LocalAppData%\Packages\*.HPScanandCapture_*\LocalState|*|RECURSE
 
 [HP Smart *]
 LangSecRef=3031
@@ -10127,7 +10132,7 @@ FileKey24=%WinDir%\SysWOW64|Gms.log
 FileKey25=%WinDir%\SysWOW64\config\systemprofile\Intel\Logs|*.*|REMOVESELF
 
 [Intel Graphics Command Center *]
-LangSecRef=3031
+LangSecRef=3024
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\AppUp.IntelGraphicsExperience_8j3eq9eme6ctt
 FileKey1=%LocalAppData%\Intel\GCC|gcc*_log_*.txt	
 FileKey2=%LocalAppData%\Packages\AppUp.IntelGraphicsExperience_*\AC\BackgroundTransferApi|*.*|RECURSE
@@ -10750,11 +10755,10 @@ FileKey1=%AppData%\JustVoip|History_*.dat
 [jv16 PowerTools *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\jv16 PowerTools*
-FileKey1=%ProgramFiles%\jv16 PowerTools*|*.log;*.reg
-FileKey2=%ProgramFiles%\jv16 PowerTools*\Backups|*|RECURSE
-FileKey3=%ProgramFiles%\jv16 PowerTools*\Settings|*.log
-FileKey4=%ProgramFiles%\jv16 PowerTools*\Temp|*|RECURSE
-FileKey5=%ProgramFiles%\jv16 PowerTools\Debug|*.log
+FileKey1=%ProgramFiles%\jv16 PowerTools*|*.log
+FileKey2=%ProgramFiles%\jv16 PowerTools*\Settings|*.log
+FileKey3=%ProgramFiles%\jv16 PowerTools*\Temp|*|RECURSE
+FileKey4=%ProgramFiles%\jv16 PowerTools\Debug|*.log;*.txt
 
 [jv16 RegCleaner *]
 LangSecRef=3024
@@ -10995,6 +10999,12 @@ LangSecRef=3023
 Detect=HKLM\Software\Krita
 FileKey1=%LocalAppData%|krita*.log
 FileKey2=%LocalAppData%\krita\cache|*.*|RECURSE
+
+[kv16 PowerTools Backups *]
+LangSecRef=3024
+DetectFile=%ProgramFiles%\jv16 PowerTools*
+FileKey1=%ProgramFiles%\jv16 PowerTools*|*.reg
+FileKey2=%ProgramFiles%\jv16 PowerTools*\Backups|*|RECURSE
 
 [L0pht AntiSniff *]
 LangSecRef=3024
@@ -12059,14 +12069,6 @@ RegKey11=HKCU\Software\Microsoft\Microsoft Help Workshop\Recent File List
 RegKey12=HKCU\Software\Microsoft\Microsoft HTML Help Image Editor\Folders
 RegKey13=HKCU\Software\Microsoft\Microsoft HTML Help Image Editor\Recent File List
 
-[Microsoft LifeCam *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.LifeCamDashboard_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\PRICache|*.*
-FileKey3=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\Temp|*.*
-FileKey4=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\TempState|*.*|RECURSE
-
 [Microsoft Management Console *]
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\MMC
@@ -12087,6 +12089,18 @@ FileKey3=%LocalAppData%\Packages\Microsoft.Messaging_*\LocalCache|*.etl;*.xml
 FileKey4=%LocalAppData%\Packages\Microsoft.Messaging_*\LocalState\Cache|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.Messaging_*\TempState|*.*|RECURSE
 
+[Microsoft Mixed Reality Portal *]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MixedReality.Portal_8wekyb3d8bbwe
+FileKey1=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\AppCache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\Temp|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\LocalCache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\LocalState\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\TempState|*|RECURSE
+
 [Microsoft Mouse and Keyboard Center *]
 LangSecRef=3021
 DetectFile1=%ProgramFiles%\Microsoft Device Center
@@ -12098,26 +12112,26 @@ RegKey2=HKCU\Software\Microsoft\IntelliType Pro\AppSpecific
 [Microsoft Network Speed Test *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.NetworkSpeedTest_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CLR_v4.0*|*.log
-FileKey3=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\PRICache|*.*
+FileKey1=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\*Cache|*.*
+FileKey2=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CLR_v4.0*|*.log
+FileKey4=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey6=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Temp|*.*
 FileKey7=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\TempState|*.*|RECURSE
 
 [Microsoft News *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingNews_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\PRICache|*.*
-FileKey5=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.BingNews_*\LocalState\Cache\Images|*.*
-FileKey8=%LocalAppData%\Packages\Microsoft.BingNews_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.BingNews_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\*Cache|*
+FileKey2=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Temp|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.BingNews_*\LocalState\Cache\Images|*
+FileKey8=%LocalAppData%\Packages\Microsoft.BingNews_*\LocalState\navigationHistory|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.BingNews_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingNews_8wekyb3d8bbwe\SearchHistory
 
 [Microsoft Office *]
@@ -12220,25 +12234,24 @@ ExcludeKey4=PATH|%AppData%\Microsoft\Word\STARTUP\|*.*
 LangSecRef=3021
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.microsoftskydrive_8wekyb3d8bbwe
 Detect2=HKCU\Software\Microsoft\OneDrive
-FileKey1=%LocalAppData%\Microsoft\OneDrive\Logs|*.*|RECURSE
-FileKey2=%LocalAppData%\Microsoft\OneDrive\Setup\Logs|*.*|RECURSE
-FileKey3=%LocalAppData%\Microsoft\Windows\OneDrive\logs|*.*|RECURSE
-FileKey4=%LocalAppData%\OneDrive\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\AppCache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\INet*|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey9=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\PRICache|*.*
-FileKey10=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Temp|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\LocalCache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\LocalState\Logs|*.log
-FileKey13=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\TempState|*.*|RECURSE
-FileKey14=%ProgramFiles%\Microsoft OneDrive\Setup\Logs|*.*
-FileKey15=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\OneDrive\Logs|*.*|RECURSE
-FileKey16=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\OneDrive\Setup\Logs|*.*|RECURSE
-FileKey17=%WinDir%\System32\LogFiles\CloudFiles|*.*|RECURSE
-FileKey18=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\OneDrive\Logs|*.*|RECURSE
-FileKey19=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\OneDrive\Setup\Logs|*.*|RECURSE
+FileKey1=%LocalAppData%\Microsoft\OneDrive\Logs|*|RECURSE
+FileKey2=%LocalAppData%\Microsoft\OneDrive\Setup\Logs|*|RECURSE
+FileKey3=%LocalAppData%\Microsoft\Windows\OneDrive\logs|*|RECURSE
+FileKey4=%LocalAppData%\OneDrive\Cache|*|RECURSE
+FileKey5=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\*Cache|*|RECURSE
+FileKey6=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\INet*|*|RECURSE
+FileKey7=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey8=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey9=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Temp|*|RECURSE
+FileKey10=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\LocalCache|*|RECURSE
+FileKey11=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\LocalState\Logs|*.log
+FileKey12=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\TempState|*|RECURSE
+FileKey13=%ProgramFiles%\Microsoft OneDrive\Setup\Logs|*
+FileKey14=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\OneDrive\Logs|*|RECURSE
+FileKey15=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\OneDrive\Setup\Logs|*|RECURSE
+FileKey16=%WinDir%\System32\LogFiles\CloudFiles|*|RECURSE
+FileKey17=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\OneDrive\Logs|*|RECURSE
+FileKey18=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\OneDrive\Setup\Logs|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.microsoftskydrive_8wekyb3d8bbwe\PersistedPickerData\microsoft.microsoftskydrive_8wekyb3d8bbwe!Microsoft.MicrosoftSkyDrive\DefaultOpenFileMultiple|LastLocation
 RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.microsoftskydrive_8wekyb3d8bbwe\SearchHistory
 
@@ -12310,36 +12323,28 @@ DetectFile=%AppData%\Microsoft\Picture It!*
 FileKey1=%AppData%\Microsoft\Picture It!*|piorg.db
 
 [Microsoft PlayReady *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Media.PlayReadyClient_8wekyb3d8bbwe
 FileKey1=%CommonAppData%\Microsoft\PlayReady|*.hds
 FileKey2=%CommonAppData%\Microsoft\PlayReady\Cache|*.*
 FileKey3=%CommonAppData%\Microsoft\Windows\DRM|*.log
 FileKey4=%CommonAppData%\Microsoft\Windows\DRM\Cache|*.*|RECURSE
 FileKey5=%CommonAppData%\Microsoft\Windows\DRM\PreUpgrade|*.log
-FileKey6=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\AppCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\INet*|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey10=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\PRICache|*.*
-FileKey12=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Temp|*.*
-FileKey13=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\Cache|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\TempState|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\*Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\INet*|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey10=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Temp|*
+FileKey12=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\Cache|*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\navigationHistory|*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\TempState|*|RECURSE
 
 [Microsoft Project 2010 *]
 LangSecRef=3021
 Detect=HKCU\Software\Microsoft\Office\14.0\MS Project
 RegKey1=HKCU\Software\Microsoft\Office\14.0\MS Project\Recent File List
 RegKey2=HKCU\Software\Microsoft\Office\14.0\MS Project\Recent Templates
-
-[Microsoft Reader *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Reader_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.Reader_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Reader_*\AC\Temp|*.*
-FileKey3=%LocalAppData%\Packages\Microsoft.Reader_*\TempState|*.*|RECURSE
 
 [Microsoft Robocopy GUI *]
 LangSecRef=3025
@@ -12372,7 +12377,7 @@ Detect=HKCU\Software\Microsoft\Microsoft Standalone System Sweeper Tool
 FileKey1=%CommonAppData%\Microsoft\Microsoft Standalone System Sweeper Tool\Support|*.log
 
 [Microsoft Store *]
-LangSecRef=3031
+LangSecRef=3025
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsStore_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\winstore_cw5n1h2txyewy
 FileKey1=%LocalAppData%\Packages\Microsoft.StorePurchaseApp_*\AC\AppCache\*|*.*|REMOVESELF
@@ -12408,6 +12413,19 @@ DetectFile=%LocalAppData%\SaRALogs
 FileKey1=%LocalAppData%\SaRALogs|*.*|RECURSE
 FileKey2=%LocalAppData%\SaraResults|SaraResult_*.xml
 
+[Microsoft Sway *]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Office.Sway_8wekyb3d8bbwe
+FileKey1=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\AppCache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Microsoft\Internet Explorer\DOMStore\*|*|REMOVESELF
+FileKey5=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Temp|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalCache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalState\Cache|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.Office.Sway_*\TempState|*|RECURSE
+
 [Microsoft Teams *]
 LangSecRef=3021
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\MicrosoftTeams_8wekyb3d8bbwe
@@ -12433,14 +12451,6 @@ FileKey18=%LocalAppData%\Packages\MicrosoftTeams_*\AC\INet*|*.*|RECURSE
 FileKey19=%LocalAppData%\Packages\MicrosoftTeams_*\AC\Temp|*.*|RECURSE
 FileKey20=%LocalAppData%\Packages\MicrosoftTeams_*\LocalCache|*.*|RECURSE
 FileKey21=%LocalAppData%\Packages\MicrosoftTeams_*\TempState|*.*|RECURSE
-
-[Microsoft Text Input *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\InputApp_cw5n1h2txyewy
-FileKey1=%LocalAppData%\Packages\InputApp_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\InputApp_*\AC\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\InputApp_*\LocalCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\InputApp_*\TempState|*.*|RECURSE
 
 [Microsoft Tips *]
 LangSecRef=3031
@@ -13045,7 +13055,7 @@ FileKey1=%CommonAppData%\Techsoft\MirrorFolder\Log|*.*
 
 [Mirrors Edge Catalyst Backup *]
 Section=Games
-Detect=HKLM\Software\Origin Games\1026480
+Detect=HKLM\Software\EA Games\1026480
 FileKey1=%Documents%\Mirrors Edge Catalyst\settings|PROF_SAVE_backup*
 
 [MiTeC DFM Editor *]
@@ -13115,18 +13125,6 @@ FileKey2=%LocalAppData%\Mixed In Key\Mixed In Key\*\AudioAnalysisCache*|*.*
 FileKey3=%LocalAppData%\Mixed In Key\Mixed In Key\*\QueryLogs|*.*
 FileKey4=%LocalAppData%\Mixed In Key\Mixed In Key\*\Temp|*.*
 FileKey5=%LocalAppData%\Mixed In Key\Mixed In Key\*\Updates|update.exe
-
-[Mixed Reality Portal *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MixedReality.Portal_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\TempState|*.*|RECURSE
 
 [MixMeister *]
 LangSecRef=3023
@@ -13357,22 +13355,21 @@ FileKey2=%LocalAppData%\Collectorz.com\Movie Collector\Temp\Images|*.*
 [Movies & TV *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneVideo_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\PRICache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalCache\PlayReady|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\Database\anonymous|*.log
-FileKey11=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageCache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageRetrievalFailure|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageStore|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\PlayReady|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Temp|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalCache\PlayReady|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\Database\anonymous|*.log
+FileKey10=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageCache|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageRetrievalFailure|*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageStore|*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\navigationHistory|*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\PlayReady|*|RECURSE
+FileKey15=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneVideo_8wekyb3d8bbwe\SearchHistory\SearchHistory
 
 [MP3Gain *]
@@ -13445,43 +13442,31 @@ LangSecRef=3024
 DetectFile=%ProgramFiles%\MSI\MSI Remind Manager
 FileKey1=%ProgramFiles%\MSI\MSI Remind Manager|Log_reminder.txt
 
-[MSN Food & Drink *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingFoodAndDrink_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.BingFoodAndDrink_*\LocalState\Cache|*.*|RECURSE
-
-[MSN Health & Fitness *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingHealthAndFitness_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.BingHealthAndFitness_*\LocalState\Cache|*.*|RECURSE
-
 [MSN Money *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingFinance_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\PRICache|*.*
-FileKey6=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.BingFinance_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Temp|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.BingFinance_*\TempState|*|RECURSE
 
 [MSN Weather *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingWeather_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\INet*|*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\CLR_v4.0|*.log
-FileKey4=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\PRICache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState|*.tmp;UserActivity.json
-FileKey10=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.BingWeather_*\TempState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Temp|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState|*.tmp;UserActivity.json
+FileKey9=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\Cache|*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\navigationHistory|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.BingWeather_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingWeather_8wekyb3d8bbwe\SearchHistory
 
 [MTA: San Andreas *]
@@ -13952,19 +13937,18 @@ FileKey2=%UserProfile%\.nbi\log|*.log|RECURSE
 [Netflix *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\4DF9E0F8.Netflix_mcm4njqhnhss8
-FileKey1=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\BackgroundTransferApi|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\INet*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\Internet Explorer\DOMStore\*|*.*|REMOVESELF
-FileKey7=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\PRICache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Temp|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AppData\Indexed DB|*.log
-FileKey10=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalCache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState|*.tmp
-FileKey12=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState\LiveTile|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\BackgroundTransferApi|*|RECURSE
+FileKey3=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\INet*|*|RECURSE
+FileKey4=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey5=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey6=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\Internet Explorer\DOMStore\*|*|REMOVESELF
+FileKey7=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Temp|*|RECURSE
+FileKey8=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AppData\Indexed DB|*.log
+FileKey9=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalCache|*|RECURSE
+FileKey10=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState|*.tmp
+FileKey11=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState\LiveTile|*|RECURSE
+FileKey12=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\4DF9E0F8.Netflix_mcm4njqhnhss8\SearchHistory
 ExcludeKey1=FILE|%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\Internet Explorer\DOMStore\*\|www.netflix[1].xml
 
@@ -17292,25 +17276,24 @@ LangSecRef=3021
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.SkypeApp_kzf8qxf38zg5c
 DetectFile=%AppData%\Microsoft\Skype for Desktop
 FileKey1=%AppData%\Microsoft\Skype for Desktop|*-journal;*.old;LOG;Network Persistent State;QuotaManager;Skype-Setup.exe|RECURSE
-FileKey2=%AppData%\Microsoft\Skype for Desktop\blob_storage|*.*|RECURSE
-FileKey3=%AppData%\Microsoft\Skype for Desktop\Code Cache|*.*|RECURSE
-FileKey4=%AppData%\Microsoft\Skype for Desktop\Logs|*.*
+FileKey2=%AppData%\Microsoft\Skype for Desktop\blob_storage|*|RECURSE
+FileKey3=%AppData%\Microsoft\Skype for Desktop\Code Cache|*|RECURSE
+FileKey4=%AppData%\Microsoft\Skype for Desktop\Logs|*
 FileKey5=%AppData%\Microsoft\Skype for Desktop\Media-stack|*.bak;*.blog;*.etl
 FileKey6=%AppData%\Microsoft\Skype for Desktop\skylib|*.blog
-FileKey7=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\AppCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\INet*|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey10=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\PRICache|*.*
-FileKey12=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Temp|*.*
-FileKey13=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalCache\Roaming\Microsoft\Skype for Store|*-journal;*.old;LOG;Network Persistent State|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalCache\Roaming\Microsoft\Skype for Store\*Cache|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalCache\Roaming\Microsoft\Skype for Store\Logs|*.*
-FileKey16=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState|*-shm;*-wal
-FileKey17=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState\DiagOutputDir|*.*
-FileKey18=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState\logs|*.*|RECURSE
-FileKey19=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState\tracing\wppmedia|*.bak;*.etl
-FileKey20=%LocalAppData%\Packages\Microsoft.SkypeApp_*\TempState|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\*Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\INet*|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey10=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Temp|*
+FileKey12=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalCache\Roaming\Microsoft\Skype for Store|*-journal;*.old;LOG;Network Persistent State|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalCache\Roaming\Microsoft\Skype for Store\*Cache|*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalCache\Roaming\Microsoft\Skype for Store\Logs|*
+FileKey15=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState|*-shm;*-wal
+FileKey16=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState\DiagOutputDir|*
+FileKey17=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState\logs|*|RECURSE
+FileKey18=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState\tracing\wppmedia|*.bak;*.etl
+FileKey19=%LocalAppData%\Packages\Microsoft.SkypeApp_*\TempState|*|RECURSE
 
 [SkypeAlyzer *]
 LangSecRef=3024
@@ -17493,7 +17476,7 @@ FileKey1=%AppData%\PictureMover\Log|*.*
 [Snip & Sketch *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ScreenSketch_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\MicrosoftWindows.Client.CBS_cw5n1h2txyewy\TempState\ScreenClip|*.*
+FileKey1=%LocalAppData%\Packages\MicrosoftWindows.Client.*\TempState\ScreenClip|*
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ScreenSketch_8wekyb3d8bbwe\PersistedPickerData\Microsoft.ScreenSketch_8wekyb3d8bbwe!App\AppSnipAndSketchFileSaveSettings|LastLocation
 RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ScreenSketch_8wekyb3d8bbwe\PersistedPickerData\Microsoft.ScreenSketch_8wekyb3d8bbwe!App\DefaultOpenFileSingle|LastLocation
 
@@ -18046,12 +18029,12 @@ Section=Games
 Detect=HKLM\Software\BioWare\Star Wars-The Old Republic
 FileKey1=%Documents%|*Install STAR WARS The Old Republic.log
 FileKey2=%LocalAppData%\SWTOR\CrashDump\swtor|*.*
-FileKey3=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\betatest\retailclient\Temp|*.log
-FileKey4=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\logs|*.log
-FileKey5=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\swtor\retailclient\swtor\logs|*.log
-FileKey6=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
-FileKey7=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\logs|*.*
-FileKey8=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
+FileKey3=%ProgramFiles%\EA Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
+FileKey4=%ProgramFiles%\EA Games\Star Wars - The Old Republic\logs|*.*
+FileKey5=%ProgramFiles%\EA Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
+FileKey6=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\betatest\retailclient\Temp|*.log
+FileKey7=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\logs|*.log
+FileKey8=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\swtor\retailclient\swtor\logs|*.log
 
 [StarCraft I/II *]
 Section=Games
@@ -18245,7 +18228,7 @@ FileKey1=%LocalAppData%\SterJo NetStalker|dscnt.exe;History.sjh
 FileKey2=%LocalAppData%\SterJo NetStalker\Logs|*.*
 
 [Sticky Notes *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MicrosoftStickyNotes_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\Microsoft.MicrosoftStickyNotes_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.MicrosoftStickyNotes_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
@@ -18253,16 +18236,6 @@ FileKey3=%LocalAppData%\Packages\Microsoft.MicrosoftStickyNotes_*\AC\Temp|*.*|RE
 FileKey4=%LocalAppData%\Packages\Microsoft.MicrosoftStickyNotes_*\AC\TokenBroker\Cache|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.MicrosoftStickyNotes_*\LocalCache|*.*|RECURSE
 FileKey6=%LocalAppData%\Packages\Microsoft.MicrosoftStickyNotes_*\TempState|*.*|RECURSE
-
-[Stocks and Futures *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\24877CutthroatSoftware.StocksandFutures_xgnzh3xnefnqe
-FileKey1=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey3=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\AC\Temp|*.*
-FileKey4=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\AppData\Indexed DB|*.log
-FileKey5=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\LocalState|*.tmp|RECURSE
-FileKey6=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\TempState|*.*|RECURSE
 
 [STOIK Smart Resizer *]
 LangSecRef=3023
@@ -18406,19 +18379,6 @@ FileKey3=%AppData%\SuuntoLink\Feedback|*.dmp;*.log
 FileKey4=%AppData%\SuuntoLink\Logs|*.*
 FileKey5=%AppData%\SuuntoLink\webrtc_event_logs|*.*
 FileKey6=%LocalAppData%\SuuntoLink|*.log|RECURSE
-
-[Sway *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Office.Sway_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Microsoft\Internet Explorer\DOMStore\*|*.*|REMOVESELF
-FileKey5=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalState\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Office.Sway_*\TempState|*.*|RECURSE
 
 [Swiff Player *]
 LangSecRef=3023
@@ -19490,15 +19450,14 @@ FileKey6=%AppData%\Twitch\logs\*|*.json;*.log|REMOVESELF
 [Twitter *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\9E2F88E3.Twitter_wgeqdkkx372wm
-FileKey1=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\INet*|*|RECURSE
 FileKey3=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Microsoft\*|*.LOG|RECURSE
-FileKey4=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Microsoft\Internet Explorer\DOMStore\*|*.*|REMOVESELF
-FileKey6=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\PRICache|*.*
-FileKey7=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AppData\Indexed DB|*.log
-FileKey9=%LocalAppData%\Packages\9E2F88E3.Twitter_*\LocalState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Microsoft\Internet Explorer\DOMStore\*|*|REMOVESELF
+FileKey6=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Temp|*|RECURSE
+FileKey7=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AppData\Indexed DB|*.log
+FileKey8=%LocalAppData%\Packages\9E2F88E3.Twitter_*\LocalState|*|RECURSE
 
 [Two Worlds Epic Edition *]
 Section=Games
@@ -19613,21 +19572,20 @@ FileKey1=%AppData%\ATViewer|ViewerHistory.ini
 [Universal Windows Platform *]
 LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData
-FileKey1=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\AC\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\LocalCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\LocalState|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\TempState|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\AppCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\INet*|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey10=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\PRICache|*.*
-FileKey12=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Temp|*.*
-FileKey13=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\Cache|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\AC\Temp|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\LocalCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\LocalState|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\TempState|*|RECURSE
+FileKey6=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\*Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\INet*|*|RECURSE
+FileKey8=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey9=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey10=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey11=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Temp|*
+FileKey12=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\Cache|*|RECURSE
+FileKey13=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\navigationHistory|*|RECURSE
+FileKey14=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Phone\ShellUI\WindowSizing
 RegKey2=HKCU\Software\Microsoft\UserData\UninstallTimes
 
@@ -19647,17 +19605,6 @@ Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\unlockroot.exe
 Detect2=HKLM\Software\UnlockrootPro
 FileKey1=%ProgramFiles%\Unlockroot*|*.txt
 FileKey2=%ProgramFiles%\Unlockroot*\tools|*.zip
-
-[Unofficial NewsReader for CNN *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\65465Fetisenko.NewsReaderforCNN_806cg6g6fmyng
-FileKey1=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\AppCache\*|*.*|REMOVESELF
-FileKey2=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\INet*\*|*.*|REMOVESELF
-FileKey3=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\Microsoft\Internet Explorer\DOMStore\*|*.*|REMOVESELF
-FileKey5=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\Temp|*.*
-FileKey6=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\TokenBroker\Cache|*.*|REMOVESELF
-FileKey7=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\TempState|*.*|RECURSE
 
 [Unreal Tournament: Game of the Year *]
 Section=Games
@@ -20441,66 +20388,65 @@ LangSecRef=3024
 Detect=HKCU\Software\Yamicsoft\Windows 7 Manager
 FileKey1=%ProgramFiles%\Yamicsoft\Windows 7 Manager\DiskAnalyzerXML|*.*
 
-[Windows Alarms & Clock *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsAlarms_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\AC\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\LocalCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\LocalState|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\TempState|*.*|RECURSE
-
 [Windows AutoPlay Devices *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers\KnownDevices
 
 [Windows Calculator *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsCalculator_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\AC\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\LocalCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\LocalState\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\AC\Temp|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\LocalCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\LocalState\Cache|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\TempState|*|RECURSE
 
 [Windows Camera *]
-LangSecRef=3031
+LangSecRef=3025
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Camera_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsCamera_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\PRICache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.*Camera_*\TempState|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\AppData|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\Cache|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\Temp|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.*Camera_*\TempState|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalCache|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\AppData|*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\Cache|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Camera_8wekyb3d8bbwe\SearchHistory
 
 [Windows CD Burning Queue *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\CD Burning
-FileKey1=%LocalAppData%\Microsoft\CD Burning|*.*|RECURSE
-FileKey2=%LocalAppData%\Microsoft\Windows\Burn|*.*|RECURSE
+FileKey1=%LocalAppData%\Microsoft\CD Burning|*|RECURSE
+FileKey2=%LocalAppData%\Microsoft\Windows\Burn|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\CD Burning\StagingInfo
+
+[Windows Clock *]
+LangSecRef=3025
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsAlarms_8wekyb3d8bbwe
+FileKey1=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\AC\Temp|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\LocalCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\LocalState|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\TempState|*|RECURSE
 
 [Windows Cryptographic Services *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
-FileKey1=%LocalLowAppData%\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey2=%LocalLowAppData%\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey3=%WinDir%\ServiceProfiles\*\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey4=%WinDir%\ServiceProfiles\*\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey5=%WinDir%\System32\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%WinDir%\System32\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%WinDir%\System32\config\systemprofile\Application Data\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey8=%WinDir%\System32\config\systemprofile\Application Data\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey9=%WinDir%\SysWOW64\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey10=%WinDir%\SysWOW64\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
+FileKey1=%LocalLowAppData%\Microsoft\CryptnetUrlCache\Content|*|RECURSE
+FileKey2=%LocalLowAppData%\Microsoft\CryptnetUrlCache\MetaData|*|RECURSE
+FileKey3=%WinDir%\ServiceProfiles\*\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*|RECURSE
+FileKey4=%WinDir%\ServiceProfiles\*\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*|RECURSE
+FileKey5=%WinDir%\System32\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*|RECURSE
+FileKey6=%WinDir%\System32\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*|RECURSE
+FileKey7=%WinDir%\System32\config\systemprofile\Application Data\Microsoft\CryptnetUrlCache\Content|*|RECURSE
+FileKey8=%WinDir%\System32\config\systemprofile\Application Data\Microsoft\CryptnetUrlCache\MetaData|*|RECURSE
+FileKey9=%WinDir%\SysWOW64\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*|RECURSE
+FileKey10=%WinDir%\SysWOW64\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*|RECURSE
 
 [Windows Device Manager *]
 LangSecRef=3025
@@ -20523,10 +20469,10 @@ RegKey8=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\MRU3
 [Windows Error Reporting *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows\Windows Error Reporting
-FileKey1=%LocalAppData%\PCHealth\ErrorRep\QSignoff|*.*
-FileKey2=%WinDir%\pchealth\ERRORREP|*.*|RECURSE
+FileKey1=%LocalAppData%\PCHealth\ErrorRep\QSignoff|*
+FileKey2=%WinDir%\pchealth\ERRORREP|*|RECURSE
 FileKey3=%WinDir%\pchealth\helpctr\DataColl|*.xml
-FileKey4=%WinDir%\pchealth\helpctr\OfflineCache|*.*|RECURSE
+FileKey4=%WinDir%\pchealth\helpctr\OfflineCache|*|RECURSE
 FileKey5=%WinDir%\System32\config\systemprofile\AppData\Local\CrashDumps|*.dmp|RECURSE
 FileKey6=%WinDir%\System32\config\systemprofile\Local Settings\Application Data\CrashDumps|*.dmp|RECURSE
 FileKey7=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\CrashDumps|*.dmp|RECURSE
@@ -20547,18 +20493,18 @@ FileKey2=%LocalAppData%\Microsoft\Event Viewer|RecentViews
 LangSecRef=3025
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsFeedback_cw5n1h2txyewy
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsFeedbackHub_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\LocalCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\TempState|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\AppCache|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\LocalCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\TempState|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\AppCache|*|RECURSE
 FileKey6=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*|*.log
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Temp|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\LocalState\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.WindowsFeedbackHub_*\AC\Temp|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Temp|*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\LocalState\Cache|*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.WindowsFeedbackHub_*\AC\Temp|*|RECURSE
 FileKey13=%LocalAppData%\Packages\Microsoft.WindowsFeedbackHub_*\LocalState\DiagOutputDir|*.txt
 
 [Windows File Manager *]
@@ -20566,14 +20512,14 @@ LangSecRef=3031
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\FileManager_cw5n1h2txyewy
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsFileManager_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\FileManager_*\LocalState|*.jpg
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\AC\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\Local\*|*.*|REMOVESELF
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\LocalLow\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\LocalLow\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\Roaming\*|*.*|REMOVESELF
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\Temp|*.*|REMOVESELF
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\AC\Temp|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\Local\*|*|REMOVESELF
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\LocalLow\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\LocalLow\Temp|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\Roaming\*|*|REMOVESELF
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\Temp|*|REMOVESELF
+FileKey9=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\TempState|*|RECURSE
 
 [Windows Font Cache *]
 LangSecRef=3025
@@ -20592,27 +20538,27 @@ FileKey1=%LocalAppData%\Microsoft Games|*.xml*|RECURSE
 LangSecRef=3025
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.GetHelp_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Windows.ContactSupport_cw5n1h2txyewy
-FileKey1=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.GetHelp_*\LocalCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.GetHelp_*\LocalState\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.GetHelp_*\TempState|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\AppCache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\AppCache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\Temp|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.GetHelp_*\LocalCache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.GetHelp_*\LocalState\Cache|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.GetHelp_*\TempState|*|RECURSE
+FileKey10=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\AppCache|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\INet*|*|RECURSE
 FileKey12=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*|*.log
-FileKey13=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Temp|*.*|RECURSE
-FileKey18=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey19=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalCache|*.*|RECURSE
-FileKey20=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalState\Cache|*.*|RECURSE
-FileKey21=%LocalAppData%\Packages\Windows.ContactSupport_*\TempState|*.*|RECURSE
+FileKey13=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*|RECURSE
+FileKey14=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*|RECURSE
+FileKey15=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey16=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey17=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Temp|*|RECURSE
+FileKey18=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey19=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalCache|*|RECURSE
+FileKey20=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalState\Cache|*|RECURSE
+FileKey21=%LocalAppData%\Packages\Windows.ContactSupport_*\TempState|*|RECURSE
 
 [Windows Grep *]
 LangSecRef=3024
@@ -20625,60 +20571,58 @@ RegKey4=HKCU\Software\Windows Grep\Windows Grep\Current Version\Search Dialog\St
 [Windows Image Acquisition *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\WIA
-FileKey1=%AppData%\Microsoft\Document Center\UserScanProfiles|*.*
-FileKey2=%LocalAppData%\Microsoft\UserScanProfiles|*.*
+FileKey1=%AppData%\Microsoft\Document Center\UserScanProfiles|*
+FileKey2=%LocalAppData%\Microsoft\UserScanProfiles|*
 FileKey3=%UserProfile%|Sti_Trace.log
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\WIA
 
 [Windows Installer *]
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Installer
-FileKey1=%SystemDrive%\Config.msi|*.*|REMOVESELF
+FileKey1=%SystemDrive%\Config.msi|*|REMOVESELF
 FileKey2=%WinDir%\Installer|*.tmp|RECURSE
 FileKey3=%WinDir%\Installer|SourceHash{*};wix{*}.SchedServiceConfig.rmi
-FileKey4=%WinDir%\Installer\Config.Msi|*.*|REMOVESELF
-FileKey5=%WinDir%\Installer\MSI*.tmp-|*.*|REMOVESELF
+FileKey4=%WinDir%\Installer\Config.Msi|*|REMOVESELF
+FileKey5=%WinDir%\Installer\MSI*.tmp-|*|REMOVESELF
 
 [Windows Language Libraries *]
 LangSecRef=3025
-DetectFile1=%LocalAppData%\Packages\Microsoft.VCLibs.1*0.00_8wekyb3d8bbwe
-DetectFile2=%LocalAppData%\Packages\Microsoft.WinJS.*.0_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey5=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\PRICache|*.*
-FileKey7=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Temp|*.*
-FileKey8=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\LocalState\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\TempState|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\AppCache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\INet*|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey15=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\PRICache|*.*
-FileKey17=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Temp|*.*
-FileKey18=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\LocalState\*Cache|*.*|RECURSE
-FileKey19=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey20=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\TempState|*.*|RECURSE
-FileKey21=%SystemDrive%|eula.*.txt;globdata.ini;install.exe;install.ini;install.res.*.dll;VC_RED.cab;VC_RED.MSI;vcredist.bmp
+DetectFile1=%LocalAppData%\Packages\Microsoft.VCLibs.*
+DetectFile2=%LocalAppData%\Packages\Microsoft.WinJS.*
+FileKey1=%LocalAppData%\Packages\Microsoft.VCLibs.*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.VCLibs.*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.VCLibs.*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.VCLibs.*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey5=%LocalAppData%\Packages\Microsoft.VCLibs.*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.VCLibs.*\AC\Temp|*
+FileKey7=%LocalAppData%\Packages\Microsoft.VCLibs.*\LocalState\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.VCLibs.*\LocalState\navigationHistory|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.VCLibs.*\TempState|*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.WinJS.*\AC\*Cache|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.WinJS.*\AC\INet*|*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.WinJS.*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.WinJS.*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey14=%LocalAppData%\Packages\Microsoft.WinJS.*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey15=%LocalAppData%\Packages\Microsoft.WinJS.*\AC\Temp|*
+FileKey16=%LocalAppData%\Packages\Microsoft.WinJS.*\LocalState\*Cache|*|RECURSE
+FileKey17=%LocalAppData%\Packages\Microsoft.WinJS.*\LocalState\navigationHistory|*|RECURSE
+FileKey18=%LocalAppData%\Packages\Microsoft.WinJS.*\TempState|*|RECURSE
+FileKey19=%SystemDrive%|eula.*.txt;globdata.ini;install.exe;install.ini;install.res.*.dll;VC_RED.cab;VC_RED.MSI;vcredist.bmp
 
 [Windows Live Mail *]
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Windows Live Mail
 FileKey1=%LocalAppData%\Microsoft\Windows*Mail|*.log;*.jrs;*.chk;*.rss;*.tmp|RECURSE
 FileKey2=%LocalAppData%\Microsoft\Windows*Mail\*|*.MSMessageStore|RECURSE
-FileKey3=%LocalAppData%\Microsoft\Windows*Mail\*.tmp|*.*|RECURSE
-FileKey4=%LocalAppData%\Microsoft\Windows*Mail\*\Backup|*.*|REMOVESELF
-FileKey5=%LocalAppData%\Microsoft\Windows*Mail\Backup|*.*|REMOVESELF
+FileKey3=%LocalAppData%\Microsoft\Windows*Mail\*.tmp|*|RECURSE
+FileKey4=%LocalAppData%\Microsoft\Windows*Mail\*\Backup|*|REMOVESELF
+FileKey5=%LocalAppData%\Microsoft\Windows*Mail\Backup|*|REMOVESELF
 RegKey1=HKCU\Software\Microsoft\Windows Live Mail|SearchFolderVersion
 
 [Windows Live Movie Maker *]
 LangSecRef=3023
 Detect=HKCU\Software\Microsoft\Windows Live\Movie Maker
-FileKey1=%LocalAppData%\Microsoft\Windows Live Movie Maker|*.*|RECURSE
+FileKey1=%LocalAppData%\Microsoft\Windows Live Movie Maker|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows Live\Movie Maker|browseformusicdirectory
 RegKey2=HKCU\Software\Microsoft\Windows Live\Movie Maker|browseforpicturesdirectory
 RegKey3=HKCU\Software\Microsoft\Windows Live\Movie Maker|browseforprojectsdirectory
@@ -20795,7 +20739,7 @@ FileKey1=%LocalAppData%\Microsoft\Windows Mail|*.log;*.jrs;*.chk|RECURSE
 FileKey2=%LocalAppData%\Microsoft\Windows Mail\Backup\Old|*.*|REMOVESELF
 
 [Windows Mail and Calendar *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.windowscommunicationsapps_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Comms\Unistore\data|AggregateCache.uca
 FileKey2=%LocalAppData%\Comms\UnistoreDB|*.jcp;*.jrs;*.jtx
@@ -20813,7 +20757,7 @@ FileKey13=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\TempStat
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.windowscommunicationsapps_8wekyb3d8bbwe\SearchHistory
 
 [Windows Maps *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsMaps_8wekyb3d8bbwe
 FileKey1=%CommonAppData%\Microsoft\MapData|events.log
 FileKey2=%CommonAppData%\Microsoft\MapData\mapscache|*.*|RECURSE
@@ -20913,12 +20857,11 @@ FileKey5=%LocalAppData%\Packages\Microsoft.Windows*Photos_*\LocalCache|*.*|RECUR
 FileKey6=%LocalAppData%\Packages\Microsoft.Windows*Photos_*\LocalState|*.etl;*.sqlite*;*.xml;*.log;*.jpg
 FileKey7=%LocalAppData%\Packages\Microsoft.Windows*Photos_*\LocalState\PhotosAppTile|*.*|RECURSE
 FileKey8=%LocalAppData%\Packages\Microsoft.Windows*Photos_*\TempState|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\AppCache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\*Cache|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\BackgroundTransferApi|*.down_data;*.up_meta
 FileKey11=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
 FileKey12=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\PRICache|*.*
-FileKey14=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState\bici|*.sqm
+FileKey13=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState\bici|*.sqm
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Photos_8wekyb3d8bbwe\PersistedPickerData\Microsoft.Windows.Photos_8wekyb3d8bbwe!App\DefaultSaveFileSingle
 RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Photos_8wekyb3d8bbwe\PersistedStorageItemTable\ManagedByApp
 RegKey3=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Photos_8wekyb3d8bbwe\PersistedStorageItemTable\MostRecentlyUsed
@@ -20967,11 +20910,6 @@ RegKey2=HKU\S-1-5-18\Software\Microsoft\Windows\CurrentVersion\Explorer\RecentDo
 RegKey3=HKU\S-1-5-19\Software\Microsoft\Windows\CurrentVersion\Explorer\RecentDocs
 RegKey4=HKU\S-1-5-20\Software\Microsoft\Windows\CurrentVersion\Explorer\RecentDocs
 
-[Windows Recent Theme Colors *]
-LangSecRef=3025
-Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\History\Colors
-RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\History\Colors
-
 [Windows Remote Desktop *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Terminal Server Client
@@ -20983,7 +20921,7 @@ DetectFile=%CommonAppData%\Microsoft\Windows\RetailDemo
 FileKey1=%CommonAppData%\Microsoft\Windows\RetailDemo|*.*|REMOVESELF
 
 [Windows Scan *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsScan_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\Temp|*.*|RECURSE
@@ -21060,16 +20998,15 @@ RegKey2=HKU\.DEFAULT\Software\Classes\Local Settings\MrtCache
 [Windows Settings *]
 LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\windows.immersivecontrolpanel_cw5n1h2txyewy
-FileKey1=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey5=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\PRICache|*.*
-FileKey7=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Temp|*.*
-FileKey8=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey4=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey5=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey6=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Temp|*
+FileKey7=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\navigationHistory|*|RECURSE
+FileKey9=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\windows.immersivecontrolpanel_cw5n1h2txyewy\SearchHistory
 
 [Windows Shell - Folder View Settings *]
@@ -21088,17 +21025,26 @@ ExcludeKey2=REG|HKCU\Software\Classes\Wow6432Node\Local Settings\Software\Micros
 ExcludeKey3=REG|HKCU\Software\Microsoft\Windows\Shell\Bags\1\Desktop
 ExcludeKey4=REG|HKCU\Software\Microsoft\Windows\ShellNoRoam\Bags\AllFolders
 
+[Windows Shell - Theme Colors History *]
+LangSecRef=3025
+Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\History\Colors
+RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\History\Colors
+
 [Windows Shell *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 FileKey1=%LocalAppData%|IconCache.db;IconCache.db.backup
 FileKey2=%LocalAppData%\Microsoft\Windows\Explorer|iconcache_*.db
 FileKey3=%LocalAppData%\Microsoft\Windows\Explorer\IconCacheToDelete|*.tmp
-FileKey4=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\INet*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Microsoft\Windows\*|*.*|REMOVESELF
-FileKey6=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\TempState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\InputApp_*\AC\INet*|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\InputApp_*\AC\Temp|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\InputApp_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\InputApp_*\TempState|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\INet*|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Microsoft\Windows\*|*|REMOVESELF
+FileKey10=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Temp|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalCache|*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer|ScreenshotIndex
 RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts
 RegKey3=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\SharingMFU
@@ -21114,9 +21060,9 @@ FileKey1=%WinDir%|SIGVERIF.TXT
 [Windows Start Menu *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\UFH
-FileKey1=%LocalAppData%\Packages\Microsoft.Windows.StartMenuExperienceHost_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Windows.StartMenuExperienceHost_*\AC\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Windows.StartMenuExperienceHost_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.Windows.StartMenuExperienceHost_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Windows.StartMenuExperienceHost_*\AC\Temp|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Windows.StartMenuExperienceHost_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage|ProgramsCache
 RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage2|ProgramsCache
 RegKey3=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage2|ProgramsCacheSMP
@@ -21131,34 +21077,35 @@ LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 FileKey1=%CommonAppData%\Microsoft\RAC\PublishedData|*.log;*.jrs
 FileKey2=%CommonAppData%\Microsoft\RAC\StateData|*.log;*.jrs
-FileKey3=%CommonAppData%\Microsoft\RAC\Temp|*.*
-FileKey4=%CommonAppData%\Microsoft\Windows\DeviceMetadataCache\dmrccache.bak|*.*|REMOVESELF
+FileKey3=%CommonAppData%\Microsoft\RAC\Temp|*
+FileKey4=%CommonAppData%\Microsoft\Windows\DeviceMetadataCache\dmrccache.bak|*|REMOVESELF
 FileKey5=%CommonAppData%\Microsoft\Windows\Sqm\Manifest|*.bin
 FileKey6=%CommonAppData%\Microsoft\Windows\Sqm\Sessions|*.psqm;*.sqm
 FileKey7=%Documents%\Remote Assistance Logs|*.xml
-FileKey8=%LocalAppData%\Microsoft\Windows Sidebar\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Microsoft\Windows\PRICache|*.*|RECURSE
-FileKey10=%LocalAppData%\Microsoft\Windows\SettingSync\metastore|*.jrs
-FileKey11=%LocalAppData%\Microsoft\Windows\SettingSync\remotemetastore\*|*.jrs
-FileKey12=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\AppCache|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\INet*|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Temp|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalCache|*.*|RECURSE
-FileKey18=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalState\Cache|*.*|RECURSE
-FileKey19=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\TempState|*.*|RECURSE
-FileKey20=%SystemDrive%\Documents and Settings\LocalService\Application Data\PeerNetworking|*.*|RECURSE
-FileKey21=%WinDir%\$regcmp$|*.*|REMOVESELF
-FileKey22=%WinDir%\ehome|PRDMOWrapper.log
-FileKey23=%WinDir%\msdownld.tmp|*.*|REMOVESELF
-FileKey24=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows|qwavecache.dat
-FileKey25=%WinDir%\ServiceProfiles\LocalService\AppData\Roaming\PeerNetworking|*.*|RECURSE
-FileKey26=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\PeerDist*|*.chk;*.jrs
-FileKey27=%WinDir%\System32|PRDMOWrapper.log;qwavecache.dat
-FileKey28=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Device Metadata\dmrccache\downloads|*.tmp
-FileKey29=%WinDir%\System32\config\systemprofile\AppData\Local\tw-*.tmp|empty.check|REMOVESELF
-FileKey30=%WinDir%\System32\sru|*.*|RECURSE
+FileKey8=%LocalAppData%\Microsoft\Windows Sidebar\Cache|*|RECURSE
+FileKey9=%LocalAppData%\Microsoft\Windows\AppCache|*|RECURSE
+FileKey10=%LocalAppData%\Microsoft\Windows\PRICache|*|RECURSE
+FileKey11=%LocalAppData%\Microsoft\Windows\SettingSync\metastore|*.jrs
+FileKey12=%LocalAppData%\Microsoft\Windows\SettingSync\remotemetastore\*|*.jrs
+FileKey13=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\AppCache|*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\INet*|*|RECURSE
+FileKey15=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey16=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey17=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Temp|*|RECURSE
+FileKey18=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalCache|*|RECURSE
+FileKey19=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalState\Cache|*|RECURSE
+FileKey20=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\TempState|*|RECURSE
+FileKey21=%SystemDrive%\Documents and Settings\LocalService\Application Data\PeerNetworking|*|RECURSE
+FileKey22=%WinDir%\$regcmp$|*|REMOVESELF
+FileKey23=%WinDir%\ehome|PRDMOWrapper.log
+FileKey24=%WinDir%\msdownld.tmp|*|REMOVESELF
+FileKey25=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows|qwavecache.dat
+FileKey26=%WinDir%\ServiceProfiles\LocalService\AppData\Roaming\PeerNetworking|*|RECURSE
+FileKey27=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\PeerDist*|*.chk;*.jrs
+FileKey28=%WinDir%\System32|PRDMOWrapper.log;qwavecache.dat
+FileKey29=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Device Metadata\dmrccache\downloads|*.tmp
+FileKey30=%WinDir%\System32\config\systemprofile\AppData\Local\tw-*.tmp|empty.check|REMOVESELF
+FileKey31=%WinDir%\System32\sru|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache
 RegKey2=HKCU\Software\Classes\MIME\Database\Content Type
 RegKey3=HKCU\Software\Local AppWizard-Generated Applications
@@ -21173,19 +21120,19 @@ RegKey10=HKLM\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\Vol
 [Windows System Assessment Tool *]
 LangSecRef=3025
 DetectFile=%WinDir%\Performance\WinSAT
-FileKey1=%WinDir%\Performance\WinSAT|*.*|REMOVESELF
+FileKey1=%WinDir%\Performance\WinSAT|*|REMOVESELF
 
 [Windows Task Scheduler *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
-FileKey1=%WinDir%\System32\Tasks_Migrated|*.*|REMOVESELF
+FileKey1=%WinDir%\System32\Tasks_Migrated|*|REMOVESELF
 
 [Windows Taskbar *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 FileKey1=%AppData%\Microsoft\Windows\Recent|*.URL|RECURSE
-FileKey2=%AppData%\Microsoft\Windows\Recent\AutomaticDestinations|*.*|RECURSE
-FileKey3=%AppData%\Microsoft\Windows\Recent\CustomDestinations|*.*|RECURSE
+FileKey2=%AppData%\Microsoft\Windows\Recent\AutomaticDestinations|*|RECURSE
+FileKey3=%AppData%\Microsoft\Windows\Recent\CustomDestinations|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\FeatureUsage\AppBadgeUpdated
 RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\FeatureUsage\AppLaunch
 RegKey3=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\FeatureUsage\AppSwitched
@@ -21197,45 +21144,45 @@ ExcludeKey1=FILE|%AppData%\Microsoft\Windows\Recent\AutomaticDestinations\|f01b4
 [Windows Temporary Files *]
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\Windows
-FileKey1=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\Temp|*.*|RECURSE
-FileKey2=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\Temp|*.*|RECURSE
-FileKey3=%WinDir%\ServiceProfiles\*\AppData\Local\Temp|*.*|RECURSE
-FileKey4=%WinDir%\System32\config\systemprofile\AppData\Local\Temp|*.*|RECURSE
-FileKey5=%WinDir%\System32\config\systemprofile\Local Settings\Temp|*.*|RECURSE
-FileKey6=%WinDir%\SystemTemp|*.*|RECURSE
-FileKey7=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Temp|*.*|RECURSE
+FileKey1=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\Temp|*|RECURSE
+FileKey2=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\Temp|*|RECURSE
+FileKey3=%WinDir%\ServiceProfiles\*\AppData\Local\Temp|*|RECURSE
+FileKey4=%WinDir%\System32\config\systemprofile\AppData\Local\Temp|*|RECURSE
+FileKey5=%WinDir%\System32\config\systemprofile\Local Settings\Temp|*|RECURSE
+FileKey6=%WinDir%\SystemTemp|*|RECURSE
+FileKey7=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Temp|*|RECURSE
 
 [Windows Update *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 FileKey1=%LocalAppData%\Microsoft\Windows\Windows Anytime Upgrade|Upgrade.log
-FileKey2=%LocalAppData%\MigWiz|*.*|REMOVESELF
-FileKey3=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\AC\AppCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\AC\INet*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\LocalState\EBWebview\*|LOG;LOG.old|RECURSE
-FileKey11=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\LocalState\EBWebview\Default\Service Worker\CacheStorage\*|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\MigWiz|*|REMOVESELF
+FileKey3=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\AppCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\INet*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey6=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey7=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\Temp|*|RECURSE
+FileKey8=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\TokenBroker\Cache|*|RECURSE
+FileKey9=%LocalAppData%\Packages\MicrosoftWindows.Client.*\LocalCache|*|RECURSE
+FileKey10=%LocalAppData%\Packages\MicrosoftWindows.Client.*\LocalState\EBWebview\*|LOG;LOG.old|RECURSE
+FileKey11=%LocalAppData%\Packages\MicrosoftWindows.Client.*\LocalState\EBWebview\Default\Service Worker\CacheStorage\*|*|RECURSE
+FileKey12=%LocalAppData%\Packages\MicrosoftWindows.Client.*\TempState|*|RECURSE
 FileKey13=%ProgramFiles%\CUAssistant\Logs|*.etl
-FileKey14=%ProgramFiles%\Microsoft Update Health Tools\Logs|*.*
+FileKey14=%ProgramFiles%\Microsoft Update Health Tools\Logs|*
 FileKey15=%ProgramFiles%\rempl\Logs|*.etl
-FileKey16=%ProgramFiles%\WindowsInstallationAssistant\Logs|*.*
-FileKey17=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Cache|*.*|RECURSE
-FileKey18=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Logs|*.*|RECURSE
-FileKey19=%WinDir%\SoftwareDistribution\DataStore\Logs|*.*|RECURSE
+FileKey16=%ProgramFiles%\WindowsInstallationAssistant\Logs|*
+FileKey17=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Cache|*|RECURSE
+FileKey18=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Logs|*|RECURSE
+FileKey19=%WinDir%\SoftwareDistribution\DataStore\Logs|*|RECURSE
 
 [Windows Voice Recorder *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsSoundRecorder_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalState\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\Temp|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalState\Cache|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\TempState|*|RECURSE
 
 [Windows XP Add/Remove Programs *]
 LangSecRef=3025
@@ -21245,7 +21192,7 @@ RegKey1=HKLM\Software\Microsoft\Windows\CurrentVersion\App Management\ARPCache
 [Windows XP Driver Reinstall Backups *]
 LangSecRef=3025
 DetectFile=%WinDir%\System32\ReinstallBackups
-FileKey1=%WinDir%\System32\ReinstallBackups|*.*|RECURSE
+FileKey1=%WinDir%\System32\ReinstallBackups|*|RECURSE
 
 [Windows XP Help and Support Center *]
 LangSecRef=3025
@@ -21721,41 +21668,40 @@ Detect=HKCU\Software\Xara\WebDesigner
 FileKey1=%LocalAppData%\Xara\WebDesigner\*\Backups|*.*|RECURSE
 
 [Xbox *]
-LangSecRef=3031
+Section=Games
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.GamingApp_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxApp_8wekyb3d8bbwe
 Detect3=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxGameOverlay_8wekyb3d8bbwe
 Detect4=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxGamingOverlay_8wekyb3d8bbwe
 Detect5=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxIdentityProvider_8wekyb3d8bbwe
 Detect6=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxLIVEGames_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\EAConnect_microsoft\Cache|*.*|RECURSE
+FileKey1=%LocalAppData%\EAConnect_microsoft\Cache|*|RECURSE
 FileKey2=%LocalAppData%\EAConnect_microsoft\QtWebEngine\Default|Network Persistent State;Visited Links
-FileKey3=%LocalAppData%\EAConnect_microsoft\QtWebEngine\Default\GPUCache|*.*
-FileKey4=%LocalAppData%\EAConnect_microsoft\QtWebEngine\Default\Platform Notifications|*.*
+FileKey3=%LocalAppData%\EAConnect_microsoft\QtWebEngine\Default\GPUCache|*
+FileKey4=%LocalAppData%\EAConnect_microsoft\QtWebEngine\Default\Platform Notifications|*
 FileKey5=%LocalAppData%\EAConnect_microsoft\QtWebEngine\Default\Session Storage|*.old;LOG
 FileKey6=%LocalAppData%\Packages\Microsoft.Gaming*\AC\TokenBroker\Cache|*|RECURSE
 FileKey7=%LocalAppData%\Packages\Microsoft.Gaming_*\AC\INet*|*|RECURSE
 FileKey8=%LocalAppData%\Packages\Microsoft.Gaming_*\AC\Temp|*|RECURSE
 FileKey9=%LocalAppData%\Packages\Microsoft.Gaming_*\LocalState|*log*|RECURSE
 FileKey10=%LocalAppData%\Packages\Microsoft.Gaming_*\TempState|*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\AppCache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\INet*|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\*Cache|*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\INet*|*|RECURSE
 FileKey13=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CLR_v4.0*|*.log
-FileKey14=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey18=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\PRICache|*.*
-FileKey19=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Temp|*.*|RECURSE
-FileKey20=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey21=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalCache|*.*|RECURSE
-FileKey22=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState|*.log*|RECURSE
-FileKey23=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\*Cache|*.*|RECURSE
-FileKey24=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\DiagOutputDir|*.txt
-FileKey25=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey26=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\PlayReady|*.*|RECURSE
-FileKey27=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\SmartGlass|*.log
-FileKey28=%LocalAppData%\Packages\Microsoft.Xbox*_*\TempState|*.*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*|RECURSE
+FileKey15=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*|RECURSE
+FileKey16=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey17=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey18=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Temp|*|RECURSE
+FileKey19=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey20=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalCache|*|RECURSE
+FileKey21=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState|*.log*|RECURSE
+FileKey22=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\*Cache|*|RECURSE
+FileKey23=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\DiagOutputDir|*.txt
+FileKey24=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\navigationHistory|*|RECURSE
+FileKey25=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\PlayReady|*|RECURSE
+FileKey26=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\SmartGlass|*.log
+FileKey27=%LocalAppData%\Packages\Microsoft.Xbox*_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxLIVEGames_8wekyb3d8bbwe\SearchHistory
 
 [XCOM *]

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
-; Version: 230217
-; # of entries: 2,681
+; Version: 230222
+; # of entries: 2,689
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -38,6 +38,25 @@ FileKey13=%LocalAppData%\Slimjet\User Data\*|Web Data
 FileKey14=%LocalAppData%\Slimjet\User Data\*\Autofill*|Web Data
 FileKey15=%LocalAppData%\Yandex\YandexBrowser\User Data\*|Web Data;Ya Autofill Data*;Ya Credit Cards*;Ya Passman Data*
 FileKey16=%LocalAppData%\Yandex\YandexBrowser\User Data\*\Autofill*|*
+
+[Chromium Bookbark Favicons *]
+LangSecRef=3029
+Detect1=HKCU\Software\Chromium\PreferenceMACs
+Detect2=HKCU\Software\CocCoc\Browser
+Detect3=HKCU\Software\Comodo\Dragon
+Detect4=HKCU\Software\Epic Privacy Browser
+Detect5=HKCU\Software\Iridium
+Detect6=HKCU\Software\Slimjet
+Detect7=HKCU\Software\Yandex\YandexBrowser
+DetectFile=%LocalAppData%\Google\Chrome*
+FileKey1=%LocalAppData%\Chromium\User Data\*|favicons*
+FileKey2=%LocalAppData%\CocCoc\Browser\User Data\*|favicons*
+FileKey3=%LocalAppData%\Comodo\Dragon\User Data\*|favicons*
+FileKey4=%LocalAppData%\Epic Privacy Browser\User Data\*|favicons*
+FileKey5=%LocalAppData%\Google\Chrome*\User Data\*|favicons*
+FileKey6=%LocalAppData%\Iridium\User Data\*|favicons*
+FileKey7=%LocalAppData%\Slimjet\User Data\*|favicons*
+FileKey8=%LocalAppData%\Yandex\YandexBrowser\User Data\*|favicons*
 
 [Chromium Bookmarks Backup *]
 LangSecRef=3029
@@ -288,7 +307,7 @@ FileKey2=%CommonAppData%\Yandex\YandexBrowser|service_update.log
 FileKey3=%LocalAppData%\Chromium\Application|debug.log
 FileKey4=%LocalAppData%\Chromium\Application\SetupMetrics|*|REMOVESELF
 FileKey5=%LocalAppData%\Chromium\User Data|*.pma;LOG;LOG.old|RECURSE
-FileKey6=%LocalAppData%\Chromium\User Data|chrome_shutdown_ms.txt;last*;first*
+FileKey6=%LocalAppData%\Chromium\User Data|chrome_shutdown_ms.txt;last*
 FileKey7=%LocalAppData%\Chromium\User Data\*\BrowserMetrics|*|REMOVESELF
 FileKey8=%LocalAppData%\Chromium\User Data\*\Feature Engagement Tracker|*|REMOVESELF
 FileKey9=%LocalAppData%\Chromium\User Data\*\Network|Media History;Network*;Reporting*;Transport*
@@ -300,7 +319,7 @@ FileKey14=%LocalAppData%\Chromium\User Data\Stability|*|REMOVESELF
 FileKey15=%LocalAppData%\CocCoc\Browser\Application|debug.log
 FileKey16=%LocalAppData%\CocCoc\Browser\Application\SetupMetrics|*|REMOVESELF
 FileKey17=%LocalAppData%\CocCoc\Browser\User Data|*.pma;LOG;LOG.old|RECURSE
-FileKey18=%LocalAppData%\CocCoc\Browser\User Data|chrome_shutdown_ms.txt;last*;first*
+FileKey18=%LocalAppData%\CocCoc\Browser\User Data|chrome_shutdown_ms.txt;last*
 FileKey19=%LocalAppData%\CocCoc\Browser\User Data\*\BrowserMetrics|*|REMOVESELF
 FileKey20=%LocalAppData%\CocCoc\Browser\User Data\*\Feature Engagement Tracker|*|REMOVESELF
 FileKey21=%LocalAppData%\CocCoc\Browser\User Data\*\Network|Media History;Network*;Reporting*;Transport*
@@ -311,7 +330,7 @@ FileKey25=%LocalAppData%\CocCoc\Browser\User Data\Crashpad\reports|*
 FileKey26=%LocalAppData%\CocCoc\Browser\User Data\Stability|*|REMOVESELF
 FileKey27=%LocalAppData%\CocCoc\CrashReports|*
 FileKey28=%LocalAppData%\Comodo\Dragon\User Data|*.pma;LOG;LOG.old|RECURSE
-FileKey29=%LocalAppData%\Comodo\Dragon\User Data|chrome_shutdown_ms.txt;last*;first*
+FileKey29=%LocalAppData%\Comodo\Dragon\User Data|chrome_shutdown_ms.txt;last*
 FileKey30=%LocalAppData%\Comodo\Dragon\User Data\*\BrowserMetrics|*|REMOVESELF
 FileKey31=%LocalAppData%\Comodo\Dragon\User Data\*\Feature Engagement Tracker|*|REMOVESELF
 FileKey32=%LocalAppData%\Comodo\Dragon\User Data\*\Network|Media History;Network*;Reporting*;Transport*
@@ -348,7 +367,7 @@ FileKey62=%LocalAppData%\Google\Chrome*\User Data\Crashpad\reports|*
 FileKey63=%LocalAppData%\Google\Chrome*\User Data\Stability|*|REMOVESELF
 FileKey64=%LocalAppData%\Google\CrashReports|*
 FileKey65=%LocalAppData%\Iridium\User Data|*.pma;LOG;LOG.old|RECURSE
-FileKey66=%LocalAppData%\Iridium\User Data|chrome_shutdown_ms.txt;last*;first*
+FileKey66=%LocalAppData%\Iridium\User Data|chrome_shutdown_ms.txt;last*
 FileKey67=%LocalAppData%\Iridium\User Data\*\BrowserMetrics|*|REMOVESELF
 FileKey68=%LocalAppData%\Iridium\User Data\*\Feature Engagement Tracker|*|REMOVESELF
 FileKey69=%LocalAppData%\Iridium\User Data\*\Network|Media History;Network*;Reporting*;Transport*
@@ -358,7 +377,7 @@ FileKey72=%LocalAppData%\Iridium\User Data\Crashpad|metadata
 FileKey73=%LocalAppData%\Iridium\User Data\Crashpad\reports|*
 FileKey74=%LocalAppData%\Iridium\User Data\Stability|*|REMOVESELF
 FileKey75=%LocalAppData%\Slimjet\User Data|*.pma;LOG;LOG.old|RECURSE
-FileKey76=%LocalAppData%\Slimjet\User Data|chrome_shutdown_ms.txt;last*;first*
+FileKey76=%LocalAppData%\Slimjet\User Data|chrome_shutdown_ms.txt;last*
 FileKey77=%LocalAppData%\Slimjet\User Data\*\BrowserMetrics|*|REMOVESELF
 FileKey78=%LocalAppData%\Slimjet\User Data\*\Feature Engagement Tracker|*|REMOVESELF
 FileKey79=%LocalAppData%\Slimjet\User Data\*\Network|Media History;Network*;Reporting*;Transport*
@@ -371,7 +390,7 @@ FileKey85=%LocalAppData%\Yandex\SearchBand|*.log
 FileKey86=%LocalAppData%\Yandex\YandexBrowser\Application|debug.log
 FileKey87=%LocalAppData%\Yandex\YandexBrowser\Application\SetupMetrics|*|REMOVESELF
 FileKey88=%LocalAppData%\Yandex\YandexBrowser\User Data|*.pma;LOG;LOG.old|RECURSE
-FileKey89=%LocalAppData%\Yandex\YandexBrowser\User Data|First*;Last*;Local State;Tab Lifetime;update*.rss;Variations;chrome_shutdown_ms.txt
+FileKey89=%LocalAppData%\Yandex\YandexBrowser\User Data|Last*;Local State;Tab Lifetime;update*.rss;Variations;chrome_shutdown_ms.txt
 FileKey90=%LocalAppData%\Yandex\YandexBrowser\User Data\*|Bookmarks Log;Passman Logs;Session Log;Tabs Log;Ya Autofill Logs;WebApp Logs
 FileKey91=%LocalAppData%\Yandex\YandexBrowser\User Data\*\BrowserMetrics|*|REMOVESELF
 FileKey92=%LocalAppData%\Yandex\YandexBrowser\User Data\*\Feature Engagement Tracker|*|REMOVESELF
@@ -474,6 +493,11 @@ LangSecRef=3006
 DetectFile=%LocalAppData%\Microsoft\Edge*
 FileKey1=%LocalAppData%\Microsoft\Edge*\User Data\*|Web Data
 
+[Microsoft Edge Bookmark Favicons *]
+LangSecRef=3006
+DetectFile=%LocalAppData%\Microsoft\Edge*
+FileKey1=%LocalAppData%\Micrsoft\Edge*\User Data\*|favicons*
+
 [Microsoft Edge Bookmarks Backup *]
 LangSecRef=3006
 DetectFile=%LocalAppData%\Microsoft\Edge*
@@ -541,10 +565,6 @@ FileKey11=%LocalAppData%\Microsoft\Edge*\User Data\Crashpad\reports|*
 FileKey12=%LocalAppData%\Microsoft\Edge*\User Data\Stability|*|REMOVESELF
 FileKey13=%ProgramFiles%\Microsoft\CrashReports|*
 FileKey14=%ProgramFiles%\Microsoft\Edge*\Application\SetupMetrics|*|REMOVESELF
-RegKey1=HKCU\Software\Microsoft\Edge Beta\BrowserExitCodes
-RegKey2=HKCU\Software\Microsoft\Edge Dev\BrowserExitCodes
-RegKey3=HKCU\Software\Microsoft\Edge SxS\BrowserExitCodes
-RegKey4=HKCU\Software\Microsoft\Edge\BrowserExitCodes
 
 [Microsoft Edge Updates *]
 LangSecRef=3006
@@ -566,7 +586,12 @@ LangSecRef=3033
 Detect=HKCU\Software\Vivaldi
 FileKey1=%LocalAppData%\Vivaldi\User Data\*|Web Data
 
-[Vivaldi Bookmark Backups *]
+[Vivaldi Bookmark Favicons *]
+LangSecRef=3033
+Detect=HKCU\Software\Vivaldi
+FileKey1=%LocalAppData%\Vivaldi\User Data\*|favicons*
+
+[Vivaldi Bookmarks Backup *]
 LangSecRef=3033
 Detect=HKCU\Software\Vivaldi
 FileKey1=%LocalAppData%\Vivaldi\User Data\*|*Bookmarks.bak
@@ -615,18 +640,23 @@ FileKey1=%LocalAppData%\Vivaldi\User Data\*\Sync Data|*|REMOVESELF
 [Vivaldi Telemetry *]
 LangSecRef=3033
 Detect=HKCU\Software\Vivaldi
-FileKey1=%LocalAppData%\Vivaldi\Application\SetupMetrics|*|REMOVESELF
-FileKey2=%LocalAppData%\Vivaldi\User Data\*|Media History
-FileKey3=%LocalAppData%\Vivaldi\User Data\*|Network Persistent State
-FileKey4=%LocalAppData%\Vivaldi\User Data\*\Feature Engagement Tracker|*|REMOVESELF
-FileKey5=%LocalAppData%\Vivaldi\User Data\*\Network|Network Persistent State
-FileKey6=%LocalAppData%\Vivaldi\User Data\*\Site Characteristics Database|*|REMOVESELF
-FileKey7=%LocalAppData%\Vivaldi\User Data\*\VideoDecodeStats|*|REMOVESELF
-FileKey8=%LocalAppData%\Vivaldi\User Data\BrowserMetrics|*|REMOVESELF
-FileKey9=%LocalAppData%\Vivaldi\User Data\Crashpad|metadata
-FileKey10=%LocalAppData%\Vivaldi\User Data\Crashpad\reports|*
-FileKey11=%ProgramFiles%\Vivaldi\Application\SetupMetrics|*|REMOVESELF
-RegKey1=HKCU\Software\Vivaldi\BrowserExitCodes
+FileKey1=%LocalAppData%\Vivaldi\Application|debug.log
+FileKey2=%LocalAppData%\Vivaldi\Application\SetupMetrics|*|REMOVESELF
+FileKey3=%LocalAppData%\Vivaldi\User Data\*|*.pma;LOG;LOG.old|RECURSE
+FileKey4=%LocalAppData%\Vivaldi\User Data\*|chrome_shutdown_ms.txt;last*;Affiliation Database*;BrowsingTopics*;DIPS;InterestGroups
+FileKey5=%LocalAppData%\Vivaldi\User Data\*\Feature Engagement Tracker|*|REMOVESELF
+FileKey6=%LocalAppData%\Vivaldi\User Data\*\Network|Media History;Network*;Reporting*;Transport*
+FileKey7=%LocalAppData%\Vivaldi\User Data\*\Site Characteristics Database|*|REMOVESELF
+FileKey8=%LocalAppData%\Vivaldi\User Data\*\VideoDecodeStats|*|REMOVESELF
+FileKey9=%LocalAppData%\Vivaldi\User Data\BrowserMetrics|*|REMOVESELF
+FileKey10=%LocalAppData%\Vivaldi\User Data\Crashpad|metadata
+FileKey11=%LocalAppData%\Vivaldi\User Data\Crashpad\reports|*
+FileKey12=%LocalAppData%\Vivaldi\User Data\Stability|*|REMOVESELF
+FileKey13=%ProgramFiles%\Vivaldi\Application\SetupMetrics|*|REMOVESELF
+FileKey14=%UserProfile%|.vivaldi_reporting_data
+RegKey1=HKCU\Software\Yandex\YandexBrowser\BlBeacon|failed_count
+RegKey2=HKCU\Software\Yandex\YandexBrowser\BlBeacon|state
+RegKey3=HKCU\Software\Yandex\YandexBrowser\StabilityMetrics
 
 [Vivaldi Updates *]
 LangSecRef=3033
@@ -643,6 +673,11 @@ FileKey3=%LocalAppData%\Vivaldi\Installer\Offline|*|RECURSE
 LangSecRef=3034
 Detect=HKCU\Software\BraveSoftware
 FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*|Web Data
+
+[Brave Bookmark Favicons *]
+LangSecRef=3034
+Detect=HKCU\Software\BraveSoftware
+FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*|Favicons*
 
 [Brave Bookmarks Backup *]
 LangSecRef=3034
@@ -694,7 +729,7 @@ FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*\Sync Data|*|REM
 [Brave Telemetry *]
 LangSecRef=3034
 Detect=HKCU\Software\BraveSoftware
-FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data|chrome_shutdown_ms.txt;last*;first*
+FileKey1=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data|chrome_shutdown_ms.txt;last*
 FileKey2=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*|Media History;Network Persistent State
 FileKey3=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*\Feature Engagement Tracker|*|REMOVESELF
 FileKey4=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\*\Network|Network Persistent State
@@ -705,10 +740,6 @@ FileKey8=%LocalAppData%\BraveSoftware\Brave-Browser*\User Data\Crashpad\reports|
 FileKey9=%LocalAppData%\BraveSoftware\CrashReports|*
 FileKey10=%ProgramFiles%\BraveSoftware\Brave-Browser*\Application\SetupMetrics|*|REMOVESELF
 FileKey11=%ProgramFiles%\BraveSoftware\CrashReports|*
-RegKey1=HKCU\Software\BraveSoftware\Brave-Browser\BrowserExitCodes
-RegKey2=HKCU\Software\BraveSoftware\Brave-Browser-Beta\BrowserExitCodes
-RegKey3=HKCU\Software\BraveSoftware\Brave-Browser-Dev\BrowserExitCodes
-RegKey4=HKCU\Software\BraveSoftware\Brave-Browser-Nightly\BrowserExitCodes
 
 [Brave Updates *]
 LangSecRef=3034
@@ -731,6 +762,16 @@ FileKey2=%ProgramFiles%\Opera 9\profile\cache*|*
 LangSecRef=3027
 DetectFile=%AppData%\Opera Software\Opera*
 FileKey1=%AppData%\Opera Software\Opera*\*|Web Data
+
+[Opera Bookmark Favicons *]
+LangSecRef=3027
+DetectFile=%AppData%\Opera Software\Opera*
+FileKey1=%AppData%\Opera Software\Opera*|favicons*
+
+[Opera Bookmarks Backup *]
+LangSecRef=3027
+DetectFile=%AppData%\Opera Software\Opera*
+FileKey1=%AppData%\Opera Software\Opera*|bookmarks.bak
 
 [Opera Caches *]
 LangSecRef=3027
@@ -757,6 +798,11 @@ FileKey17=%ProgramFiles%\Opera\Temp|*|REMOVESELF
 LangSecRef=3027
 DetectFile=%AppData%\Opera Software\Opera*
 FileKey1=%AppData%\Opera Software\Opera*\*\Network|Cookies
+
+[Opera History *]
+LangSecRef=3027
+DetectFile=%AppData%\Opera Software\Opera*
+FileKey1=%AppData%\Opera Software\Opera*\*|History*;Visited Links*;Top Sites*;Network Action Predictor*;Shortcuts
 
 [Opera Logs *]
 LangSecRef=3027
@@ -789,10 +835,6 @@ FileKey11=%AppData%\Opera Software\Opera*\VideoDecodeStats|*|REMOVESELF
 FileKey12=%LocalAppData%\Opera\CrashReports|*
 FileKey13=%ProgramFiles%\Opera\CrashReports|*
 FileKey14=%ProgramFiles%\Opera\Opera*\Application\SetupMetrics|*|REMOVESELF
-RegKey1=HKCU\Software\Opera\Opera Dev\BrowserExitCodes
-RegKey2=HKCU\Software\Opera\Opera Stable\BrowserExitCodes
-RegKey3=HKCU\Software\Opera\Opera SxS\BrowserExitCodes
-RegKey4=HKCU\Software\Opera\Opera\BrowserExitCodes
 
 [Opera Update *]
 LangSecRef=3027
@@ -804,6 +846,42 @@ FileKey3=%LocalAppData%\Programs\Opera*|*.backup;*.old;*.tmp|RECURSE
 ; End of Opera
 ;
 ; Firefox/Mozilla based browsers
+
+[Firefox Autocomplete History *]
+LangSecRef=3026
+Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Mozilla.Firefox_n80bbvh6b1yt2
+Detect2=HKCU\Software\LibreWolf
+Detect3=HKLM\Software\FlashPeak\SlimBrowser
+Detect4=HKLM\Software\Mozilla\Basilisk
+Detect5=HKLM\Software\Mozilla\Pale Moon
+Detect6=HKLM\Software\Mozilla\SeaMonkey
+Detect7=HKLM\Software\Mozilla\Waterfox
+DetectFile=%AppData%\Mozilla\Firefox
+FileKey1=%AppData%\Basilisk-Dev\Basilisk\Profiles\*|formhistory*
+FileKey2=%AppData%\FlashPeak\SlimBrowser\Profiles\*|formhistory*
+FileKey3=%AppData%\LibreWolf\Profiles\*|formhistory*
+FileKey4=%AppData%\Moonchild Productions\*\Profiles\*|formhistory*
+FileKey5=%AppData%\Mozilla\*\Profiles\*|formhistory*
+FileKey6=%AppData%\Waterfox\Profiles\*|formhistory*
+FileKey7=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*|formhistory*
+
+[Firefox Bookmark Favicons *]
+LangSecRef=3026
+Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Mozilla.Firefox_n80bbvh6b1yt2
+Detect2=HKCU\Software\LibreWolf
+Detect3=HKLM\Software\FlashPeak\SlimBrowser
+Detect4=HKLM\Software\Mozilla\Basilisk
+Detect5=HKLM\Software\Mozilla\Pale Moon
+Detect6=HKLM\Software\Mozilla\SeaMonkey
+Detect7=HKLM\Software\Mozilla\Waterfox
+DetectFile=%AppData%\Mozilla\Firefox
+FileKey1=%AppData%\Basilisk-Dev\Basilisk\Profiles\*|favicons*
+FileKey2=%AppData%\FlashPeak\SlimBrowser\Profiles\*|favicons*
+FileKey3=%AppData%\LibreWolf\Profiles\*|favicons*
+FileKey4=%AppData%\Moonchild Productions\*\Profiles\*|favicons*
+FileKey5=%AppData%\Mozilla\*\Profiles\*|favicons*
+FileKey6=%AppData%\Waterfox\Profiles\*|favicons*
+FileKey7=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*|favicons*
 
 [Firefox Caches *]
 LangSecRef=3026
@@ -820,7 +898,7 @@ FileKey1=%AppData%\ArtistScope\ArtisBrowser\Profiles\*|*.corrupt|RECURSE
 FileKey2=%AppData%\ArtistScope\ArtisBrowser\Profiles\*|AlternateServices.txt;notificationstore.json;parent.lock;serviceworker.txt;webappsstore.sqlite;cert9.db
 FileKey3=%AppData%\ArtistScope\ArtisBrowser\Profiles\*\storage\temporary|*|RECURSE
 FileKey4=%AppData%\Comodo\IceDragon\Profiles\*|*.corrupt|RECURSE
-FileKey5=%AppData%\Comodo\IceDragon\Profiles\*|AlternateServices.txt;notificationstore.json;parent.lock;serviceworker.txt;webappsstore.sqlite;favicons*
+FileKey5=%AppData%\Comodo\IceDragon\Profiles\*|AlternateServices.txt;notificationstore.json;parent.lock;serviceworker.txt;webappsstore.sqlite
 FileKey6=%AppData%\Comodo\IceDragon\Profiles\*\storage\temporary|*|RECURSE
 FileKey7=%AppData%\FlashPeak\SlimBrowser\Profiles\*|*.corrupt|RECURSE
 FileKey8=%AppData%\FlashPeak\SlimBrowser\Profiles\*|AlternateServices.txt;notificationstore.json;parent.lock;serviceworker.txt;webappsstore.sqlite
@@ -955,6 +1033,31 @@ FileKey30=%ProgramFiles%\SlimBrowser|*.log
 FileKey31=%ProgramFiles%\Waterfox|*.log
 FileKey32=%ProgramFiles%\WindowsApps\Mozilla.Firefox_*\VFS\ProgramFiles\Firefox Package Root|*.log
 
+[Firefox Sessions *]
+LangSecRef=3026
+Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Mozilla.Firefox_n80bbvh6b1yt2
+Detect2=HKCU\Software\LibreWolf
+Detect3=HKLM\Software\FlashPeak\SlimBrowser
+Detect4=HKLM\Software\Mozilla\Basilisk
+Detect5=HKLM\Software\Mozilla\Pale Moon
+Detect6=HKLM\Software\Mozilla\SeaMonkey
+Detect7=HKLM\Software\Mozilla\Waterfox
+DetectFile=%AppData%\Mozilla\Firefox
+FileKey1=%AppData%\Basilisk-Dev\Basilisk\Profiles\*|session*.json*
+FileKey2=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\sessionstore-backups|*
+FileKey3=%AppData%\FlashPeak\SlimBrowser\Profiles\*|session*.json*
+FileKey4=%AppData%\FlashPeak\SlimBrowser\Profiles\*\sessionstore-backups|*
+FileKey5=%AppData%\LibreWolf\Profiles\*|session*.json*
+FileKey6=%AppData%\LibreWolf\Profiles\*\sessionstore-backups|*
+FileKey7=%AppData%\Moonchild Productions\*\Profiles\*|session*.json*
+FileKey8=%AppData%\Moonchild Productions\*\Profiles\*\sessionstore-backups|*
+FileKey9=%AppData%\Mozilla\*\Profiles\*|session*.json*
+FileKey10=%AppData%\Mozilla\*\Profiles\*\sessionstore-backups|*
+FileKey11=%AppData%\Waterfox\Profiles\*|session*.json*
+FileKey12=%AppData%\Waterfox\Profiles\*\sessionstore-backups|*
+FileKey13=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*|session*.json*
+FileKey14=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\sessionstore-backups|*
+
 [Firefox Telemetry *]
 LangSecRef=3026
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Mozilla.Firefox_n80bbvh6b1yt2
@@ -968,49 +1071,55 @@ Detect8=HKLM\Software\Mozilla\Waterfox
 DetectFile=%AppData%\Mozilla\Firefox
 FileKey1=%AppData%\Basilisk-Dev\Basilisk\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
 FileKey2=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\Crash Reports|*|RECURSE
-FileKey3=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\datareporting|*|REMOVESELF
-FileKey4=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\minidumps|*
-FileKey5=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\saved-telemetry-pings|*
-FileKey6=%AppData%\FlashPeak\SlimBrowser\Crash Reports|*|RECURSE
-FileKey7=%AppData%\FlashPeak\SlimBrowser\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
-FileKey8=%AppData%\FlashPeak\SlimBrowser\Profiles\*\datareporting|*|REMOVESELF
-FileKey9=%AppData%\FlashPeak\SlimBrowser\Profiles\*\minidumps|*
-FileKey10=%AppData%\FlashPeak\SlimBrowser\Profiles\*\saved-telemetry-pings|*
-FileKey11=%AppData%\LibreWolf\Crash Reports|*|RECURSE
-FileKey12=%AppData%\LibreWolf\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
-FileKey13=%AppData%\LibreWolf\Profiles\*\datareporting|*|REMOVESELF
-FileKey14=%AppData%\LibreWolf\Profiles\*\minidumps|*
-FileKey15=%AppData%\LibreWolf\Profiles\*\saved-telemetry-pings|*
-FileKey16=%AppData%\Moonchild Productions\*\Crash Reports|*|RECURSE
-FileKey17=%AppData%\Moonchild Productions\*\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
-FileKey18=%AppData%\Moonchild Productions\*\Profiles\*\datareporting|*|REMOVESELF
-FileKey19=%AppData%\Moonchild Productions\*\Profiles\*\minidumps|*
-FileKey20=%AppData%\Moonchild Productions\*\Profiles\*\saved-telemetry-pings|*
-FileKey21=%AppData%\Mozilla\*\Crash Reports|*|RECURSE
-FileKey22=%AppData%\Mozilla\*\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
-FileKey23=%AppData%\Mozilla\*\Profiles\*\datareporting|*|REMOVESELF
-FileKey24=%AppData%\Mozilla\*\Profiles\*\minidumps|*
-FileKey25=%AppData%\Mozilla\*\Profiles\*\saved-telemetry-pings|*
-FileKey26=%AppData%\Talkback\MozillaOrg\Firefox*|*|RECURSE
-FileKey27=%AppData%\Talkback\MozillaOrg\Thunderbird*|*|RECURSE
-FileKey28=%AppData%\Waterfox\Crash Reports|*|RECURSE
-FileKey29=%AppData%\Waterfox\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
-FileKey30=%AppData%\Waterfox\Profiles\*\datareporting|*|REMOVESELF
-FileKey31=%AppData%\Waterfox\Profiles\*\minidumps|*
-FileKey32=%AppData%\Waterfox\Profiles\*\saved-telemetry-pings|*
-FileKey33=%CommonAppData%\Mozilla*|profile_count_*.json
-FileKey34=%LocalAppData%\Basilisk-Dev\Basilisk\Profiles\*|ShutdownDuration.*
-FileKey35=%LocalAppData%\FlashPeak\SlimBrowser\Profiles\*|ShutdownDuration.*
-FileKey36=%LocalAppData%\LibreWolf\Profiles\*|ShutdownDuration.*
-FileKey37=%LocalAppData%\Moonchild Productions\*\Profiles\*|ShutdownDuration.*
-FileKey38=%LocalAppData%\Mozilla\*\Profiles\*|ShutdownDuration.*
-FileKey39=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Local\Mozilla\Firefox\Profiles\*|ShutdownDuration.*
-FileKey40=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Crash Reports|*|RECURSE
-FileKey41=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
-FileKey42=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\datareporting|*|REMOVESELF
-FileKey43=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\minidumps|*
-FileKey44=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\saved-telemetry-pings|*
-FileKey45=%LocalAppData%\Waterfox\Profiles\*|ShutdownDuration.*
+FileKey3=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\crashes|*
+FileKey4=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\datareporting|*|REMOVESELF
+FileKey5=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\minidumps|*
+FileKey6=%AppData%\Basilisk-Dev\Basilisk\Profiles\*\saved-telemetry-pings|*
+FileKey7=%AppData%\FlashPeak\SlimBrowser\Crash Reports|*|RECURSE
+FileKey8=%AppData%\FlashPeak\SlimBrowser\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
+FileKey9=%AppData%\FlashPeak\SlimBrowser\Profiles\*\crashes|*
+FileKey10=%AppData%\FlashPeak\SlimBrowser\Profiles\*\datareporting|*|REMOVESELF
+FileKey11=%AppData%\FlashPeak\SlimBrowser\Profiles\*\minidumps|*
+FileKey12=%AppData%\FlashPeak\SlimBrowser\Profiles\*\saved-telemetry-pings|*
+FileKey13=%AppData%\LibreWolf\Crash Reports|*|RECURSE
+FileKey14=%AppData%\LibreWolf\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
+FileKey15=%AppData%\LibreWolf\Profiles\*\crashes|*
+FileKey16=%AppData%\LibreWolf\Profiles\*\datareporting|*|REMOVESELF
+FileKey17=%AppData%\LibreWolf\Profiles\*\minidumps|*
+FileKey18=%AppData%\LibreWolf\Profiles\*\saved-telemetry-pings|*
+FileKey19=%AppData%\Moonchild Productions\*\Crash Reports|*|RECURSE
+FileKey20=%AppData%\Moonchild Productions\*\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
+FileKey21=%AppData%\Moonchild Productions\*\Profiles\*\crashes|*
+FileKey22=%AppData%\Moonchild Productions\*\Profiles\*\datareporting|*|REMOVESELF
+FileKey23=%AppData%\Moonchild Productions\*\Profiles\*\minidumps|*
+FileKey24=%AppData%\Moonchild Productions\*\Profiles\*\saved-telemetry-pings|*
+FileKey25=%AppData%\Mozilla\*\Crash Reports|*|RECURSE
+FileKey26=%AppData%\Mozilla\*\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
+FileKey27=%AppData%\Mozilla\*\Profiles\*\crashes|*
+FileKey28=%AppData%\Mozilla\*\Profiles\*\datareporting|*|REMOVESELF
+FileKey29=%AppData%\Mozilla\*\Profiles\*\minidumps|*
+FileKey30=%AppData%\Mozilla\*\Profiles\*\saved-telemetry-pings|*
+FileKey31=%AppData%\Talkback\MozillaOrg\Firefox*|*|RECURSE
+FileKey32=%AppData%\Talkback\MozillaOrg\Thunderbird*|*|RECURSE
+FileKey33=%AppData%\Waterfox\Crash Reports|*|RECURSE
+FileKey34=%AppData%\Waterfox\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
+FileKey35=%AppData%\Waterfox\Profiles\*\crashes|*
+FileKey36=%AppData%\Waterfox\Profiles\*\datareporting|*|REMOVESELF
+FileKey37=%AppData%\Waterfox\Profiles\*\minidumps|*
+FileKey38=%AppData%\Waterfox\Profiles\*\saved-telemetry-pings|*
+FileKey39=%CommonAppData%\Mozilla*|profile_count_*.json
+FileKey40=%LocalAppData%\Basilisk-Dev\Basilisk\Profiles\*|ShutdownDuration.*
+FileKey41=%LocalAppData%\FlashPeak\SlimBrowser\Profiles\*|ShutdownDuration.*
+FileKey42=%LocalAppData%\LibreWolf\Profiles\*|ShutdownDuration.*
+FileKey43=%LocalAppData%\Moonchild Productions\*\Profiles\*|ShutdownDuration.*
+FileKey44=%LocalAppData%\Mozilla\*\Profiles\*|ShutdownDuration.*
+FileKey45=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Local\Mozilla\Firefox\Profiles\*|ShutdownDuration.*
+FileKey46=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Crash Reports|*|RECURSE
+FileKey47=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*|protections.sqlite;storage.sqlite;Telemetry*;times.json;targeting.snapshot.json
+FileKey48=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\datareporting|*|REMOVESELF
+FileKey49=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\minidumps|*
+FileKey50=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\saved-telemetry-pings|*
+FileKey51=%LocalAppData%\Waterfox\Profiles\*|ShutdownDuration.*
 RegKey1=HKLM\Software\FullCircle\TalkBack
 
 [Firefox Updates *]
@@ -1098,39 +1207,38 @@ FileKey2=%LocalAppData%\Microsoft\Internet Explorer|*.log;*.txt|RECURSE
 FileKey3=%LocalAppData%\Microsoft\Internet Explorer\CacheStorage|*|RECURSE
 FileKey4=%LocalAppData%\Microsoft\Windows\*Cache*|*|RECURSE
 FileKey5=%LocalAppData%\Microsoft\Windows\INetCookies|*|RECURSE
-FileKey6=%LocalAppData%\Packages\windows_ie_ac_*\AC\AppCache|*|RECURSE
-FileKey7=%LocalAppData%\Packages\windows_ie_ac_*\AC\IECompat*Cache|*|RECURSE
-FileKey8=%LocalAppData%\Packages\windows_ie_ac_*\AC\IEDownloadHistory|*|RECURSE
-FileKey9=%LocalAppData%\Packages\windows_ie_ac_*\AC\INet*|*|RECURSE
-FileKey10=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
-FileKey11=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\CryptnetUrlCache\*|*
-FileKey12=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
-FileKey13=%LocalAppData%\Packages\windows_ie_ac_*\AC\Microsoft\Internet Explorer\Emie*List|*|RECURSE
-FileKey14=%LocalAppData%\Packages\windows_ie_ac_*\AC\PRICache|*|RECURSE
-FileKey15=%LocalAppData%\Packages\windows_ie_ac_*\AC\Temp|*|RECURSE
-FileKey16=%LocalAppData%\Packages\windows_ie_ac_*\LocalState\Cache|*|RECURSE
-FileKey17=%LocalAppData%\Packages\windows_ie_ac_*\LocalState\navigationHistory|*|RECURSE
-FileKey18=%LocalAppData%\Packages\windows_ie_ac_*\TempState|*|RECURSE
-FileKey19=%SystemDrive%\Documents and Settings\LocalService*\Cookies|*|RECURSE
-FileKey20=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\History|*|RECURSE
-FileKey21=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\Temporary Internet Files|*|RECURSE
-FileKey22=%SystemDrive%\Documents and Settings\NetworkService*\Cookies|*|RECURSE
-FileKey23=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\History|*|RECURSE
-FileKey24=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\Temporary Internet Files|*|RECURSE
-FileKey25=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\History|*|RECURSE
-FileKey26=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
-FileKey27=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
-FileKey28=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\History|*|RECURSE
-FileKey29=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
-FileKey30=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
-FileKey31=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache|*|RECURSE
-FileKey32=%WinDir%\System32\config\systemprofile\Cookies|*|RECURSE
-FileKey33=%WinDir%\System32\config\systemprofile\History|*|RECURSE
-FileKey34=%WinDir%\System32\config\systemprofile\Local Settings\Temporary Internet Files|*|RECURSE
-FileKey35=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\History|*|RECURSE
-FileKey36=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
-FileKey37=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
-FileKey38=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache|*|RECURSE
+FileKey6=%LocalAppData%\Packages\windows_ie_*\AC\*Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\windows_ie_*\AC\IECompat*Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\windows_ie_*\AC\IEDownloadHistory|*|RECURSE
+FileKey9=%LocalAppData%\Packages\windows_ie_*\AC\INet*|*|RECURSE
+FileKey10=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey11=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey12=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey13=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\Internet Explorer\Emie*List|*|RECURSE
+FileKey14=%LocalAppData%\Packages\windows_ie_*\AC\Temp|*|RECURSE
+FileKey15=%LocalAppData%\Packages\windows_ie_*\LocalState\Cache|*|RECURSE
+FileKey16=%LocalAppData%\Packages\windows_ie_*\LocalState\navigationHistory|*|RECURSE
+FileKey17=%LocalAppData%\Packages\windows_ie_*\TempState|*|RECURSE
+FileKey18=%SystemDrive%\Documents and Settings\LocalService*\Cookies|*|RECURSE
+FileKey19=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\History|*|RECURSE
+FileKey20=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\Temporary Internet Files|*|RECURSE
+FileKey21=%SystemDrive%\Documents and Settings\NetworkService*\Cookies|*|RECURSE
+FileKey22=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\History|*|RECURSE
+FileKey23=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\Temporary Internet Files|*|RECURSE
+FileKey24=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\History|*|RECURSE
+FileKey25=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
+FileKey26=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
+FileKey27=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\History|*|RECURSE
+FileKey28=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
+FileKey29=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
+FileKey30=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache|*|RECURSE
+FileKey31=%WinDir%\System32\config\systemprofile\Cookies|*|RECURSE
+FileKey32=%WinDir%\System32\config\systemprofile\History|*|RECURSE
+FileKey33=%WinDir%\System32\config\systemprofile\Local Settings\Temporary Internet Files|*|RECURSE
+FileKey34=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\History|*|RECURSE
+FileKey35=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
+FileKey36=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
+FileKey37=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\windows_ie_ac_001\Internet Explorer\DOMStorage
 RegKey2=HKCU\Software\Microsoft\Internet Explorer\DOMStorage
 RegKey3=HKCU\Software\Microsoft\Internet Explorer\LowRegistry\DOMStorage
@@ -2415,13 +2523,12 @@ FileKey1=%LocalAppData%\Akamai\Logs|*.log
 [Al Quran *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\57100Goheer.TheQuran_s6gg0ptmhrgye
-FileKey1=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\INet*|*|RECURSE
 FileKey3=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey4=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\PRICache|*.*
-FileKey6=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\Temp|*.*
-FileKey7=%LocalAppData%\Packages\*Goheer.TheQuran_*\LocalState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\*Goheer.TheQuran_*\AC\Temp|*
+FileKey6=%LocalAppData%\Packages\*Goheer.TheQuran_*\LocalState|*|RECURSE
 
 [AlbumPlayer *]
 LangSecRef=3023
@@ -4541,14 +4648,13 @@ LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\134D4F5B.Box_2qk4zy5s3qmee
 DetectFile=%LocalAppData%\Box\BoxforOffice*
 FileKey1=%LocalAppData%\Box\BoxforOfficeLogs|*.*
-FileKey2=%LocalAppData%\Packages\134D4F5B.Box_*\AC\AppCache|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\134D4F5B.Box_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\134D4F5B.Box_*\AC\*Cache|*|RECURSE
+FileKey3=%LocalAppData%\Packages\134D4F5B.Box_*\AC\INet*|*|RECURSE
 FileKey4=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
-FileKey5=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey7=%LocalAppData%\Packages\134D4F5B.Box_*\AC\PRICache|*.*
-FileKey8=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Temp|*.*
-FileKey9=%LocalAppData%\Packages\134D4F5B.Box_*\LocalState|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*|RECURSE
+FileKey6=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey7=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Temp|*
+FileKey8=%LocalAppData%\Packages\134D4F5B.Box_*\LocalState|*|RECURSE
 
 [Breevy *]
 LangSecRef=3021
@@ -7638,19 +7744,6 @@ LangSecRef=3022
 DetectFile=%AppData%\eSobi
 FileKey1=%AppData%\eSobi\*\temp|*.*|RECURSE
 
-[ESPN Cricinfo *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma
-FileKey1=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey3=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey5=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\PRICache|*.*
-FileKey7=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Temp|*.*
-FileKey8=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\LocalState|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\TempState|*.*|RECURSE
-
 [Essential NetTools 3 *]
 LangSecRef=3022
 Detect=HKCU\Software\ENT3
@@ -8653,16 +8746,6 @@ Section=Games
 DetectFile=%ProgramFiles%\Steam\steamapps\common\GarrysMod
 FileKey1=%ProgramFiles%\Steam\steamapps\common\GarrysMod|*.cache|RECURSE
 
-[GasBuddy *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\45351D82.GasBuddy-FindCheapGasPrices_932xwky9axss4
-FileKey1=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\PRICache|*.*
-FileKey5=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Temp|*.*
-FileKey6=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\TempState|*.*|RECURSE
-
 [Gatewatch *]
 Section=Games
 DetectFile=%Documents%\Gatewatch_Logs
@@ -9074,24 +9157,23 @@ FileKey1=%AppData%\Elephant Games\Grim Tales The Wishes CE|logfile.txt
 [Groove Media Player *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneMusic_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\AppCache|*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\*Cache|*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\INet*|*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\PRICache|*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Temp|*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\TokenBroker\Cache|*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalCache\Image|*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalCache\PlayReady|*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState|*.tmp;AppState.json*;*.db*
-FileKey12=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\Database\*|*.log
-FileKey13=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageCache|*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageRetrievalFailure|*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageStore|*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\navigationHistory|*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\PlayReady|*|RECURSE
-FileKey18=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\TempState|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\Temp|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalCache\Image|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalCache\PlayReady|*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState|*.tmp;AppState.json*;*.db*
+FileKey11=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\Database\*|*.log
+FileKey12=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageCache|*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageRetrievalFailure|*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\ImageStore|*|RECURSE
+FileKey15=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\navigationHistory|*|RECURSE
+FileKey16=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\LocalState\PlayReady|*|RECURSE
+FileKey17=%LocalAppData%\Packages\Microsoft.ZuneMusic_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneMusic_8wekyb3d8bbwe\SearchHistory
 
 [GroupWise Messenger *]
@@ -9621,13 +9703,12 @@ FileKey2=%LocalAppData%\Hewlett-Packard\MediaSmart\Photo\tm*Cache|*.*|REMOVESELF
 [HP Scan and Capture *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\AD2F1837.HPScanandCapture_v10z8vjag6ke6
-FileKey1=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\INet*|*|RECURSE
 FileKey3=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
-FileKey4=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey5=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\PRICache|*.*
-FileKey6=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\Temp|*.*
-FileKey7=%LocalAppData%\Packages\*.HPScanandCapture_*\LocalState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey5=%LocalAppData%\Packages\*.HPScanandCapture_*\AC\Temp|*
+FileKey6=%LocalAppData%\Packages\*.HPScanandCapture_*\LocalState|*|RECURSE
 
 [HP Smart *]
 LangSecRef=3031
@@ -10747,11 +10828,10 @@ FileKey1=%AppData%\JustVoip|History_*.dat
 [jv16 PowerTools *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\jv16 PowerTools*
-FileKey1=%ProgramFiles%\jv16 PowerTools*|*.log;*.reg
-FileKey2=%ProgramFiles%\jv16 PowerTools*\Backups|*|RECURSE
-FileKey3=%ProgramFiles%\jv16 PowerTools*\Settings|*.log
-FileKey4=%ProgramFiles%\jv16 PowerTools*\Temp|*|RECURSE
-FileKey5=%ProgramFiles%\jv16 PowerTools\Debug|*.log
+FileKey1=%ProgramFiles%\jv16 PowerTools*|*.log
+FileKey2=%ProgramFiles%\jv16 PowerTools*\Settings|*.log
+FileKey3=%ProgramFiles%\jv16 PowerTools*\Temp|*|RECURSE
+FileKey4=%ProgramFiles%\jv16 PowerTools\Debug|*.log;*.txt
 
 [jv16 RegCleaner *]
 LangSecRef=3024
@@ -10992,6 +11072,12 @@ LangSecRef=3023
 Detect=HKLM\Software\Krita
 FileKey1=%LocalAppData%|krita*.log
 FileKey2=%LocalAppData%\krita\cache|*.*|RECURSE
+
+[kv16 PowerTools Backups *]
+LangSecRef=3024
+DetectFile=%ProgramFiles%\jv16 PowerTools*
+FileKey1=%ProgramFiles%\jv16 PowerTools*|*.reg
+FileKey2=%ProgramFiles%\jv16 PowerTools*\Backups|*|RECURSE
 
 [L0pht AntiSniff *]
 LangSecRef=3024
@@ -12056,14 +12142,6 @@ RegKey11=HKCU\Software\Microsoft\Microsoft Help Workshop\Recent File List
 RegKey12=HKCU\Software\Microsoft\Microsoft HTML Help Image Editor\Folders
 RegKey13=HKCU\Software\Microsoft\Microsoft HTML Help Image Editor\Recent File List
 
-[Microsoft LifeCam *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.LifeCamDashboard_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\PRICache|*.*
-FileKey3=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\Temp|*.*
-FileKey4=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\TempState|*.*|RECURSE
-
 [Microsoft Management Console *]
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\MMC
@@ -12095,26 +12173,26 @@ RegKey2=HKCU\Software\Microsoft\IntelliType Pro\AppSpecific
 [Microsoft Network Speed Test *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.NetworkSpeedTest_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CLR_v4.0*|*.log
-FileKey3=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\PRICache|*.*
+FileKey1=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\*Cache|*.*
+FileKey2=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CLR_v4.0*|*.log
+FileKey4=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
 FileKey6=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Temp|*.*
 FileKey7=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\TempState|*.*|RECURSE
 
 [Microsoft News *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingNews_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\PRICache|*.*
-FileKey5=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.BingNews_*\LocalState\Cache\Images|*.*
-FileKey8=%LocalAppData%\Packages\Microsoft.BingNews_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.BingNews_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\*Cache|*
+FileKey2=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\Temp|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.BingNews_*\LocalState\Cache\Images|*
+FileKey8=%LocalAppData%\Packages\Microsoft.BingNews_*\LocalState\navigationHistory|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.BingNews_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingNews_8wekyb3d8bbwe\SearchHistory
 
 [Microsoft Office *]
@@ -12217,25 +12295,24 @@ ExcludeKey4=PATH|%AppData%\Microsoft\Word\STARTUP\|*.*
 LangSecRef=3021
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.microsoftskydrive_8wekyb3d8bbwe
 Detect2=HKCU\Software\Microsoft\OneDrive
-FileKey1=%LocalAppData%\Microsoft\OneDrive\Logs|*.*|RECURSE
-FileKey2=%LocalAppData%\Microsoft\OneDrive\Setup\Logs|*.*|RECURSE
-FileKey3=%LocalAppData%\Microsoft\Windows\OneDrive\logs|*.*|RECURSE
-FileKey4=%LocalAppData%\OneDrive\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\AppCache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\INet*|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey9=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\PRICache|*.*
-FileKey10=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Temp|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\LocalCache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\LocalState\Logs|*.log
-FileKey13=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\TempState|*.*|RECURSE
-FileKey14=%ProgramFiles%\Microsoft OneDrive\Setup\Logs|*.*
-FileKey15=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\OneDrive\Logs|*.*|RECURSE
-FileKey16=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\OneDrive\Setup\Logs|*.*|RECURSE
-FileKey17=%WinDir%\System32\LogFiles\CloudFiles|*.*|RECURSE
-FileKey18=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\OneDrive\Logs|*.*|RECURSE
-FileKey19=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\OneDrive\Setup\Logs|*.*|RECURSE
+FileKey1=%LocalAppData%\Microsoft\OneDrive\Logs|*|RECURSE
+FileKey2=%LocalAppData%\Microsoft\OneDrive\Setup\Logs|*|RECURSE
+FileKey3=%LocalAppData%\Microsoft\Windows\OneDrive\logs|*|RECURSE
+FileKey4=%LocalAppData%\OneDrive\Cache|*|RECURSE
+FileKey5=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\*Cache|*|RECURSE
+FileKey6=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\INet*|*|RECURSE
+FileKey7=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey8=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey9=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\AC\Temp|*|RECURSE
+FileKey10=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\LocalCache|*|RECURSE
+FileKey11=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\LocalState\Logs|*.log
+FileKey12=%LocalAppData%\Packages\microsoft.microsoftskydrive_*\TempState|*|RECURSE
+FileKey13=%ProgramFiles%\Microsoft OneDrive\Setup\Logs|*
+FileKey14=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\OneDrive\Logs|*|RECURSE
+FileKey15=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\OneDrive\Setup\Logs|*|RECURSE
+FileKey16=%WinDir%\System32\LogFiles\CloudFiles|*|RECURSE
+FileKey17=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\OneDrive\Logs|*|RECURSE
+FileKey18=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\OneDrive\Setup\Logs|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.microsoftskydrive_8wekyb3d8bbwe\PersistedPickerData\microsoft.microsoftskydrive_8wekyb3d8bbwe!Microsoft.MicrosoftSkyDrive\DefaultOpenFileMultiple|LastLocation
 RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.microsoftskydrive_8wekyb3d8bbwe\SearchHistory
 
@@ -12314,16 +12391,15 @@ FileKey2=%CommonAppData%\Microsoft\PlayReady\Cache|*.*
 FileKey3=%CommonAppData%\Microsoft\Windows\DRM|*.log
 FileKey4=%CommonAppData%\Microsoft\Windows\DRM\Cache|*.*|RECURSE
 FileKey5=%CommonAppData%\Microsoft\Windows\DRM\PreUpgrade|*.log
-FileKey6=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\AppCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\INet*|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey10=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\PRICache|*.*
-FileKey12=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Temp|*.*
-FileKey13=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\Cache|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\TempState|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\*Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\INet*|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey10=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Temp|*
+FileKey12=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\Cache|*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\LocalState\navigationHistory|*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\TempState|*|RECURSE
 
 [Microsoft Project 2010 *]
 LangSecRef=3021
@@ -13354,22 +13430,21 @@ FileKey2=%LocalAppData%\Collectorz.com\Movie Collector\Temp\Images|*.*
 [Movies & TV *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneVideo_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\PRICache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalCache\PlayReady|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\Database\anonymous|*.log
-FileKey11=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageCache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageRetrievalFailure|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageStore|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\PlayReady|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\Temp|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalCache\PlayReady|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\Database\anonymous|*.log
+FileKey10=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageCache|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageRetrievalFailure|*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\ImageStore|*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\navigationHistory|*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\LocalState\PlayReady|*|RECURSE
+FileKey15=%LocalAppData%\Packages\Microsoft.ZuneVideo_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ZuneVideo_8wekyb3d8bbwe\SearchHistory\SearchHistory
 
 [MP3Gain *]
@@ -13455,30 +13530,28 @@ FileKey1=%LocalAppData%\Packages\Microsoft.BingHealthAndFitness_*\LocalState\Cac
 [MSN Money *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingFinance_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\PRICache|*.*
-FileKey6=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.BingFinance_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\Temp|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.BingFinance_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.BingFinance_*\TempState|*|RECURSE
 
 [MSN Weather *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingWeather_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\INet*|*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\CLR_v4.0|*.log
-FileKey4=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\PRICache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState|*.tmp;UserActivity.json
-FileKey10=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.BingWeather_*\TempState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\Temp|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.BingWeather_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState|*.tmp;UserActivity.json
+FileKey9=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\Cache|*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.BingWeather_*\LocalState\navigationHistory|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.BingWeather_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingWeather_8wekyb3d8bbwe\SearchHistory
 
 [MTA: San Andreas *]
@@ -13949,19 +14022,18 @@ FileKey2=%UserProfile%\.nbi\log|*.log|RECURSE
 [Netflix *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\4DF9E0F8.Netflix_mcm4njqhnhss8
-FileKey1=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\BackgroundTransferApi|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\INet*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\Internet Explorer\DOMStore\*|*.*|REMOVESELF
-FileKey7=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\PRICache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Temp|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AppData\Indexed DB|*.log
-FileKey10=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalCache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState|*.tmp
-FileKey12=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState\LiveTile|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\BackgroundTransferApi|*|RECURSE
+FileKey3=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\INet*|*|RECURSE
+FileKey4=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey5=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey6=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\Internet Explorer\DOMStore\*|*|REMOVESELF
+FileKey7=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Temp|*|RECURSE
+FileKey8=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AppData\Indexed DB|*.log
+FileKey9=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalCache|*|RECURSE
+FileKey10=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState|*.tmp
+FileKey11=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\LocalState\LiveTile|*|RECURSE
+FileKey12=%LocalAppData%\Packages\4DF9E0F8.Netflix_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\4DF9E0F8.Netflix_mcm4njqhnhss8\SearchHistory
 ExcludeKey1=FILE|%LocalAppData%\Packages\4DF9E0F8.Netflix_*\AC\Microsoft\Internet Explorer\DOMStore\*\|www.netflix[1].xml
 
@@ -17289,25 +17361,24 @@ LangSecRef=3021
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.SkypeApp_kzf8qxf38zg5c
 DetectFile=%AppData%\Microsoft\Skype for Desktop
 FileKey1=%AppData%\Microsoft\Skype for Desktop|*-journal;*.old;LOG;Network Persistent State;QuotaManager;Skype-Setup.exe|RECURSE
-FileKey2=%AppData%\Microsoft\Skype for Desktop\blob_storage|*.*|RECURSE
-FileKey3=%AppData%\Microsoft\Skype for Desktop\Code Cache|*.*|RECURSE
-FileKey4=%AppData%\Microsoft\Skype for Desktop\Logs|*.*
+FileKey2=%AppData%\Microsoft\Skype for Desktop\blob_storage|*|RECURSE
+FileKey3=%AppData%\Microsoft\Skype for Desktop\Code Cache|*|RECURSE
+FileKey4=%AppData%\Microsoft\Skype for Desktop\Logs|*
 FileKey5=%AppData%\Microsoft\Skype for Desktop\Media-stack|*.bak;*.blog;*.etl
 FileKey6=%AppData%\Microsoft\Skype for Desktop\skylib|*.blog
-FileKey7=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\AppCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\INet*|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey10=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\PRICache|*.*
-FileKey12=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Temp|*.*
-FileKey13=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalCache\Roaming\Microsoft\Skype for Store|*-journal;*.old;LOG;Network Persistent State|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalCache\Roaming\Microsoft\Skype for Store\*Cache|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalCache\Roaming\Microsoft\Skype for Store\Logs|*.*
-FileKey16=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState|*-shm;*-wal
-FileKey17=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState\DiagOutputDir|*.*
-FileKey18=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState\logs|*.*|RECURSE
-FileKey19=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState\tracing\wppmedia|*.bak;*.etl
-FileKey20=%LocalAppData%\Packages\Microsoft.SkypeApp_*\TempState|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\*Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\INet*|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey10=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.SkypeApp_*\AC\Temp|*
+FileKey12=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalCache\Roaming\Microsoft\Skype for Store|*-journal;*.old;LOG;Network Persistent State|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalCache\Roaming\Microsoft\Skype for Store\*Cache|*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalCache\Roaming\Microsoft\Skype for Store\Logs|*
+FileKey15=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState|*-shm;*-wal
+FileKey16=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState\DiagOutputDir|*
+FileKey17=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState\logs|*|RECURSE
+FileKey18=%LocalAppData%\Packages\Microsoft.SkypeApp_*\LocalState\tracing\wppmedia|*.bak;*.etl
+FileKey19=%LocalAppData%\Packages\Microsoft.SkypeApp_*\TempState|*|RECURSE
 
 [SkypeAlyzer *]
 LangSecRef=3024
@@ -19487,15 +19558,14 @@ FileKey6=%AppData%\Twitch\logs\*|*.json;*.log|REMOVESELF
 [Twitter *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\9E2F88E3.Twitter_wgeqdkkx372wm
-FileKey1=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\INet*|*|RECURSE
 FileKey3=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Microsoft\*|*.LOG|RECURSE
-FileKey4=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Microsoft\Internet Explorer\DOMStore\*|*.*|REMOVESELF
-FileKey6=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\PRICache|*.*
-FileKey7=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AppData\Indexed DB|*.log
-FileKey9=%LocalAppData%\Packages\9E2F88E3.Twitter_*\LocalState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Microsoft\Internet Explorer\DOMStore\*|*|REMOVESELF
+FileKey6=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AC\Temp|*|RECURSE
+FileKey7=%LocalAppData%\Packages\9E2F88E3.Twitter_*\AppData\Indexed DB|*.log
+FileKey8=%LocalAppData%\Packages\9E2F88E3.Twitter_*\LocalState|*|RECURSE
 
 [Two Worlds Epic Edition *]
 Section=Games
@@ -19610,21 +19680,20 @@ FileKey1=%AppData%\ATViewer|ViewerHistory.ini
 [Universal Windows Platform *]
 LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData
-FileKey1=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\AC\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\LocalCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\LocalState|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\TempState|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\AppCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\INet*|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey10=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\PRICache|*.*
-FileKey12=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Temp|*.*
-FileKey13=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\Cache|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\AC\Temp|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\LocalCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\LocalState|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\TempState|*|RECURSE
+FileKey6=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\*Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\INet*|*|RECURSE
+FileKey8=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey9=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey10=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey11=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\AC\Temp|*
+FileKey12=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\Cache|*|RECURSE
+FileKey13=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\LocalState\navigationHistory|*|RECURSE
+FileKey14=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Phone\ShellUI\WindowSizing
 RegKey2=HKCU\Software\Microsoft\UserData\UninstallTimes
 
@@ -20441,11 +20510,11 @@ FileKey1=%ProgramFiles%\Yamicsoft\Windows 7 Manager\DiskAnalyzerXML|*.*
 [Windows Alarms & Clock *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsAlarms_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\AC\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\LocalCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\LocalState|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\AC\Temp|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\LocalCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\LocalState|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\TempState|*|RECURSE
 
 [Windows AutoPlay Devices *]
 LangSecRef=3025
@@ -20455,49 +20524,48 @@ RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers
 [Windows Calculator *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsCalculator_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\AC\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\LocalCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\LocalState\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\AC\Temp|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\LocalCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\LocalState\Cache|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\TempState|*|RECURSE
 
 [Windows Camera *]
 LangSecRef=3031
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Camera_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsCamera_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\PRICache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.*Camera_*\TempState|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\AppData|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\Cache|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\Temp|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.*Camera_*\TempState|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalCache|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\AppData|*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.WindowsCamera_*\LocalState\Cache|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Camera_8wekyb3d8bbwe\SearchHistory
 
 [Windows CD Burning Queue *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\CD Burning
-FileKey1=%LocalAppData%\Microsoft\CD Burning|*.*|RECURSE
-FileKey2=%LocalAppData%\Microsoft\Windows\Burn|*.*|RECURSE
+FileKey1=%LocalAppData%\Microsoft\CD Burning|*|RECURSE
+FileKey2=%LocalAppData%\Microsoft\Windows\Burn|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\CD Burning\StagingInfo
 
 [Windows Cryptographic Services *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
-FileKey1=%LocalLowAppData%\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey2=%LocalLowAppData%\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey3=%WinDir%\ServiceProfiles\*\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey4=%WinDir%\ServiceProfiles\*\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey5=%WinDir%\System32\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey6=%WinDir%\System32\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey7=%WinDir%\System32\config\systemprofile\Application Data\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey8=%WinDir%\System32\config\systemprofile\Application Data\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
-FileKey9=%WinDir%\SysWOW64\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*.*|RECURSE
-FileKey10=%WinDir%\SysWOW64\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*.*|RECURSE
+FileKey1=%LocalLowAppData%\Microsoft\CryptnetUrlCache\Content|*|RECURSE
+FileKey2=%LocalLowAppData%\Microsoft\CryptnetUrlCache\MetaData|*|RECURSE
+FileKey3=%WinDir%\ServiceProfiles\*\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*|RECURSE
+FileKey4=%WinDir%\ServiceProfiles\*\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*|RECURSE
+FileKey5=%WinDir%\System32\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*|RECURSE
+FileKey6=%WinDir%\System32\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*|RECURSE
+FileKey7=%WinDir%\System32\config\systemprofile\Application Data\Microsoft\CryptnetUrlCache\Content|*|RECURSE
+FileKey8=%WinDir%\System32\config\systemprofile\Application Data\Microsoft\CryptnetUrlCache\MetaData|*|RECURSE
+FileKey9=%WinDir%\SysWOW64\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\Content|*|RECURSE
+FileKey10=%WinDir%\SysWOW64\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\MetaData|*|RECURSE
 
 [Windows Device Manager *]
 LangSecRef=3025
@@ -20520,10 +20588,10 @@ RegKey8=HKCU\Software\Microsoft\Microsoft DVD Wizard Settings\MRU3
 [Windows Error Reporting *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows\Windows Error Reporting
-FileKey1=%LocalAppData%\PCHealth\ErrorRep\QSignoff|*.*
-FileKey2=%WinDir%\pchealth\ERRORREP|*.*|RECURSE
+FileKey1=%LocalAppData%\PCHealth\ErrorRep\QSignoff|*
+FileKey2=%WinDir%\pchealth\ERRORREP|*|RECURSE
 FileKey3=%WinDir%\pchealth\helpctr\DataColl|*.xml
-FileKey4=%WinDir%\pchealth\helpctr\OfflineCache|*.*|RECURSE
+FileKey4=%WinDir%\pchealth\helpctr\OfflineCache|*|RECURSE
 FileKey5=%WinDir%\System32\config\systemprofile\AppData\Local\CrashDumps|*.dmp|RECURSE
 FileKey6=%WinDir%\System32\config\systemprofile\Local Settings\Application Data\CrashDumps|*.dmp|RECURSE
 FileKey7=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\CrashDumps|*.dmp|RECURSE
@@ -20544,18 +20612,18 @@ FileKey2=%LocalAppData%\Microsoft\Event Viewer|RecentViews
 LangSecRef=3025
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsFeedback_cw5n1h2txyewy
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsFeedbackHub_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\LocalCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\TempState|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\AppCache|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\LocalCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsFeedback*_*\TempState|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\AppCache|*|RECURSE
 FileKey6=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*|*.log
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Temp|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\LocalState\Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.WindowsFeedbackHub_*\AC\Temp|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\Temp|*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.WindowsFeedback_*\LocalState\Cache|*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.WindowsFeedbackHub_*\AC\Temp|*|RECURSE
 FileKey13=%LocalAppData%\Packages\Microsoft.WindowsFeedbackHub_*\LocalState\DiagOutputDir|*.txt
 
 [Windows File Manager *]
@@ -20563,14 +20631,14 @@ LangSecRef=3031
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\FileManager_cw5n1h2txyewy
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsFileManager_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\FileManager_*\LocalState|*.jpg
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\AC\Temp|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\Local\*|*.*|REMOVESELF
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\LocalLow\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\LocalLow\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\Roaming\*|*.*|REMOVESELF
-FileKey8=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\Temp|*.*|REMOVESELF
-FileKey9=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\AC\Temp|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\Local\*|*|REMOVESELF
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\LocalLow\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\LocalLow\Temp|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\Roaming\*|*|REMOVESELF
+FileKey8=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\LocalCache\Temp|*|REMOVESELF
+FileKey9=%LocalAppData%\Packages\Microsoft.WindowsFileManager_*\TempState|*|RECURSE
 
 [Windows Font Cache *]
 LangSecRef=3025
@@ -20589,27 +20657,27 @@ FileKey1=%LocalAppData%\Microsoft Games|*.xml*|RECURSE
 LangSecRef=3025
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.GetHelp_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Windows.ContactSupport_cw5n1h2txyewy
-FileKey1=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.GetHelp_*\LocalCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.GetHelp_*\LocalState\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.GetHelp_*\TempState|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\AppCache|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\INet*|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\AppCache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\Temp|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.GetHelp_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.GetHelp_*\LocalCache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.GetHelp_*\LocalState\Cache|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.GetHelp_*\TempState|*|RECURSE
+FileKey10=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\AppCache|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\INet*|*|RECURSE
 FileKey12=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*|*.log
-FileKey13=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Temp|*.*|RECURSE
-FileKey18=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey19=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalCache|*.*|RECURSE
-FileKey20=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalState\Cache|*.*|RECURSE
-FileKey21=%LocalAppData%\Packages\Windows.ContactSupport_*\TempState|*.*|RECURSE
+FileKey13=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*|RECURSE
+FileKey14=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*|RECURSE
+FileKey15=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey16=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey17=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\Temp|*|RECURSE
+FileKey18=%LocalAppData%\Packages\Windows.ContactSupport_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey19=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalCache|*|RECURSE
+FileKey20=%LocalAppData%\Packages\Windows.ContactSupport_*\LocalState\Cache|*|RECURSE
+FileKey21=%LocalAppData%\Packages\Windows.ContactSupport_*\TempState|*|RECURSE
 
 [Windows Grep *]
 LangSecRef=3024
@@ -20622,60 +20690,58 @@ RegKey4=HKCU\Software\Windows Grep\Windows Grep\Current Version\Search Dialog\St
 [Windows Image Acquisition *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\WIA
-FileKey1=%AppData%\Microsoft\Document Center\UserScanProfiles|*.*
-FileKey2=%LocalAppData%\Microsoft\UserScanProfiles|*.*
+FileKey1=%AppData%\Microsoft\Document Center\UserScanProfiles|*
+FileKey2=%LocalAppData%\Microsoft\UserScanProfiles|*
 FileKey3=%UserProfile%|Sti_Trace.log
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\WIA
 
 [Windows Installer *]
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Installer
-FileKey1=%SystemDrive%\Config.msi|*.*|REMOVESELF
+FileKey1=%SystemDrive%\Config.msi|*|REMOVESELF
 FileKey2=%WinDir%\Installer|*.tmp|RECURSE
 FileKey3=%WinDir%\Installer|SourceHash{*};wix{*}.SchedServiceConfig.rmi
-FileKey4=%WinDir%\Installer\Config.Msi|*.*|REMOVESELF
-FileKey5=%WinDir%\Installer\MSI*.tmp-|*.*|REMOVESELF
+FileKey4=%WinDir%\Installer\Config.Msi|*|REMOVESELF
+FileKey5=%WinDir%\Installer\MSI*.tmp-|*|REMOVESELF
 
 [Windows Language Libraries *]
 LangSecRef=3025
-DetectFile1=%LocalAppData%\Packages\Microsoft.VCLibs.1*0.00_8wekyb3d8bbwe
-DetectFile2=%LocalAppData%\Packages\Microsoft.WinJS.*.0_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey5=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\PRICache|*.*
-FileKey7=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\AC\Temp|*.*
-FileKey8=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\LocalState\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\Microsoft.VCLibs.*_*\TempState|*.*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\AppCache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\INet*|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey15=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\PRICache|*.*
-FileKey17=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\AC\Temp|*.*
-FileKey18=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\LocalState\*Cache|*.*|RECURSE
-FileKey19=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey20=%LocalAppData%\Packages\Microsoft.WinJS.*.*_*\TempState|*.*|RECURSE
-FileKey21=%SystemDrive%|eula.*.txt;globdata.ini;install.exe;install.ini;install.res.*.dll;VC_RED.cab;VC_RED.MSI;vcredist.bmp
+DetectFile1=%LocalAppData%\Packages\Microsoft.VCLibs.*
+DetectFile2=%LocalAppData%\Packages\Microsoft.WinJS.*
+FileKey1=%LocalAppData%\Packages\Microsoft.VCLibs.*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.VCLibs.*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.VCLibs.*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.VCLibs.*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey5=%LocalAppData%\Packages\Microsoft.VCLibs.*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.VCLibs.*\AC\Temp|*
+FileKey7=%LocalAppData%\Packages\Microsoft.VCLibs.*\LocalState\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.VCLibs.*\LocalState\navigationHistory|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.VCLibs.*\TempState|*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.WinJS.*\AC\*Cache|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.WinJS.*\AC\INet*|*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.WinJS.*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.WinJS.*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey14=%LocalAppData%\Packages\Microsoft.WinJS.*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey15=%LocalAppData%\Packages\Microsoft.WinJS.*\AC\Temp|*
+FileKey16=%LocalAppData%\Packages\Microsoft.WinJS.*\LocalState\*Cache|*|RECURSE
+FileKey17=%LocalAppData%\Packages\Microsoft.WinJS.*\LocalState\navigationHistory|*|RECURSE
+FileKey18=%LocalAppData%\Packages\Microsoft.WinJS.*\TempState|*|RECURSE
+FileKey19=%SystemDrive%|eula.*.txt;globdata.ini;install.exe;install.ini;install.res.*.dll;VC_RED.cab;VC_RED.MSI;vcredist.bmp
 
 [Windows Live Mail *]
 LangSecRef=3022
 Detect=HKCU\Software\Microsoft\Windows Live Mail
 FileKey1=%LocalAppData%\Microsoft\Windows*Mail|*.log;*.jrs;*.chk;*.rss;*.tmp|RECURSE
 FileKey2=%LocalAppData%\Microsoft\Windows*Mail\*|*.MSMessageStore|RECURSE
-FileKey3=%LocalAppData%\Microsoft\Windows*Mail\*.tmp|*.*|RECURSE
-FileKey4=%LocalAppData%\Microsoft\Windows*Mail\*\Backup|*.*|REMOVESELF
-FileKey5=%LocalAppData%\Microsoft\Windows*Mail\Backup|*.*|REMOVESELF
+FileKey3=%LocalAppData%\Microsoft\Windows*Mail\*.tmp|*|RECURSE
+FileKey4=%LocalAppData%\Microsoft\Windows*Mail\*\Backup|*|REMOVESELF
+FileKey5=%LocalAppData%\Microsoft\Windows*Mail\Backup|*|REMOVESELF
 RegKey1=HKCU\Software\Microsoft\Windows Live Mail|SearchFolderVersion
 
 [Windows Live Movie Maker *]
 LangSecRef=3023
 Detect=HKCU\Software\Microsoft\Windows Live\Movie Maker
-FileKey1=%LocalAppData%\Microsoft\Windows Live Movie Maker|*.*|RECURSE
+FileKey1=%LocalAppData%\Microsoft\Windows Live Movie Maker|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows Live\Movie Maker|browseformusicdirectory
 RegKey2=HKCU\Software\Microsoft\Windows Live\Movie Maker|browseforpicturesdirectory
 RegKey3=HKCU\Software\Microsoft\Windows Live\Movie Maker|browseforprojectsdirectory
@@ -20910,12 +20976,11 @@ FileKey5=%LocalAppData%\Packages\Microsoft.Windows*Photos_*\LocalCache|*.*|RECUR
 FileKey6=%LocalAppData%\Packages\Microsoft.Windows*Photos_*\LocalState|*.etl;*.sqlite*;*.xml;*.log;*.jpg
 FileKey7=%LocalAppData%\Packages\Microsoft.Windows*Photos_*\LocalState\PhotosAppTile|*.*|RECURSE
 FileKey8=%LocalAppData%\Packages\Microsoft.Windows*Photos_*\TempState|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\AppCache|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\*Cache|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\BackgroundTransferApi|*.down_data;*.up_meta
 FileKey11=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
 FileKey12=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\microsoft.windowsphotos_*\AC\PRICache|*.*
-FileKey14=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState\bici|*.sqm
+FileKey13=%LocalAppData%\Packages\microsoft.windowsphotos_*\LocalState\bici|*.sqm
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Photos_8wekyb3d8bbwe\PersistedPickerData\Microsoft.Windows.Photos_8wekyb3d8bbwe!App\DefaultSaveFileSingle
 RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Photos_8wekyb3d8bbwe\PersistedStorageItemTable\ManagedByApp
 RegKey3=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Windows.Photos_8wekyb3d8bbwe\PersistedStorageItemTable\MostRecentlyUsed
@@ -20963,11 +21028,6 @@ RegKey1=HKU\.DEFAULT\Software\Microsoft\Windows\CurrentVersion\Explorer\RecentDo
 RegKey2=HKU\S-1-5-18\Software\Microsoft\Windows\CurrentVersion\Explorer\RecentDocs
 RegKey3=HKU\S-1-5-19\Software\Microsoft\Windows\CurrentVersion\Explorer\RecentDocs
 RegKey4=HKU\S-1-5-20\Software\Microsoft\Windows\CurrentVersion\Explorer\RecentDocs
-
-[Windows Recent Theme Colors *]
-LangSecRef=3025
-Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\History\Colors
-RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\History\Colors
 
 [Windows Remote Desktop *]
 LangSecRef=3025
@@ -21057,16 +21117,15 @@ RegKey2=HKU\.DEFAULT\Software\Classes\Local Settings\MrtCache
 [Windows Settings *]
 LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\windows.immersivecontrolpanel_cw5n1h2txyewy
-FileKey1=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey5=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\PRICache|*.*
-FileKey7=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Temp|*.*
-FileKey8=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\*Cache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey4=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey5=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey6=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\AC\Temp|*
+FileKey7=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\LocalState\navigationHistory|*|RECURSE
+FileKey9=%LocalAppData%\Packages\windows.immersivecontrolpanel_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\windows.immersivecontrolpanel_cw5n1h2txyewy\SearchHistory
 
 [Windows Shell - Folder View Settings *]
@@ -21085,17 +21144,22 @@ ExcludeKey2=REG|HKCU\Software\Classes\Wow6432Node\Local Settings\Software\Micros
 ExcludeKey3=REG|HKCU\Software\Microsoft\Windows\Shell\Bags\1\Desktop
 ExcludeKey4=REG|HKCU\Software\Microsoft\Windows\ShellNoRoam\Bags\AllFolders
 
+[Windows Shell - Theme Colors History *]
+LangSecRef=3025
+Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\History\Colors
+RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\History\Colors
+
 [Windows Shell *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 FileKey1=%LocalAppData%|IconCache.db;IconCache.db.backup
 FileKey2=%LocalAppData%\Microsoft\Windows\Explorer|iconcache_*.db
 FileKey3=%LocalAppData%\Microsoft\Windows\Explorer\IconCacheToDelete|*.tmp
-FileKey4=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\INet*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Microsoft\Windows\*|*.*|REMOVESELF
-FileKey6=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Temp|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\TempState|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\INet*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Microsoft\Windows\*|*|REMOVESELF
+FileKey6=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Temp|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalCache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer|ScreenshotIndex
 RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts
 RegKey3=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\SharingMFU
@@ -21111,9 +21175,9 @@ FileKey1=%WinDir%|SIGVERIF.TXT
 [Windows Start Menu *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\UFH
-FileKey1=%LocalAppData%\Packages\Microsoft.Windows.StartMenuExperienceHost_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Windows.StartMenuExperienceHost_*\AC\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Windows.StartMenuExperienceHost_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.Windows.StartMenuExperienceHost_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Windows.StartMenuExperienceHost_*\AC\Temp|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Windows.StartMenuExperienceHost_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage|ProgramsCache
 RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage2|ProgramsCache
 RegKey3=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage2|ProgramsCacheSMP
@@ -21128,34 +21192,35 @@ LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 FileKey1=%CommonAppData%\Microsoft\RAC\PublishedData|*.log;*.jrs
 FileKey2=%CommonAppData%\Microsoft\RAC\StateData|*.log;*.jrs
-FileKey3=%CommonAppData%\Microsoft\RAC\Temp|*.*
-FileKey4=%CommonAppData%\Microsoft\Windows\DeviceMetadataCache\dmrccache.bak|*.*|REMOVESELF
+FileKey3=%CommonAppData%\Microsoft\RAC\Temp|*
+FileKey4=%CommonAppData%\Microsoft\Windows\DeviceMetadataCache\dmrccache.bak|*|REMOVESELF
 FileKey5=%CommonAppData%\Microsoft\Windows\Sqm\Manifest|*.bin
 FileKey6=%CommonAppData%\Microsoft\Windows\Sqm\Sessions|*.psqm;*.sqm
 FileKey7=%Documents%\Remote Assistance Logs|*.xml
-FileKey8=%LocalAppData%\Microsoft\Windows Sidebar\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Microsoft\Windows\PRICache|*.*|RECURSE
-FileKey10=%LocalAppData%\Microsoft\Windows\SettingSync\metastore|*.jrs
-FileKey11=%LocalAppData%\Microsoft\Windows\SettingSync\remotemetastore\*|*.jrs
-FileKey12=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\AppCache|*.*|RECURSE
-FileKey13=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\INet*|*.*|RECURSE
-FileKey14=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Temp|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalCache|*.*|RECURSE
-FileKey18=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalState\Cache|*.*|RECURSE
-FileKey19=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\TempState|*.*|RECURSE
-FileKey20=%SystemDrive%\Documents and Settings\LocalService\Application Data\PeerNetworking|*.*|RECURSE
-FileKey21=%WinDir%\$regcmp$|*.*|REMOVESELF
-FileKey22=%WinDir%\ehome|PRDMOWrapper.log
-FileKey23=%WinDir%\msdownld.tmp|*.*|REMOVESELF
-FileKey24=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows|qwavecache.dat
-FileKey25=%WinDir%\ServiceProfiles\LocalService\AppData\Roaming\PeerNetworking|*.*|RECURSE
-FileKey26=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\PeerDist*|*.chk;*.jrs
-FileKey27=%WinDir%\System32|PRDMOWrapper.log;qwavecache.dat
-FileKey28=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Device Metadata\dmrccache\downloads|*.tmp
-FileKey29=%WinDir%\System32\config\systemprofile\AppData\Local\tw-*.tmp|empty.check|REMOVESELF
-FileKey30=%WinDir%\System32\sru|*.*|RECURSE
+FileKey8=%LocalAppData%\Microsoft\Windows Sidebar\Cache|*|RECURSE
+FileKey9=%LocalAppData%\Microsoft\Windows\AppCache|*|RECURSE
+FileKey10=%LocalAppData%\Microsoft\Windows\PRICache|*|RECURSE
+FileKey11=%LocalAppData%\Microsoft\Windows\SettingSync\metastore|*.jrs
+FileKey12=%LocalAppData%\Microsoft\Windows\SettingSync\remotemetastore\*|*.jrs
+FileKey13=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\AppCache|*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\INet*|*|RECURSE
+FileKey15=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey16=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey17=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\AC\Temp|*|RECURSE
+FileKey18=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalCache|*|RECURSE
+FileKey19=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\LocalState\Cache|*|RECURSE
+FileKey20=%LocalAppData%\Packages\Microsoft.Windows.CloudExperienceHost_*\TempState|*|RECURSE
+FileKey21=%SystemDrive%\Documents and Settings\LocalService\Application Data\PeerNetworking|*|RECURSE
+FileKey22=%WinDir%\$regcmp$|*|REMOVESELF
+FileKey23=%WinDir%\ehome|PRDMOWrapper.log
+FileKey24=%WinDir%\msdownld.tmp|*|REMOVESELF
+FileKey25=%WinDir%\ServiceProfiles\LocalService\AppData\Local\Microsoft\Windows|qwavecache.dat
+FileKey26=%WinDir%\ServiceProfiles\LocalService\AppData\Roaming\PeerNetworking|*|RECURSE
+FileKey27=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\PeerDist*|*.chk;*.jrs
+FileKey28=%WinDir%\System32|PRDMOWrapper.log;qwavecache.dat
+FileKey29=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Device Metadata\dmrccache\downloads|*.tmp
+FileKey30=%WinDir%\System32\config\systemprofile\AppData\Local\tw-*.tmp|empty.check|REMOVESELF
+FileKey31=%WinDir%\System32\sru|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache
 RegKey2=HKCU\Software\Classes\MIME\Database\Content Type
 RegKey3=HKCU\Software\Local AppWizard-Generated Applications
@@ -21170,19 +21235,19 @@ RegKey10=HKLM\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\Vol
 [Windows System Assessment Tool *]
 LangSecRef=3025
 DetectFile=%WinDir%\Performance\WinSAT
-FileKey1=%WinDir%\Performance\WinSAT|*.*|REMOVESELF
+FileKey1=%WinDir%\Performance\WinSAT|*|REMOVESELF
 
 [Windows Task Scheduler *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
-FileKey1=%WinDir%\System32\Tasks_Migrated|*.*|REMOVESELF
+FileKey1=%WinDir%\System32\Tasks_Migrated|*|REMOVESELF
 
 [Windows Taskbar *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 FileKey1=%AppData%\Microsoft\Windows\Recent|*.URL|RECURSE
-FileKey2=%AppData%\Microsoft\Windows\Recent\AutomaticDestinations|*.*|RECURSE
-FileKey3=%AppData%\Microsoft\Windows\Recent\CustomDestinations|*.*|RECURSE
+FileKey2=%AppData%\Microsoft\Windows\Recent\AutomaticDestinations|*|RECURSE
+FileKey3=%AppData%\Microsoft\Windows\Recent\CustomDestinations|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\FeatureUsage\AppBadgeUpdated
 RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\FeatureUsage\AppLaunch
 RegKey3=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\FeatureUsage\AppSwitched
@@ -21194,45 +21259,45 @@ ExcludeKey1=FILE|%AppData%\Microsoft\Windows\Recent\AutomaticDestinations\|f01b4
 [Windows Temporary Files *]
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\Windows
-FileKey1=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\Temp|*.*|RECURSE
-FileKey2=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\Temp|*.*|RECURSE
-FileKey3=%WinDir%\ServiceProfiles\*\AppData\Local\Temp|*.*|RECURSE
-FileKey4=%WinDir%\System32\config\systemprofile\AppData\Local\Temp|*.*|RECURSE
-FileKey5=%WinDir%\System32\config\systemprofile\Local Settings\Temp|*.*|RECURSE
-FileKey6=%WinDir%\SystemTemp|*.*|RECURSE
-FileKey7=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Temp|*.*|RECURSE
+FileKey1=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\Temp|*|RECURSE
+FileKey2=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\Temp|*|RECURSE
+FileKey3=%WinDir%\ServiceProfiles\*\AppData\Local\Temp|*|RECURSE
+FileKey4=%WinDir%\System32\config\systemprofile\AppData\Local\Temp|*|RECURSE
+FileKey5=%WinDir%\System32\config\systemprofile\Local Settings\Temp|*|RECURSE
+FileKey6=%WinDir%\SystemTemp|*|RECURSE
+FileKey7=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Temp|*|RECURSE
 
 [Windows Update *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 FileKey1=%LocalAppData%\Microsoft\Windows\Windows Anytime Upgrade|Upgrade.log
-FileKey2=%LocalAppData%\MigWiz|*.*|REMOVESELF
-FileKey3=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\AC\AppCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\AC\INet*|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\AC\Temp|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\LocalCache|*.*|RECURSE
-FileKey10=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\LocalState\EBWebview\*|LOG;LOG.old|RECURSE
-FileKey11=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\LocalState\EBWebview\Default\Service Worker\CacheStorage\*|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\MicrosoftWindows.Client.*_*\TempState|*.*|RECURSE
+FileKey2=%LocalAppData%\MigWiz|*|REMOVESELF
+FileKey3=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\AppCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\INet*|*|RECURSE
+FileKey5=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey6=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey7=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\Temp|*|RECURSE
+FileKey8=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\TokenBroker\Cache|*|RECURSE
+FileKey9=%LocalAppData%\Packages\MicrosoftWindows.Client.*\LocalCache|*|RECURSE
+FileKey10=%LocalAppData%\Packages\MicrosoftWindows.Client.*\LocalState\EBWebview\*|LOG;LOG.old|RECURSE
+FileKey11=%LocalAppData%\Packages\MicrosoftWindows.Client.*\LocalState\EBWebview\Default\Service Worker\CacheStorage\*|*|RECURSE
+FileKey12=%LocalAppData%\Packages\MicrosoftWindows.Client.*\TempState|*|RECURSE
 FileKey13=%ProgramFiles%\CUAssistant\Logs|*.etl
-FileKey14=%ProgramFiles%\Microsoft Update Health Tools\Logs|*.*
+FileKey14=%ProgramFiles%\Microsoft Update Health Tools\Logs|*
 FileKey15=%ProgramFiles%\rempl\Logs|*.etl
-FileKey16=%ProgramFiles%\WindowsInstallationAssistant\Logs|*.*
-FileKey17=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Cache|*.*|RECURSE
-FileKey18=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Logs|*.*|RECURSE
-FileKey19=%WinDir%\SoftwareDistribution\DataStore\Logs|*.*|RECURSE
+FileKey16=%ProgramFiles%\WindowsInstallationAssistant\Logs|*
+FileKey17=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Cache|*|RECURSE
+FileKey18=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Logs|*|RECURSE
+FileKey19=%WinDir%\SoftwareDistribution\DataStore\Logs|*|RECURSE
 
 [Windows Voice Recorder *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsSoundRecorder_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalState\Cache|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\TempState|*.*|RECURSE
+FileKey1=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\Temp|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\LocalState\Cache|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\TempState|*|RECURSE
 
 [Windows XP Add/Remove Programs *]
 LangSecRef=3025
@@ -21242,7 +21307,7 @@ RegKey1=HKLM\Software\Microsoft\Windows\CurrentVersion\App Management\ARPCache
 [Windows XP Driver Reinstall Backups *]
 LangSecRef=3025
 DetectFile=%WinDir%\System32\ReinstallBackups
-FileKey1=%WinDir%\System32\ReinstallBackups|*.*|RECURSE
+FileKey1=%WinDir%\System32\ReinstallBackups|*|RECURSE
 
 [Windows XP Help and Support Center *]
 LangSecRef=3025
@@ -21725,34 +21790,33 @@ Detect3=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 Detect4=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxGamingOverlay_8wekyb3d8bbwe
 Detect5=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxIdentityProvider_8wekyb3d8bbwe
 Detect6=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxLIVEGames_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\EAConnect_microsoft\Cache|*.*|RECURSE
+FileKey1=%LocalAppData%\EAConnect_microsoft\Cache|*|RECURSE
 FileKey2=%LocalAppData%\EAConnect_microsoft\QtWebEngine\Default|Network Persistent State;Visited Links
-FileKey3=%LocalAppData%\EAConnect_microsoft\QtWebEngine\Default\GPUCache|*.*
-FileKey4=%LocalAppData%\EAConnect_microsoft\QtWebEngine\Default\Platform Notifications|*.*
+FileKey3=%LocalAppData%\EAConnect_microsoft\QtWebEngine\Default\GPUCache|*
+FileKey4=%LocalAppData%\EAConnect_microsoft\QtWebEngine\Default\Platform Notifications|*
 FileKey5=%LocalAppData%\EAConnect_microsoft\QtWebEngine\Default\Session Storage|*.old;LOG
 FileKey6=%LocalAppData%\Packages\Microsoft.Gaming*\AC\TokenBroker\Cache|*|RECURSE
 FileKey7=%LocalAppData%\Packages\Microsoft.Gaming_*\AC\INet*|*|RECURSE
 FileKey8=%LocalAppData%\Packages\Microsoft.Gaming_*\AC\Temp|*|RECURSE
 FileKey9=%LocalAppData%\Packages\Microsoft.Gaming_*\LocalState|*log*|RECURSE
 FileKey10=%LocalAppData%\Packages\Microsoft.Gaming_*\TempState|*|RECURSE
-FileKey11=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\AppCache|*.*|RECURSE
-FileKey12=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\INet*|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\*Cache|*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\INet*|*|RECURSE
 FileKey13=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CLR_v4.0*|*.log
-FileKey14=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
-FileKey15=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*.*|RECURSE
-FileKey16=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey17=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-FileKey18=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\PRICache|*.*
-FileKey19=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Temp|*.*|RECURSE
-FileKey20=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey21=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalCache|*.*|RECURSE
-FileKey22=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState|*.log*|RECURSE
-FileKey23=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\*Cache|*.*|RECURSE
-FileKey24=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\DiagOutputDir|*.txt
-FileKey25=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\navigationHistory|*.*|RECURSE
-FileKey26=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\PlayReady|*.*|RECURSE
-FileKey27=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\SmartGlass|*.log
-FileKey28=%LocalAppData%\Packages\Microsoft.Xbox*_*\TempState|*.*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*|RECURSE
+FileKey15=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CLR_v4.0*\UsageLogs|*|RECURSE
+FileKey16=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey17=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey18=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\Temp|*|RECURSE
+FileKey19=%LocalAppData%\Packages\Microsoft.Xbox*_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey20=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalCache|*|RECURSE
+FileKey21=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState|*.log*|RECURSE
+FileKey22=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\*Cache|*|RECURSE
+FileKey23=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\DiagOutputDir|*.txt
+FileKey24=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\navigationHistory|*|RECURSE
+FileKey25=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\PlayReady|*|RECURSE
+FileKey26=%LocalAppData%\Packages\Microsoft.Xbox*_*\LocalState\SmartGlass|*.log
+FileKey27=%LocalAppData%\Packages\Microsoft.Xbox*_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxLIVEGames_8wekyb3d8bbwe\SearchHistory
 
 [XCOM *]

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
 ; Version: 230222
-; # of entries: 2,689
+; # of entries: 2,680
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -4081,17 +4081,6 @@ LangSecRef=3023
 Detect=HKCU\Software\KC Softwares\AVIToolbox
 FileKey1=%AppData%\KC Softwares\AVI Toolbox|*.log
 
-[Aviary Photo Editor *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\57AB5DD0.PhotoEditor_6hb943tstq5q8
-FileKey1=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
-FileKey4=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Temp|*.*
-FileKey6=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\LocalState|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\TempState|*.*|RECURSE
-
 [AVIcodec *]
 LangSecRef=3023
 Detect=HKLM\Software\AVIcodec
@@ -4643,18 +4632,10 @@ Section=Games
 DetectFile=%SystemDrive%\BOSS
 FileKey1=%SystemDrive%\BOSS\*|BOSSlog.*
 
-[Box *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\134D4F5B.Box_2qk4zy5s3qmee
+[Box For Office *]
+LangSecRef=3021
 DetectFile=%LocalAppData%\Box\BoxforOffice*
 FileKey1=%LocalAppData%\Box\BoxforOfficeLogs|*.*
-FileKey2=%LocalAppData%\Packages\134D4F5B.Box_*\AC\*Cache|*|RECURSE
-FileKey3=%LocalAppData%\Packages\134D4F5B.Box_*\AC\INet*|*|RECURSE
-FileKey4=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
-FileKey5=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*|RECURSE
-FileKey6=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Microsoft\CryptnetUrlCache\*|*
-FileKey7=%LocalAppData%\Packages\134D4F5B.Box_*\AC\Temp|*
-FileKey8=%LocalAppData%\Packages\134D4F5B.Box_*\LocalState|*|RECURSE
 
 [Breevy *]
 LangSecRef=3021
@@ -5146,13 +5127,6 @@ Section=Games
 DetectFile=%LocalLowAppData%\Behold Studios\Chroma Squad
 FileKey1=%LocalLowAppData%\Behold Studios\Chroma Squad|*txt
 FileKey2=%LocalLowAppData%\Behold Studios\Chroma Squad\Crashes|*
-
-[Chrome Sandbox *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\chrome.sandbox.mfcdmec0b66bbd70f841470aa70f965aa4fb831f77b7f
-FileKey1=%LocalAppData%\Packages\chrome.sandbox.*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\chrome.sandbox.*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\chrome.sandbox.*\AC\Temp|*.*|RECURSE
 
 [Chromium Embedded Framework *]
 LangSecRef=3022
@@ -5741,7 +5715,7 @@ FileKey2=%CommonAppData%\Corsair\CUE\Service logs|Service_Trace*.log
 FileKey3=%LocalAppData%\Corsair\CUE\logs|*.log
 
 [Cortana *]
-LangSecRef=3031
+LangSecRef=3025
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.549981C3F5F10_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Cortana_8wekyb3d8bbwe
 Detect3=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.CortanaFollowMe_8wekyb3d8bbwe
@@ -8171,15 +8145,6 @@ LangSecRef=3022
 Detect=HKLM\Software\FileZilla Client
 FileKey1=%ProgramFiles%\FileZilla FTP Client|*.tmp
 
-[FilmOn TV *]
-LangSecRef=3031
-DetectFile=%LocalAppData%\Packages\FilmOnLiveTVFree.*_zx03kxexxb716
-FileKey1=%LocalAppData%\Packages\FilmOnLiveTVFree.*_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\FilmOnLiveTVFree.*_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\FilmOnLiveTVFree.*_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey4=%LocalAppData%\Packages\FilmOnLiveTVFree.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
-RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\FilmOnLiveTVFree.FilmOnLiveTVFree_zx03kxexxb716\SearchHistory
-
 [FINAM Forex Terminal *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\FINAM Forex Terminal
@@ -10205,7 +10170,7 @@ FileKey24=%WinDir%\SysWOW64|Gms.log
 FileKey25=%WinDir%\SysWOW64\config\systemprofile\Intel\Logs|*.*|REMOVESELF
 
 [Intel Graphics Command Center *]
-LangSecRef=3031
+LangSecRef=3024
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\AppUp.IntelGraphicsExperience_8j3eq9eme6ctt
 FileKey1=%LocalAppData%\Intel\GCC|gcc*_log_*.txt	
 FileKey2=%LocalAppData%\Packages\AppUp.IntelGraphicsExperience_*\AC\BackgroundTransferApi|*.*|RECURSE
@@ -12162,6 +12127,18 @@ FileKey3=%LocalAppData%\Packages\Microsoft.Messaging_*\LocalCache|*.etl;*.xml
 FileKey4=%LocalAppData%\Packages\Microsoft.Messaging_*\LocalState\Cache|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.Messaging_*\TempState|*.*|RECURSE
 
+[Microsoft Mixed Reality Portal *]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MixedReality.Portal_8wekyb3d8bbwe
+FileKey1=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\AppCache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\Temp|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\LocalCache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\LocalState\Cache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\TempState|*|RECURSE
+
 [Microsoft Mouse and Keyboard Center *]
 LangSecRef=3021
 DetectFile1=%ProgramFiles%\Microsoft Device Center
@@ -12182,7 +12159,7 @@ FileKey6=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\AC\Temp|*.*
 FileKey7=%LocalAppData%\Packages\Microsoft.NetworkSpeedTest_*\TempState|*.*|RECURSE
 
 [Microsoft News *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingNews_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\*Cache|*
 FileKey2=%LocalAppData%\Packages\Microsoft.BingNews_*\AC\INet*|*|RECURSE
@@ -12384,7 +12361,7 @@ DetectFile=%AppData%\Microsoft\Picture It!*
 FileKey1=%AppData%\Microsoft\Picture It!*|piorg.db
 
 [Microsoft PlayReady *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Media.PlayReadyClient_8wekyb3d8bbwe
 FileKey1=%CommonAppData%\Microsoft\PlayReady|*.hds
 FileKey2=%CommonAppData%\Microsoft\PlayReady\Cache|*.*
@@ -12406,13 +12383,6 @@ LangSecRef=3021
 Detect=HKCU\Software\Microsoft\Office\14.0\MS Project
 RegKey1=HKCU\Software\Microsoft\Office\14.0\MS Project\Recent File List
 RegKey2=HKCU\Software\Microsoft\Office\14.0\MS Project\Recent Templates
-
-[Microsoft Reader *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Reader_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.Reader_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Reader_*\AC\Temp|*.*
-FileKey3=%LocalAppData%\Packages\Microsoft.Reader_*\TempState|*.*|RECURSE
 
 [Microsoft Robocopy GUI *]
 LangSecRef=3025
@@ -12445,7 +12415,7 @@ Detect=HKCU\Software\Microsoft\Microsoft Standalone System Sweeper Tool
 FileKey1=%CommonAppData%\Microsoft\Microsoft Standalone System Sweeper Tool\Support|*.log
 
 [Microsoft Store *]
-LangSecRef=3031
+LangSecRef=3025
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsStore_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\winstore_cw5n1h2txyewy
 FileKey1=%LocalAppData%\Packages\Microsoft.StorePurchaseApp_*\AC\AppCache\*|*.*|REMOVESELF
@@ -12481,6 +12451,19 @@ DetectFile=%LocalAppData%\SaRALogs
 FileKey1=%LocalAppData%\SaRALogs|*.*|RECURSE
 FileKey2=%LocalAppData%\SaraResults|SaraResult_*.xml
 
+[Microsoft Sway *]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Office.Sway_8wekyb3d8bbwe
+FileKey1=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\AppCache|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\INet*|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Microsoft\CryptnetUrlCache\*|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Microsoft\Internet Explorer\DOMStore\*|*|REMOVESELF
+FileKey5=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Temp|*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\TokenBroker\Cache|*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalCache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalState\Cache|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.Office.Sway_*\TempState|*|RECURSE
+
 [Microsoft Teams *]
 LangSecRef=3021
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\MicrosoftTeams_8wekyb3d8bbwe
@@ -12506,14 +12489,6 @@ FileKey18=%LocalAppData%\Packages\MicrosoftTeams_*\AC\INet*|*.*|RECURSE
 FileKey19=%LocalAppData%\Packages\MicrosoftTeams_*\AC\Temp|*.*|RECURSE
 FileKey20=%LocalAppData%\Packages\MicrosoftTeams_*\LocalCache|*.*|RECURSE
 FileKey21=%LocalAppData%\Packages\MicrosoftTeams_*\TempState|*.*|RECURSE
-
-[Microsoft Text Input *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\InputApp_cw5n1h2txyewy
-FileKey1=%LocalAppData%\Packages\InputApp_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\InputApp_*\AC\Temp|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\InputApp_*\LocalCache|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\InputApp_*\TempState|*.*|RECURSE
 
 [Microsoft Tips *]
 LangSecRef=3031
@@ -13189,18 +13164,6 @@ FileKey3=%LocalAppData%\Mixed In Key\Mixed In Key\*\QueryLogs|*.*
 FileKey4=%LocalAppData%\Mixed In Key\Mixed In Key\*\Temp|*.*
 FileKey5=%LocalAppData%\Mixed In Key\Mixed In Key\*\Updates|update.exe
 
-[Mixed Reality Portal *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MixedReality.Portal_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\Temp|*.*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\LocalCache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\LocalState\Cache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.MixedReality.Portal_*\TempState|*.*|RECURSE
-
 [MixMeister *]
 LangSecRef=3023
 DetectFile=%ProgramFiles%\MixMeister*
@@ -13516,16 +13479,6 @@ FileKey2=%ProgramFiles%\MSI Afterburner|HardwareMonitoring.hml
 LangSecRef=3024
 DetectFile=%ProgramFiles%\MSI\MSI Remind Manager
 FileKey1=%ProgramFiles%\MSI\MSI Remind Manager|Log_reminder.txt
-
-[MSN Food & Drink *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingFoodAndDrink_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.BingFoodAndDrink_*\LocalState\Cache|*.*|RECURSE
-
-[MSN Health & Fitness *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingHealthAndFitness_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.BingHealthAndFitness_*\LocalState\Cache|*.*|RECURSE
 
 [MSN Money *]
 LangSecRef=3031
@@ -17561,7 +17514,7 @@ FileKey1=%AppData%\PictureMover\Log|*.*
 [Snip & Sketch *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ScreenSketch_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\MicrosoftWindows.Client.CBS_cw5n1h2txyewy\TempState\ScreenClip|*.*
+FileKey1=%LocalAppData%\Packages\MicrosoftWindows.Client.*\TempState\ScreenClip|*
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ScreenSketch_8wekyb3d8bbwe\PersistedPickerData\Microsoft.ScreenSketch_8wekyb3d8bbwe!App\AppSnipAndSketchFileSaveSettings|LastLocation
 RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.ScreenSketch_8wekyb3d8bbwe\PersistedPickerData\Microsoft.ScreenSketch_8wekyb3d8bbwe!App\DefaultOpenFileSingle|LastLocation
 
@@ -18313,7 +18266,7 @@ FileKey1=%LocalAppData%\SterJo NetStalker|dscnt.exe;History.sjh
 FileKey2=%LocalAppData%\SterJo NetStalker\Logs|*.*
 
 [Sticky Notes *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MicrosoftStickyNotes_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\Microsoft.MicrosoftStickyNotes_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.MicrosoftStickyNotes_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
@@ -18321,16 +18274,6 @@ FileKey3=%LocalAppData%\Packages\Microsoft.MicrosoftStickyNotes_*\AC\Temp|*.*|RE
 FileKey4=%LocalAppData%\Packages\Microsoft.MicrosoftStickyNotes_*\AC\TokenBroker\Cache|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.MicrosoftStickyNotes_*\LocalCache|*.*|RECURSE
 FileKey6=%LocalAppData%\Packages\Microsoft.MicrosoftStickyNotes_*\TempState|*.*|RECURSE
-
-[Stocks and Futures *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\24877CutthroatSoftware.StocksandFutures_xgnzh3xnefnqe
-FileKey1=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\AC\INet*|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\AC\Microsoft\CryptnetUrlCache\*|*.*
-FileKey3=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\AC\Temp|*.*
-FileKey4=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\AppData\Indexed DB|*.log
-FileKey5=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\LocalState|*.tmp|RECURSE
-FileKey6=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\TempState|*.*|RECURSE
 
 [STOIK Smart Resizer *]
 LangSecRef=3023
@@ -18474,19 +18417,6 @@ FileKey3=%AppData%\SuuntoLink\Feedback|*.dmp;*.log
 FileKey4=%AppData%\SuuntoLink\Logs|*.*
 FileKey5=%AppData%\SuuntoLink\webrtc_event_logs|*.*
 FileKey6=%LocalAppData%\SuuntoLink|*.log|RECURSE
-
-[Sway *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Office.Sway_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\AppCache|*.*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\INet*|*.*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Microsoft\Internet Explorer\DOMStore\*|*.*|REMOVESELF
-FileKey5=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\Temp|*.*|RECURSE
-FileKey6=%LocalAppData%\Packages\Microsoft.Office.Sway_*\AC\TokenBroker\Cache|*.*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalCache|*.*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Office.Sway_*\LocalState\Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Packages\Microsoft.Office.Sway_*\TempState|*.*|RECURSE
 
 [Swiff Player *]
 LangSecRef=3023
@@ -19714,17 +19644,6 @@ Detect2=HKLM\Software\UnlockrootPro
 FileKey1=%ProgramFiles%\Unlockroot*|*.txt
 FileKey2=%ProgramFiles%\Unlockroot*\tools|*.zip
 
-[Unofficial NewsReader for CNN *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\65465Fetisenko.NewsReaderforCNN_806cg6g6fmyng
-FileKey1=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\AppCache\*|*.*|REMOVESELF
-FileKey2=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\INet*\*|*.*|REMOVESELF
-FileKey3=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
-FileKey4=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\Microsoft\Internet Explorer\DOMStore\*|*.*|REMOVESELF
-FileKey5=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\Temp|*.*
-FileKey6=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\TokenBroker\Cache|*.*|REMOVESELF
-FileKey7=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\TempState|*.*|RECURSE
-
 [Unreal Tournament: Game of the Year *]
 Section=Games
 DetectFile=%ProgramFiles%\GOG.com\Unreal Tournament GOTY
@@ -20507,22 +20426,13 @@ LangSecRef=3024
 Detect=HKCU\Software\Yamicsoft\Windows 7 Manager
 FileKey1=%ProgramFiles%\Yamicsoft\Windows 7 Manager\DiskAnalyzerXML|*.*
 
-[Windows Alarms & Clock *]
-LangSecRef=3031
-Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsAlarms_8wekyb3d8bbwe
-FileKey1=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\AC\INet*|*|RECURSE
-FileKey2=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\AC\Temp|*|RECURSE
-FileKey3=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\LocalCache|*|RECURSE
-FileKey4=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\LocalState|*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\TempState|*|RECURSE
-
 [Windows AutoPlay Devices *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers\KnownDevices
 
 [Windows Calculator *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsCalculator_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\AC\INet*|*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\AC\Temp|*|RECURSE
@@ -20531,7 +20441,7 @@ FileKey4=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\LocalState\Cache|
 FileKey5=%LocalAppData%\Packages\Microsoft.WindowsCalculator_*\TempState|*|RECURSE
 
 [Windows Camera *]
-LangSecRef=3031
+LangSecRef=3025
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Camera_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsCamera_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\Microsoft.*Camera_*\AC\*Cache|*|RECURSE
@@ -20552,6 +20462,15 @@ Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\CD Burning
 FileKey1=%LocalAppData%\Microsoft\CD Burning|*|RECURSE
 FileKey2=%LocalAppData%\Microsoft\Windows\Burn|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\CD Burning\StagingInfo
+
+[Windows Clock *]
+LangSecRef=3025
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsAlarms_8wekyb3d8bbwe
+FileKey1=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\AC\INet*|*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\AC\Temp|*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\LocalCache|*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\LocalState|*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.WindowsAlarms_*\TempState|*|RECURSE
 
 [Windows Cryptographic Services *]
 LangSecRef=3025
@@ -20858,7 +20777,7 @@ FileKey1=%LocalAppData%\Microsoft\Windows Mail|*.log;*.jrs;*.chk|RECURSE
 FileKey2=%LocalAppData%\Microsoft\Windows Mail\Backup\Old|*.*|REMOVESELF
 
 [Windows Mail and Calendar *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.windowscommunicationsapps_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Comms\Unistore\data|AggregateCache.uca
 FileKey2=%LocalAppData%\Comms\UnistoreDB|*.jcp;*.jrs;*.jtx
@@ -20876,7 +20795,7 @@ FileKey13=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\TempStat
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\microsoft.windowscommunicationsapps_8wekyb3d8bbwe\SearchHistory
 
 [Windows Maps *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsMaps_8wekyb3d8bbwe
 FileKey1=%CommonAppData%\Microsoft\MapData|events.log
 FileKey2=%CommonAppData%\Microsoft\MapData\mapscache|*.*|RECURSE
@@ -21040,7 +20959,7 @@ DetectFile=%CommonAppData%\Microsoft\Windows\RetailDemo
 FileKey1=%CommonAppData%\Microsoft\Windows\RetailDemo|*.*|REMOVESELF
 
 [Windows Scan *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsScan_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.WindowsScan_*\AC\Temp|*.*|RECURSE
@@ -21155,11 +21074,15 @@ Detect=HKCU\Software\Microsoft\Windows
 FileKey1=%LocalAppData%|IconCache.db;IconCache.db.backup
 FileKey2=%LocalAppData%\Microsoft\Windows\Explorer|iconcache_*.db
 FileKey3=%LocalAppData%\Microsoft\Windows\Explorer\IconCacheToDelete|*.tmp
-FileKey4=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\INet*|*|RECURSE
-FileKey5=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Microsoft\Windows\*|*|REMOVESELF
-FileKey6=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Temp|*|RECURSE
-FileKey7=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalCache|*|RECURSE
-FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\TempState|*|RECURSE
+FileKey4=%LocalAppData%\Packages\InputApp_*\AC\INet*|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\InputApp_*\AC\Temp|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\InputApp_*\LocalCache|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\InputApp_*\TempState|*.*|RECURSE
+FileKey8=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\INet*|*|RECURSE
+FileKey9=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Microsoft\Windows\*|*|REMOVESELF
+FileKey10=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\AC\Temp|*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\LocalCache|*|RECURSE
+FileKey12=%LocalAppData%\Packages\Microsoft.Windows.ShellExperienceHost_*\TempState|*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer|ScreenshotIndex
 RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts
 RegKey3=HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\SharingMFU
@@ -21291,7 +21214,7 @@ FileKey18=%WinDir%\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Window
 FileKey19=%WinDir%\SoftwareDistribution\DataStore\Logs|*|RECURSE
 
 [Windows Voice Recorder *]
-LangSecRef=3031
+LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsSoundRecorder_8wekyb3d8bbwe
 FileKey1=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\INet*|*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.WindowsSoundRecorder_*\AC\Temp|*|RECURSE
@@ -21783,7 +21706,7 @@ Detect=HKCU\Software\Xara\WebDesigner
 FileKey1=%LocalAppData%\Xara\WebDesigner\*\Backups|*.*|RECURSE
 
 [Xbox *]
-LangSecRef=3031
+Section=Games
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.GamingApp_8wekyb3d8bbwe
 Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxApp_8wekyb3d8bbwe
 Detect3=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxGameOverlay_8wekyb3d8bbwe

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
-; Version: 230222
-; # of entries: 2,680
+; Version: 230224
+; # of entries: 2,678
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -813,6 +813,22 @@ FileKey3=%LocalAppData%\Programs\Opera*|*.log|REMOVESELF
 FileKey4=%ProgramFiles%\Opera*|*.log|RECURSE
 FileKey5=%WinDir%\System32\config\systemprofile\AppData\Local\Opera Software\Opera*\*|LOG;LOG.old|RECURSE
 
+[Opera Presto *]
+LangSecRef=3027
+DetectFile=%LocalAppData%\Opera\Opera*
+FileKey1=%LocalAppData%\Opera\Opera*|*.log
+FileKey2=%LocalAppData%\Opera\Opera*\application_cache|*|REMOVESELF
+FileKey3=%LocalAppData%\Opera\Opera*\icons|*|REMOVESELF
+FileKey4=%LocalAppData%\Opera\Opera*\logs|*|REMOVESELF
+FileKey5=%LocalAppData%\Opera\Opera*\temporary_downloads|*|REMOVESELF
+FileKey6=%LocalAppData%\Opera\Opera*\thumbnails|*|REMOVESELF
+FileKey7=%LocalAppData%\Opera\Opera*\vps|*|REMOVESELF
+FileKey8=%UserProfile%\.opera|*|REMOVESELF
+FileKey9=%UserProfile%\Downloads\.opera|*|REMOVESELF
+FileKey10=%UserProfile%\Downloads\Opera Autoupdate|*.log
+FileKey11=%UserProfile%\Opera Autoupdate|*.log
+RegKey1=HKCU\Software\Opera Software|Last CommandLine v2
+
 [Opera Sync Data *]
 LangSecRef=3027
 DetectFile=%AppData%\Opera Software\Opera*
@@ -1205,40 +1221,42 @@ Detect=HKCU\Software\Microsoft\Internet Explorer
 FileKey1=%AppData%\Microsoft\Internet Explorer\UserData|*|RECURSE
 FileKey2=%LocalAppData%\Microsoft\Internet Explorer|*.log;*.txt|RECURSE
 FileKey3=%LocalAppData%\Microsoft\Internet Explorer\CacheStorage|*|RECURSE
-FileKey4=%LocalAppData%\Microsoft\Windows\*Cache*|*|RECURSE
-FileKey5=%LocalAppData%\Microsoft\Windows\INetCookies|*|RECURSE
-FileKey6=%LocalAppData%\Packages\windows_ie_*\AC\*Cache|*|RECURSE
-FileKey7=%LocalAppData%\Packages\windows_ie_*\AC\IECompat*Cache|*|RECURSE
-FileKey8=%LocalAppData%\Packages\windows_ie_*\AC\IEDownloadHistory|*|RECURSE
-FileKey9=%LocalAppData%\Packages\windows_ie_*\AC\INet*|*|RECURSE
-FileKey10=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
-FileKey11=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\CryptnetUrlCache\*|*
-FileKey12=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
-FileKey13=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\Internet Explorer\Emie*List|*|RECURSE
-FileKey14=%LocalAppData%\Packages\windows_ie_*\AC\Temp|*|RECURSE
-FileKey15=%LocalAppData%\Packages\windows_ie_*\LocalState\Cache|*|RECURSE
-FileKey16=%LocalAppData%\Packages\windows_ie_*\LocalState\navigationHistory|*|RECURSE
-FileKey17=%LocalAppData%\Packages\windows_ie_*\TempState|*|RECURSE
-FileKey18=%SystemDrive%\Documents and Settings\LocalService*\Cookies|*|RECURSE
-FileKey19=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\History|*|RECURSE
-FileKey20=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\Temporary Internet Files|*|RECURSE
-FileKey21=%SystemDrive%\Documents and Settings\NetworkService*\Cookies|*|RECURSE
-FileKey22=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\History|*|RECURSE
-FileKey23=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\Temporary Internet Files|*|RECURSE
-FileKey24=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\History|*|RECURSE
-FileKey25=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
-FileKey26=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
-FileKey27=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\History|*|RECURSE
-FileKey28=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
-FileKey29=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
-FileKey30=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache|*|RECURSE
-FileKey31=%WinDir%\System32\config\systemprofile\Cookies|*|RECURSE
-FileKey32=%WinDir%\System32\config\systemprofile\History|*|RECURSE
-FileKey33=%WinDir%\System32\config\systemprofile\Local Settings\Temporary Internet Files|*|RECURSE
-FileKey34=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\History|*|RECURSE
-FileKey35=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
-FileKey36=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
-FileKey37=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache|*|RECURSE
+FileKey4=%LocalAppData%\Microsoft\Windows\AppCache|*|RECURSE
+FileKey5=%LocalAppData%\Microsoft\Windows\INetCache|*|RECURSE
+FileKey6=%LocalAppData%\Microsoft\Windows\INetCookies|*|RECURSE
+FileKey7=%LocalAppData%\Microsoft\Windows\WebCache|*|RECURSE
+FileKey8=%LocalAppData%\Packages\windows_ie_*\AC\*Cache|*|RECURSE
+FileKey9=%LocalAppData%\Packages\windows_ie_*\AC\IECompat*Cache|*|RECURSE
+FileKey10=%LocalAppData%\Packages\windows_ie_*\AC\IEDownloadHistory|*|RECURSE
+FileKey11=%LocalAppData%\Packages\windows_ie_*\AC\INet*|*|RECURSE
+FileKey12=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
+FileKey13=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\CryptnetUrlCache\*|*
+FileKey14=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\Internet Explorer\DOMStore|*|RECURSE
+FileKey15=%LocalAppData%\Packages\windows_ie_*\AC\Microsoft\Internet Explorer\Emie*List|*|RECURSE
+FileKey16=%LocalAppData%\Packages\windows_ie_*\AC\Temp|*|RECURSE
+FileKey17=%LocalAppData%\Packages\windows_ie_*\LocalState\Cache|*|RECURSE
+FileKey18=%LocalAppData%\Packages\windows_ie_*\LocalState\navigationHistory|*|RECURSE
+FileKey19=%LocalAppData%\Packages\windows_ie_*\TempState|*|RECURSE
+FileKey20=%SystemDrive%\Documents and Settings\LocalService*\Cookies|*|RECURSE
+FileKey21=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\History|*|RECURSE
+FileKey22=%SystemDrive%\Documents and Settings\LocalService*\Local Settings\Temporary Internet Files|*|RECURSE
+FileKey23=%SystemDrive%\Documents and Settings\NetworkService*\Cookies|*|RECURSE
+FileKey24=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\History|*|RECURSE
+FileKey25=%SystemDrive%\Documents and Settings\NetworkService*\Local Settings\Temporary Internet Files|*|RECURSE
+FileKey26=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\History|*|RECURSE
+FileKey27=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
+FileKey28=%WinDir%\ServiceProfiles\*\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
+FileKey29=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\History|*|RECURSE
+FileKey30=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
+FileKey31=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
+FileKey32=%WinDir%\System32\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache|*|RECURSE
+FileKey33=%WinDir%\System32\config\systemprofile\Cookies|*|RECURSE
+FileKey34=%WinDir%\System32\config\systemprofile\History|*|RECURSE
+FileKey35=%WinDir%\System32\config\systemprofile\Local Settings\Temporary Internet Files|*|RECURSE
+FileKey36=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\History|*|RECURSE
+FileKey37=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\INetCache|*|RECURSE
+FileKey38=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\INetCookies|*|RECURSE
+FileKey39=%WinDir%\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\WebCache|*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\windows_ie_ac_001\Internet Explorer\DOMStorage
 RegKey2=HKCU\Software\Microsoft\Internet Explorer\DOMStorage
 RegKey3=HKCU\Software\Microsoft\Internet Explorer\LowRegistry\DOMStorage
@@ -1632,12 +1650,7 @@ LangSecRef=3024
 DetectFile=%LocalAppData%\Abelssoft\AntiBrowserSpy
 FileKey1=%LocalAppData%\Abelssoft\AntiBrowserSpy|*.log
 
-[Abelssoft CCFinder *]
-LangSecRef=3024
-DetectFile=%LocalAppData%\Abelssoft\CCfinder
-FileKey1=%LocalAppData%\FlickrNet|responseCache.dat
-
-[Abelssoft GoogleClean *]
+[Abelssoft GClean *]
 LangSecRef=3024
 DetectFile1=%LocalAppData%\Abelssoft\GClean
 DetectFile2=%LocalAppData%\Abelssoft\GoogleClean
@@ -3037,19 +3050,6 @@ FileKey2=%LocalAppData%\AnyMusic\QtWebEngine\Default|*-journal;*.old;LOG;Network
 FileKey3=%LocalAppData%\AnyMusic\QtWebEngine\Default\blob_storage|*.*|RECURSE
 FileKey4=%LocalAppData%\AnyMusic\QtWebEngine\Default\GPUCache|*.*
 
-[AOL *]
-LangSecRef=3022
-Detect=HKCU\Software\America Online
-FileKey1=%AppData%\AOL\C_AOL*|*.tmp|RECURSE
-FileKey2=%CommonAppData%\AOL Downloads|*.*|RECURSE
-FileKey3=%CommonAppData%\AOL\C_AOL*|*.tmp|RECURSE
-FileKey4=%CommonAppData%\AOL\C_AOL*\bart|*.*|RECURSE
-FileKey5=%CommonAppData%\AOL\C_AOL*\spool|*.*|RECURSE
-FileKey6=%LocalAppData%\AOL\C_AOL*|*-journal;*.tmp|RECURSE
-FileKey7=%LocalAppData%\AOL\C_AOL*\BrowserCache|*.*|RECURSE
-FileKey8=%LocalAppData%\AOL\C_AOL*\ToolbarCache|data_*;f_*;index;VisitedLinks
-FileKey9=%LocalAppData%\AOL\C_AOL*\ToolbarCache\AppCache\Cache|*.*
-
 [AOMEI Backupper *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\AOMEI Backupper
@@ -3985,11 +3985,6 @@ FileKey13=%LocalAppData%\Background_Fault|debug.log
 FileKey14=%ProgramFiles%\Alwil Software\Avast*\Setup|*.log
 FileKey15=%ProgramFiles%\AVAST Software\Avast|*.tmp
 RegKey1=HKCU\Software\AVAST Software\Avast Browser Cleanup
-
-[Avast EasyPass *]
-LangSecRef=3022
-DetectFile=%Documents%\My Avast EasyPass Data
-FileKey1=%Documents%\My Avast EasyPass Data\Default Profile|mru.rfo;cache.rfo|RECURSE
 
 [Avast TuneUp *]
 LangSecRef=3024

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -4420,13 +4420,7 @@ FileKey1=%Documents%\my games\BioShock Infinite\Benchmarks|*.*
 
 [BIT.TRIP *]
 Section=Games
-Detect1=HKCU\Software\Valve\Steam\Apps\63700
-Detect2=HKCU\Software\Valve\Steam\Apps\63710
-Detect3=HKCU\Software\Valve\Steam\Apps\205060
-Detect4=HKCU\Software\Valve\Steam\Apps\205070
-Detect5=HKCU\Software\Valve\Steam\Apps\205080
-Detect6=HKCU\Software\Valve\Steam\Apps\205090
-Detect7=HKCU\Software\Valve\Steam\Apps\218060
+DetectFile=%LocalAppDAta%\BIT.TRIP *
 FileKey1=%LocalAppData%\BIT.TRIP *|*.txt
 
 [Bitcoin *]
@@ -5141,10 +5135,7 @@ FileKey1=%ProgramFiles%\HP Games\Chuzzle Deluxe|DEBUG.TXT
 
 [Cinema Tycoon *]
 Section=Games
-Detect1=HKCU\Software\TikGames\Cinema Tycoon Gold
-Detect2=HKLM\Software\Big Fish Games\Persistence\GameDB\Cinema Tycoon Gold
-Detect3=HKLM\Software\Big Fish Games\Persistence\Install\F2676T1L1
-Detect4=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Cinema Tycoon 2  Movie Mania1.0
+DetectFile=%ProgramFiles%\Cinema Tycoon*
 FileKey1=%ProgramFiles%\Cinema Tycoon*|flashplayer7_winax.exe;*.txt
 
 [Cisco Connect *]
@@ -5821,11 +5812,11 @@ RegKey1=HKCU\Software\CrypTool2.0|recentFileList
 
 [Crysis *]
 Section=Games
-DetectFile1=%ProgramFiles%\Origin Games\Crysis*
+DetectFile1=%ProgramFiles%\EA Games\Crysis*
 DetectFile2=%ProgramFiles%\Steam\Steamapps\common\Crysis*
 FileKey1=%Documents%\My Games\Crysis*\Shaders\Cache|*.*|RECURSE
-FileKey2=%ProgramFiles%\Origin Games\Crysis *|*.log
-FileKey3=%ProgramFiles%\Origin Games\Crysis *\LogBackups|*.*
+FileKey2=%ProgramFiles%\EA Games\Crysis *|*.log
+FileKey3=%ProgramFiles%\EA Games\Crysis *\LogBackups|*.*
 FileKey4=%ProgramFiles%\Steam\Steamapps\common\Crysis *|*.log
 FileKey5=%ProgramFiles%\Steam\Steamapps\common\Crysis *\LogBackups|*.*
 FileKey6=%UserProfile%\Saved Games\Crysis*\Shaders\Cache|*.*|RECURSE
@@ -7351,39 +7342,12 @@ Section=Games
 DetectFile=%Documents%\Battlefield 2042
 FileKey1=%Documents%\Battlefield 2042\Screenshots|*|RECURSE
 
-[EA Origin *]
-Section=Games
-Detect=HKLM\Software\Classes\Origin
-DetectFile=%AppData%\Origin
-FileKey1=%AppData%\Origin\*Cache|*.*
-FileKey2=%AppData%\Origin\Logs|*.*
-FileKey3=%AppData%\Origin\Telemetry|*.*
-FileKey4=%CommonAppData%\Origin\*Cache|*.*|RECURSE
-FileKey5=%CommonAppData%\Origin\*Logs|*.*
-FileKey6=%CommonAppData%\Origin\SelfUpdate\Staged|*.log
-FileKey7=%CommonAppData%\Origin\Telemetry|*.*
-FileKey8=%LocalAppData%\Origin\*Cache|*.*|RECURSE
-FileKey9=%LocalAppData%\Origin\Logs|*.txt
-FileKey10=%LocalAppData%\Origin\Origin\cache|*.*|RECURSE
-FileKey11=%LocalAppData%\Origin\Origin\QtWebEngine\Default\Application Cache|*.*|RECURSE
-FileKey12=%LocalAppData%\Origin\Origin\QtWebEngine\Default\Service Worker\*Cache*|*.*|RECURSE
-FileKey13=%LocalAppData%\Origin\ThinSetup|*_Log.txt
-FileKey14=%ProgramFiles%\Origin|*.log
-FileKey15=%SystemDrive%|shared.log
-
-[EA Origin Installers *]
-Section=Games
-Detect=HKLM\Software\Classes\Origin
-FileKey1=%LocalAppData%\Origin\ThinSetup|*.*|REMOVESELF
-FileKey2=%ProgramFiles%\Origin|vc*redist*.exe
-FileKey3=%ProgramFiles%\Origin Games|*.cab;dotnetfx3setup;dotNetFx*.exe;dsetup*.dll;DXSETUP.EXE;dxwebsetup.exe;eula.*.txt;GamesExplorerIntegrationTool.exe;gfwlivesetup.exe;globdata.ini;install.exe;install.ini;install.res.*.dll;oalinst.exe;vc_red.exe;vc_red.msi;vcredist.bmp;vc*redist*x*.exe;xnafx*_redist.msi|RECURSE
-
 [EA Sports FIFA *]
 Section=Games
-DetectFile=%ProgramFiles%\Origin Games\FIFA*
-FileKey1=%ProgramFiles%\Origin Games\FIFA*\__Installer|InstallLog.txt
-FileKey2=%ProgramFiles%\Origin Games\FIFA*\__Installer\dotnet|*.*|REMOVESELF
-FileKey3=%ProgramFiles%\Origin Games\FIFA*\__Installer\vc|*.*|REMOVESELF
+DetectFile=%ProgramFiles%\EA Games\FIFA*
+FileKey1=%ProgramFiles%\EA Games\FIFA*\__Installer|InstallLog.txt
+FileKey2=%ProgramFiles%\EA Games\FIFA*\__Installer\dotnet|*.*|REMOVESELF
+FileKey3=%ProgramFiles%\EA Games\FIFA*\__Installer\vc|*.*|REMOVESELF
 
 [Earth 2160 *]
 Section=Games
@@ -13088,7 +13052,7 @@ FileKey1=%CommonAppData%\Techsoft\MirrorFolder\Log|*.*
 
 [Mirrors Edge Catalyst Backup *]
 Section=Games
-Detect=HKLM\Software\Origin Games\1026480
+Detect=HKLM\Software\EA Games\1026480
 FileKey1=%Documents%\Mirrors Edge Catalyst\settings|PROF_SAVE_backup*
 
 [MiTeC DFM Editor *]
@@ -18065,9 +18029,9 @@ FileKey2=%LocalAppData%\SWTOR\CrashDump\swtor|*.*
 FileKey3=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\betatest\retailclient\Temp|*.log
 FileKey4=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\logs|*.log
 FileKey5=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\swtor\retailclient\swtor\logs|*.log
-FileKey6=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
-FileKey7=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\logs|*.*
-FileKey8=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
+FileKey6=%ProgramFiles%\EA Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
+FileKey7=%ProgramFiles%\EA Games\Star Wars - The Old Republic\logs|*.*
+FileKey8=%ProgramFiles%\EA Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
 
 [StarCraft I/II *]
 Section=Games

--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -1,5 +1,5 @@
 ; Version: 230224
-; # of entries: 2,678
+; # of entries: 2,676
 ;
 ; Winapp2.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/License.md
 ; If you plan on modifying, distributing, and/or hosting Winapp2.ini for your own program or website, please ask first.
@@ -4420,7 +4420,7 @@ FileKey1=%Documents%\my games\BioShock Infinite\Benchmarks|*.*
 
 [BIT.TRIP *]
 Section=Games
-DetectFile=%LocalAppDAta%\BIT.TRIP *
+DetectFile=%LocalAppData%\BIT.TRIP *
 FileKey1=%LocalAppData%\BIT.TRIP *|*.txt
 
 [Bitcoin *]
@@ -18026,12 +18026,12 @@ Section=Games
 Detect=HKLM\Software\BioWare\Star Wars-The Old Republic
 FileKey1=%Documents%|*Install STAR WARS The Old Republic.log
 FileKey2=%LocalAppData%\SWTOR\CrashDump\swtor|*.*
-FileKey3=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\betatest\retailclient\Temp|*.log
-FileKey4=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\logs|*.log
-FileKey5=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\swtor\retailclient\swtor\logs|*.log
-FileKey6=%ProgramFiles%\EA Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
-FileKey7=%ProgramFiles%\EA Games\Star Wars - The Old Republic\logs|*.*
-FileKey8=%ProgramFiles%\EA Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
+FileKey3=%ProgramFiles%\EA Games\Star Wars - The Old Republic\__Installer|InstallLog.txt
+FileKey4=%ProgramFiles%\EA Games\Star Wars - The Old Republic\logs|*.*
+FileKey5=%ProgramFiles%\EA Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
+FileKey6=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\betatest\retailclient\Temp|*.log
+FileKey7=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\logs|*.log
+FileKey8=%ProgramFiles%\Electronic Arts\BioWare\Star Wars-The Old Republic\swtor\retailclient\swtor\logs|*.log
 
 [StarCraft I/II *]
 Section=Games

--- a/Winapp3/Archived entries.ini
+++ b/Winapp3/Archived entries.ini
@@ -1478,6 +1478,20 @@ Detect2=HKCU\Software\eBay\Turbo lister2
 FileKey1=%CommonAppData%\eBay\Turbo Lister*|*.log|RECURSE
 ; Discontinued (2020) 
 
+[ESPN Cricinfo *]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\ESPNCricinfo.ESPNCricinfo_y1atfjxm9t5ma
+FileKey1=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Microsoft\CLR_v4.0|*.log|RECURSE
+FileKey3=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Microsoft\CLR_v4.0\NativeImages\Temp|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey5=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\PRICache|*.*
+FileKey7=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\AC\Temp|*.*
+FileKey8=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\LocalState|*.*|RECURSE
+FileKey9=%LocalAppData%\Packages\ESPNCricinfo.ESPNCricinfo_*\TempState|*.*|RECURSE
+; No longer available for download on the microsoft store 
+
 [ESPN FC *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\ESPNCricinfo.ESPNFC_y1atfjxm9t5ma
@@ -1574,6 +1588,17 @@ Detect1=HKCR\Installer\Products\81024F76746FC3D4EB268FBCF42ECF5D
 Detect2=HKCR\Installer\Products\3128052F989958E40A8727EB849371FE
 FileKey1=%ProgramFiles%\Microsoft Games for Windows - LIVE\Redist|*.*|RECURSE
 ; Discontinued (2014)
+
+[GasBuddy *]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\45351D82.GasBuddy-FindCheapGasPrices_932xwky9axss4
+FileKey1=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\PRICache|*.*
+FileKey5=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\AC\Temp|*.*
+FileKey6=%LocalAppData%\Packages\45351D82.GasBuddy-FindCheapGasPrices_*\TempState|*.*|RECURSE
+; No longer available on the microsoft store 
 
 [GIANT AntiSpyware *]
 LangSecRef=3021
@@ -1865,6 +1890,15 @@ LangSecRef=3021
 Detect=HKCU\Software\AppDataLow\Software\Microsoft\BingBar
 FileKey1=%LocalAppData%\Microsoft\BingBar\Apps|*.tmp|RECURSE
 ; Discontinued web browser plugin 
+
+[Microsoft LifeCam *]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.LifeCamDashboard_8wekyb3d8bbwe
+FileKey1=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\PRICache|*.*
+FileKey3=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\AC\Temp|*.*
+FileKey4=%LocalAppData%\Packages\Microsoft.LifeCamDashboard_*\TempState|*.*|RECURSE
+; No longer available for download 
 
 [Microsoft Reader *]
 DetectOS=6.2|6.3

--- a/Winapp3/Archived entries.ini
+++ b/Winapp3/Archived entries.ini
@@ -1225,12 +1225,23 @@ FileKey2=%AppData%\Auslogics\Disk*Defrag*\Reports|*.*|RECURSE
 FileKey3=%CommonAppData%\Auslogics\Disk*Defrag*\*\Reports|*.*|RECURSE
 ; Outdated version
 
-
 [Avant Browser *]
 LangSecRef=3022
 Detect=HKCU\Software\Avant Browser
 FileKey1=%AppData%\Avant Browser|keywords.dat;pages.dat;recents.dat;reopen.dat
 ; Discontinued web browser 
+
+[Aviary Photo Editor *]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\57AB5DD0.PhotoEditor_6hb943tstq5q8
+FileKey1=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\AppCache|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\INet*|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0*|*.log|RECURSE
+FileKey4=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Microsoft\CLR_v4.0*\NativeImages\Temp|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\AC\Temp|*.*
+FileKey6=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\LocalState|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\57AB5DD0.PhotoEditor_*\TempState|*.*|RECURSE
+; Discontinued by Adobe (2014)
 
 [Awesomium *]
 LangSecRef=3021
@@ -1547,6 +1558,16 @@ Detect=HKCU\Software\Filehippo.com\Update Checker
 FileKey1=%Documents%\My Filehippo Downloads|*.*|RECURSE
 ; Discontinued 
 
+[FilmOn TV *]
+LangSecRef=3031
+DetectFile=%LocalAppData%\Packages\FilmOnLiveTVFree.*_zx03kxexxb716
+FileKey1=%LocalAppData%\Packages\FilmOnLiveTVFree.*_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\FilmOnLiveTVFree.*_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\FilmOnLiveTVFree.*_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey4=%LocalAppData%\Packages\FilmOnLiveTVFree.*_*\AC\Microsoft\Internet Explorer\DOMStore|*.*|RECURSE
+RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\FilmOnLiveTVFree.FilmOnLiveTVFree_zx03kxexxb716\SearchHistory
+; No longer available on the microsoft store 
+
 [FireShot Chrome Plugin *]
 LangSecRef=3021
 DetectFile=%AppData%\FireShot\fireshot-chrome-plugin.exe
@@ -1662,6 +1683,13 @@ LangSecRef=3023
 Detect=HKCU\Software\Google\Google Video Player
 RegKey1=HKCU\Software\Google\Google Video Player\MRUList
 ; Retired component of Google Video
+
+[Gravity Guy *]
+Section=Games
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\MiniclipSA.GravityGuy_gpanv85qtf6rc
+FileKey1=%LocalAppData%\Packages\MiniclipSA.GravityGuy_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\MiniclipSA.GravityGuy_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+; Removed from microsoft store 
 
 [Grokster *]
 LangSecRef=3022
@@ -1891,6 +1919,42 @@ Detect=HKCU\Software\AppDataLow\Software\Microsoft\BingBar
 FileKey1=%LocalAppData%\Microsoft\BingBar\Apps|*.tmp|RECURSE
 ; Discontinued web browser plugin 
 
+[Microsoft Edge *]
+LangSecRef=3005
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MicrosoftEdge_8wekyb3d8bbwe
+FileKey1=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!00*\INetCookies|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!00*\Microsoft\Cryptnet*Cache|*.*|RECURSE
+FileKey3=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!00*\MicrosoftEdge\Cookies|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\#!00*\MicrosoftEdge\User\Default\DOMStore|*.*|RECURSE
+FileKey5=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\Microsoft\Cryptnet*Cache|*.*|RECURSE
+FileKey6=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\Cookies|*.*|RECURSE
+FileKey7=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\UrlBlock|*.tmp
+FileKey8=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\DataStore\Data\nouser1\*\DBStore|V01*.log;V01*.jrs
+FileKey9=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\DataStore\Indexed\Data\nouser1\*|*.*|RECURSE
+FileKey10=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\ImageStore|*.*|RECURSE
+FileKey11=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\Recovery\Active|*.dat
+FileKey12=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\Temp|*.*|RECURSE
+FileKey13=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AppData\User\Default\Indexed DB|*.*|RECURSE
+FileKey14=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\LocalState\Favicons\PushNotificationGrouping|*.*|RECURSE
+FileKey15=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\TempState|*.*|RECURSE
+RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\Recovery\PendingDelete
+RegKey2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\PersistedPickerData\Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge\DefaultOpenFileMultiple
+RegKey3=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\PersistedPickerData\Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge\DefaultOpenFileSingle
+RegKey4=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\PersistedPickerData\Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge\DefaultSaveFileSingle
+; Non-Chromium edge discontinued 
+
+[Microsoft Edge Favorites Backup *]
+LangSecRef=3005
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MicrosoftEdge_8wekyb3d8bbwe
+FileKey1=%UserProfile%\MicrosoftEdgeBackups|*.*|RECURSE
+; Non-Chromium edge discontinued 
+
+[Microsoft Edge Favorites Icons *]
+LangSecRef=3005
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.MicrosoftEdge_8wekyb3d8bbwe
+FileKey1=%LocalAppData%\Packages\Microsoft.MicrosoftEdge_*\AC\MicrosoftEdge\User\Default\Datastore\Data\nouser1\*\Favorites|*.ico
+; Non-Chromium edge discontinued
+
 [Microsoft LifeCam *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.LifeCamDashboard_8wekyb3d8bbwe
@@ -1967,6 +2031,18 @@ LangSecRef=3025
 Detect=HKCU\Software\Microsoft\PhotoDraw\1.0
 RegKey1=HKCU\Software\Microsoft\PhotoDraw\1.0\Recent File List
 ; Discontinued (1999) 
+
+[MSN Food & Drink *]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingFoodAndDrink_8wekyb3d8bbwe
+FileKey1=%LocalAppData%\Packages\Microsoft.BingFoodAndDrink_*\LocalState\Cache|*.*|RECURSE
+; Discontinued by microsoft 
+
+[MSN Health & Fitness *]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.BingHealthAndFitness_8wekyb3d8bbwe
+FileKey1=%LocalAppData%\Packages\Microsoft.BingHealthAndFitness_*\LocalState\Cache|*.*|RECURSE
+; Discontinued by microsoft 
 
 [MultiBit *]
 LangSecRef=3023
@@ -2223,6 +2299,14 @@ DetectFile=%CommonAppData%\Logs
 FileKey1=%CommonAppData%\Logs|*.*|REMOVESELF
 ; Keys don't seem specific enough to be linked to this particular application, revisions needed 
 
+
+[Shark Dash *]
+Section=Games
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\GAMELOFTSA.SharkDashByGameloft_0pp20fcewvvtj
+FileKey1=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\GAMELOFTSA.SharkDashByGameloft_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+; No longer available on the microsoft store 
+
 [Skype *]
 LangSecRef=3022
 Detect=HKCU\Software\Skype
@@ -2330,6 +2414,17 @@ DetectFile=%AppData%\Style Jukebox Settings
 FileKey1=%AppData%\Style Jukebox Settings|*.bmp|RECURSE
 ; Discontinued (2017)
 
+[Stocks and Futures *]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\24877CutthroatSoftware.StocksandFutures_xgnzh3xnefnqe
+FileKey1=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\AC\INet*|*.*|RECURSE
+FileKey2=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\AC\Microsoft\CryptnetUrlCache\*|*.*
+FileKey3=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\AC\Temp|*.*
+FileKey4=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\AppData\Indexed DB|*.log
+FileKey5=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\LocalState|*.tmp|RECURSE
+FileKey6=%LocalAppData%\Packages\24877CutthroatSoftware.StocksandFutures_*\TempState|*.*|RECURSE
+; No longer available on microsoft store 
+
 [Team Crossword *]
 Section=Games
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.TeamCrossword_8wekyb3d8bbwe
@@ -2399,6 +2494,18 @@ LangSecRef=3023
 Detect=HKCU\Software\Unity\WebPlayer
 FileKey1=%LocalLowAppData%\Unity\*Player\Cache|*.*|RECURSE
 ; Discontinued web browser plugin 
+
+[Unofficial NewsReader for CNN *]
+LangSecRef=3031
+Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\65465Fetisenko.NewsReaderforCNN_806cg6g6fmyng
+FileKey1=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\AppCache\*|*.*|REMOVESELF
+FileKey2=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\INet*\*|*.*|REMOVESELF
+FileKey3=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
+FileKey4=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\Microsoft\Internet Explorer\DOMStore\*|*.*|REMOVESELF
+FileKey5=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\Temp|*.*
+FileKey6=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\AC\TokenBroker\Cache|*.*|REMOVESELF
+FileKey7=%LocalAppData%\Packages\65465Fetisenko.NewsReaderforCNN_*\TempState|*.*|RECURSE
+; Reemoved from Microsoft Store 
 
 [USA Today *]
 LangSecRef=3031

--- a/Winapp3/Archived entries.ini
+++ b/Winapp3/Archived entries.ini
@@ -1499,6 +1499,35 @@ Detect=HKCU\Software\CBS Interactive\Download App
 FileKey1=%Documents%\Downloads\Download App|*.*
 ; Discontinued 
 
+[EA Origin *]
+Section=Games
+Detect=HKLM\Software\Classes\Origin
+DetectFile=%AppData%\Origin
+FileKey1=%AppData%\Origin\*Cache|*.*
+FileKey2=%AppData%\Origin\Logs|*.*
+FileKey3=%AppData%\Origin\Telemetry|*.*
+FileKey4=%CommonAppData%\Origin\*Cache|*.*|RECURSE
+FileKey5=%CommonAppData%\Origin\*Logs|*.*
+FileKey6=%CommonAppData%\Origin\SelfUpdate\Staged|*.log
+FileKey7=%CommonAppData%\Origin\Telemetry|*.*
+FileKey8=%LocalAppData%\Origin\*Cache|*.*|RECURSE
+FileKey9=%LocalAppData%\Origin\Logs|*.txt
+FileKey10=%LocalAppData%\Origin\Origin\cache|*.*|RECURSE
+FileKey11=%LocalAppData%\Origin\Origin\QtWebEngine\Default\Application Cache|*.*|RECURSE
+FileKey12=%LocalAppData%\Origin\Origin\QtWebEngine\Default\Service Worker\*Cache*|*.*|RECURSE
+FileKey13=%LocalAppData%\Origin\ThinSetup|*_Log.txt
+FileKey14=%ProgramFiles%\Origin|*.log
+FileKey15=%SystemDrive%|shared.log
+; Discontinued, replaced with EA App
+
+[EA Origin Installers *]
+Section=Games
+Detect=HKLM\Software\Classes\Origin
+FileKey1=%LocalAppData%\Origin\ThinSetup|*.*|REMOVESELF
+FileKey2=%ProgramFiles%\Origin|vc*redist*.exe
+FileKey3=%ProgramFiles%\Origin Games|*.cab;dotnetfx3setup;dotNetFx*.exe;dsetup*.dll;DXSETUP.EXE;dxwebsetup.exe;eula.*.txt;GamesExplorerIntegrationTool.exe;gfwlivesetup.exe;globdata.ini;install.exe;install.ini;install.res.*.dll;oalinst.exe;vc_red.exe;vc_red.msi;vcredist.bmp;vc*redist*x*.exe;xnafx*_redist.msi|RECURSE
+; Discontinued, EA App doesn't like when you delete the installers
+
 [eBay Toolbar *]
 LangSecRef=3022
 Detect=HKCU\Software\eBay\eBayToolbar

--- a/Winapp3/Archived entries.ini
+++ b/Winapp3/Archived entries.ini
@@ -1086,6 +1086,12 @@ FileKey2=%AppData%\337 Wallpaper\apps\webcache|*.*|RECURSE
 FileKey3=%AppData%\337 Wallpaper\wallpaper|*.jpg
 ; Application unavailable for download 
 
+[Abelssoft CCFinder *]
+LangSecRef=3024
+DetectFile=%LocalAppData%\Abelssoft\CCfinder
+FileKey1=%LocalAppData%\FlickrNet|responseCache.dat
+; No longer available 
+
 [Ace Explorer Browser *]
 LangSecRef=3022
 Detect=HKCU\Software\Ace Explorer\Ace Explorer
@@ -1204,6 +1210,20 @@ FileKey1=%LocalAppData%\Packages\*.AngryBirdsBlack_*\AC\INet*|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\*.AngryBirdsBlack_*\AC\Microsoft\CryptnetUrlCache\*|*.*
 ; Discontinued and no longer available for download 
 
+[AOL *]
+LangSecRef=3022
+Detect=HKCU\Software\America Online
+FileKey1=%AppData%\AOL\C_AOL*|*.tmp|RECURSE
+FileKey2=%CommonAppData%\AOL Downloads|*.*|RECURSE
+FileKey3=%CommonAppData%\AOL\C_AOL*|*.tmp|RECURSE
+FileKey4=%CommonAppData%\AOL\C_AOL*\bart|*.*|RECURSE
+FileKey5=%CommonAppData%\AOL\C_AOL*\spool|*.*|RECURSE
+FileKey6=%LocalAppData%\AOL\C_AOL*|*-journal;*.tmp|RECURSE
+FileKey7=%LocalAppData%\AOL\C_AOL*\BrowserCache|*.*|RECURSE
+FileKey8=%LocalAppData%\AOL\C_AOL*\ToolbarCache|data_*;f_*;index;VisitedLinks
+FileKey9=%LocalAppData%\AOL\C_AOL*\ToolbarCache\AppCache\Cache|*.*
+; Discontinued
+
 [AOL Instant Messenger *]
 LangSecRef=3022
 DetectFile=%LocalAppData%\AOL\AIM
@@ -1230,6 +1250,12 @@ LangSecRef=3022
 Detect=HKCU\Software\Avant Browser
 FileKey1=%AppData%\Avant Browser|keywords.dat;pages.dat;recents.dat;reopen.dat
 ; Discontinued web browser 
+
+[Avast EasyPass *]
+LangSecRef=3022
+DetectFile=%Documents%\My Avast EasyPass Data
+FileKey1=%Documents%\My Avast EasyPass Data\Default Profile|mru.rfo;cache.rfo|RECURSE
+; Discontinued, replaced with Avast Passwords 
 
 [Aviary Photo Editor *]
 LangSecRef=3031


### PR DESCRIPTION
clean up some entries
don't clean the first start file for chromium browsers
fold windows 8 support for some keys into a wildcard for some UWP applications
improve firefox support
improve chromium browser entry parity
make internet explorer cleaning less aggressive 