### PR TITLE
Fixing [Wondershare *] cleaning aggressiveness

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -21408,7 +21408,6 @@ FileKey1=%AppData%\se_tmp*|*.*|REMOVESELF
 FileKey2=%CommonAppData%\Wondershare\*\*Log*|*.*|RECURSE
 FileKey3=%CommonAppData%\Wondershare\WAF\ProductFeatures\*Logs|*.*|RECURSE
 FileKey4=%Public%\Documents\Wondershare|*.*|REMOVESELF
-FileKey5=%UserProfile%\.cache|*.*|REMOVESELF
 
 [Wondershare AllMyTube *]
 LangSecRef=3022


### PR DESCRIPTION
This cleaning rule was too wide and cause issues with other software sharing that folder.

> FileKey5=%UserProfile%\.cache|*.*|REMOVESELF