### PR TITLE
Don't delete WinGet pin database

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -19494,6 +19494,7 @@ FileKey10=%LocalAppData%\Packages\microsoft.windows.authhost.sso_*\TempState|*|R
 RegKey1=HKCU\Software\Microsoft\Phone\ShellUI\WindowSizing
 RegKey2=HKCU\Software\Microsoft\UserData\UninstallTimes
 ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\LocalState\|settings.json
+ExcludeKey2=FILE|%LocalAppData%\Packages\Microsoft.DesktopAppInstaller_*\LocalState\|pinning.db
 
 [Universe Sandbox *]
 Section=Games


### PR DESCRIPTION
A WinGet update moved the pinning settings out of settings.json into pinning.db.

I think this will work based on the fix for https://github.com/MoscaDotTo/Winapp2/issues/932?