### PR TITLE
Fix Winapp3, Non-CCleaner: `%CommonAppData%` -> `%ProgramData%`

### DIFF
--- a/Non-CCleaner/Winapp2.ini
+++ b/Non-CCleaner/Winapp2.ini
@@ -1,4 +1,4 @@
-; Version: 230301
+; Version: 230305
 ; # of entries: 2,669 + 149 removed entries
 ;
 ; Winapp2.ini (non-CCleaner version) is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp2.ini (non-CCleaner version): https://github.com/MoscaDotTo/Winapp2/blob/master/Non-CCleaner/License.md
@@ -321,8 +321,8 @@ Detect5=HKCU\Software\Iridium
 Detect6=HKCU\Software\Slimjet
 Detect7=HKCU\Software\Yandex\YandexBrowser
 DetectFile=%LocalAppData%\Google\Chrome*
-FileKey1=%CommonAppData%\Epic Privacy Browser\Installer\Log|*.log
-FileKey2=%CommonAppData%\Yandex\YandexBrowser|service_update.log
+FileKey1=%ProgramData%\Epic Privacy Browser\Installer\Log|*.log
+FileKey2=%ProgramData%\Yandex\YandexBrowser|service_update.log
 FileKey3=%LocalAppData%\Chromium\Application|debug.log
 FileKey4=%LocalAppData%\Chromium\Application\SetupMetrics|*|REMOVESELF
 FileKey5=%LocalAppData%\Chromium\User Data|*.pma;LOG;LOG.old|RECURSE
@@ -589,7 +589,7 @@ FileKey14=%ProgramFiles%\Microsoft\Edge*\Application\SetupMetrics|*|REMOVESELF
 [Microsoft Edge Updates *]
 LangSecRef=3006
 DetectFile=%LocalAppData%\Microsoft\Edge*
-FileKey1=%CommonAppData%\Microsoft\EdgeUpdate\Log|*
+FileKey1=%ProgramData%\Microsoft\EdgeUpdate\Log|*
 FileKey2=%LocalAppData%\Microsoft\EdgeUpdate\Download|*|RECURSE
 FileKey3=%LocalAppData%\Microsoft\EdgeUpdate\Install|*|RECURSE
 FileKey4=%LocalAppData%\Microsoft\EdgeUpdate\Offline|*|RECURSE
@@ -900,7 +900,7 @@ FileKey14=%ProgramFiles%\Opera\Opera*\Application\SetupMetrics|*|REMOVESELF
 LangSecRef=3027
 DetectFile=%AppData%\Opera Software\Opera*
 FileKey1=%AppData%\Opera Software\Opera*|ssdfp*
-FileKey2=%CommonAppData%\Opera\OperaUpdate\Log|*
+FileKey2=%ProgramData%\Opera\OperaUpdate\Log|*
 FileKey3=%LocalAppData%\Programs\Opera*|*.backup;*.old;*.tmp|RECURSE
 
 ; End of Opera
@@ -982,7 +982,7 @@ FileKey25=%AppData%\Waterfox\Profiles\*|*.corrupt|RECURSE
 FileKey26=%AppData%\Waterfox\Profiles\*|AlternateServices.txt;notificationstore.json;parent.lock;serviceworker.txt;webappsstore.sqlite
 FileKey27=%AppData%\Waterfox\Profiles\*\shader-cache|*
 FileKey28=%AppData%\Waterfox\Profiles\*\storage\temporary|*|RECURSE
-FileKey29=%CommonAppData%\Mozilla*|cache2.*
+FileKey29=%ProgramData%\Mozilla*|cache2.*
 FileKey30=%LocalAppData%\Basilisk-Dev\Basilisk\Profiles\*\*cache*|*|REMOVESELF
 FileKey31=%LocalAppData%\Basilisk-Dev\Basilisk\Profiles\*\Safebrowsing-failedupdate|*|REMOVESELF
 FileKey32=%LocalAppData%\Basilisk-Dev\Basilisk\Profiles\*\thumbnails|*|REMOVESELF
@@ -1085,7 +1085,7 @@ FileKey15=%AppData%\Mozilla\*\Profiles\*\weave\logs|*
 FileKey16=%AppData%\Waterfox|*.log|RECURSE
 FileKey17=%AppData%\Waterfox\Profiles\*|TestPilotErrorLog.*
 FileKey18=%AppData%\Waterfox\Profiles\*\weave\logs|*
-FileKey19=%CommonAppData%\Mozilla*\logs|*
+FileKey19=%ProgramData%\Mozilla*\logs|*
 FileKey20=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox|*.log|RECURSE
 FileKey21=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*|TestPilotErrorLog.*
 FileKey22=%LocalAppData%\Packages\Mozilla.Firefox_*\LocalCache\Roaming\Mozilla\Firefox\Profiles\*\weave\logs|*
@@ -1174,7 +1174,7 @@ FileKey35=%AppData%\Waterfox\Profiles\*\crashes|*
 FileKey36=%AppData%\Waterfox\Profiles\*\datareporting|*|REMOVESELF
 FileKey37=%AppData%\Waterfox\Profiles\*\minidumps|*
 FileKey38=%AppData%\Waterfox\Profiles\*\saved-telemetry-pings|*
-FileKey39=%CommonAppData%\Mozilla*|profile_count_*.json
+FileKey39=%ProgramData%\Mozilla*|profile_count_*.json
 FileKey40=%LocalAppData%\Basilisk-Dev\Basilisk\Profiles\*|ShutdownDuration.*
 FileKey41=%LocalAppData%\FlashPeak\SlimBrowser\Profiles\*|ShutdownDuration.*
 FileKey42=%LocalAppData%\LibreWolf\Profiles\*|ShutdownDuration.*
@@ -1200,7 +1200,7 @@ Detect6=HKLM\Software\Mozilla\SeaMonkey
 Detect7=HKLM\Software\Mozilla\Waterfox
 DetectFile=%AppData%\Mozilla\Firefox
 FileKey1=%AppData%\Waterfox*\Waterfox*\install|*|RECURSE
-FileKey2=%CommonAppData%\Mozilla*\updates|*|RECURSE
+FileKey2=%ProgramData%\Mozilla*\updates|*|RECURSE
 FileKey3=%LocalAppData%\Basilisk-Dev\Basilisk\Basilisk|*|RECURSE
 FileKey4=%LocalAppData%\Moonchild Productions\Basilisk\Basilisk|*|RECURSE
 FileKey5=%LocalAppData%\Moonchild Productions\Pale Moon\Pale Moon|*|RECURSE
@@ -1210,7 +1210,7 @@ FileKey8=%LocalAppData%\Waterfox\updates|*.log|RECURSE
 FileKey9=%ProgramFiles%\Mozilla Firefox\tobedeleted|*
 FileKey10=%ProgramFiles%\Mozilla Maintenance Service|*.moz-delete
 FileKey11=%ProgramFiles%\WindowsApps\Mozilla.Firefox_*\VFS\ProgramFiles\Firefox Package Root\tobedeleted|*
-ExcludeKey1=FILE|%CommonAppData%\Mozilla*\updates\*\|update-config.json
+ExcludeKey1=FILE|%ProgramData%\Mozilla*\updates\*\|update-config.json
 
 ; End of Firefox/Mozilla based browsers
 ;
@@ -1237,7 +1237,7 @@ Detect1=HKLM\Software\Binary Outcast\Interlink
 Detect2=HKLM\Software\Mozilla\Mozilla Thunderbird
 FileKey1=%AppData%\Binary Outcast\Interlink\Profiles\*|extensions.log;filterlog.html;TestPilotErrorLog.*
 FileKey2=%AppData%\Thunderbird\Profiles\*|extensions.log;filterlog.html;TestPilotErrorLog.*
-FileKey3=%CommonAppData%\Mozilla*\logs|*|RECURSE
+FileKey3=%ProgramData%\Mozilla*\logs|*|RECURSE
 FileKey4=%ProgramFiles%\Interlink|*.log
 FileKey5=%ProgramFiles%\Mozilla Maintenance Service\*logs|*
 FileKey6=%ProgramFiles%\Mozilla Thunderbird|*.log
@@ -1257,10 +1257,10 @@ FileKey6=%AppData%\Thunderbird\Profiles\*\saved-telemetry-pings|*|RECURSE
 LangSecRef=3030
 Detect1=HKLM\Software\Binary Outcast\Interlink
 Detect2=HKLM\Software\Mozilla\Mozilla Thunderbird
-FileKey1=%CommonAppData%\Mozilla*\updates|*|RECURSE
+FileKey1=%ProgramData%\Mozilla*\updates|*|RECURSE
 FileKey2=%LocalAppData%\Binary Outcast\updates|*|RECURSE
 FileKey3=%LocalAppData%\Thunderbird\updates|*|RECURSE
-ExcludeKey1=FILE|%CommonAppData%\Mozilla*\updates\*\|update-config.json
+ExcludeKey1=FILE|%ProgramData%\Mozilla*\updates\*\|update-config.json
 
 ; End of Thunderbird
 ;
@@ -1339,8 +1339,8 @@ FileKey2=%LocalAppData%\NPPDRUSH\*Cache|*.*|RECURSE
 
 [1Click DVD Copy Pro *]
 LangSecRef=3023
-DetectFile=%CommonAppData%\1click dvd copy pro
-FileKey1=%CommonAppData%\1click dvd copy pro|*.log
+DetectFile=%ProgramData%\1click dvd copy pro
+FileKey1=%ProgramData%\1click dvd copy pro|*.log
 
 [2K Launcher *]
 Section=Games
@@ -1521,10 +1521,10 @@ Detect6=HKCU\Software\ABBYY\FineReader\14.00
 Detect7=HKCU\Software\ABBYY\FineReader\15
 Detect8=HKCU\Software\ABBYY\FineReaderSprint\9.00
 Detect9=HKCU\Software\ABBYY\Sprint\5.00
-FileKey1=%CommonAppData%\ABBYY\FineReader*\*\Licenses|*.log
-FileKey2=%CommonAppData%\ABBYY\FineReader\*\*\Dumps|*.*
-FileKey3=%CommonAppData%\ABBYY\FineReader\*\Dumps|*.*
-FileKey4=%CommonAppData%\ABBYY\FineReader\*\PdfToolsCache|FontsCache*.dat
+FileKey1=%ProgramData%\ABBYY\FineReader*\*\Licenses|*.log
+FileKey2=%ProgramData%\ABBYY\FineReader\*\*\Dumps|*.*
+FileKey3=%ProgramData%\ABBYY\FineReader\*\Dumps|*.*
+FileKey4=%ProgramData%\ABBYY\FineReader\*\PdfToolsCache|FontsCache*.dat
 FileKey5=%LocalAppData%\ABBYY\FineReader\*|datafile.bin;SendToWorkFiles.txt
 FileKey6=%LocalAppData%\ABBYY\FineReader\*\*\Dumps|*.*
 FileKey7=%LocalAppData%\ABBYY\FineReader\*\Dumps|*.*
@@ -1622,7 +1622,7 @@ RegKey83=HKCU\Software\ABBYY\Sprint\5.00\Options|SaveImagePath
 LangSecRef=3021
 Detect=HKCU\Software\ABBYY\Lingvo\15.0
 DetectFile=%ProgramFiles%\ABBYY Lingvo x5
-FileKey1=%CommonAppData%\ABBYY\Lingvo\*\Licenses|*.log
+FileKey1=%ProgramData%\ABBYY\Lingvo\*\Licenses|*.log
 FileKey2=%ProgramFiles%\ABBYY Lingvo x5|*.log;*.rtf
 RegKey1=HKCU\Software\ABBYY\Lingvo\15.0\Dictionaries\FavoriteDirections
 RegKey2=HKCU\Software\ABBYY\Lingvo\15.0\View|LastText
@@ -1632,7 +1632,7 @@ RegKey3=HKCU\Software\ABBYY\Lingvo\15.0\X3M|LastActivity
 LangSecRef=3021
 Detect1=HKCU\Software\ABBYY\PDFTransformer\3.00
 Detect2=HKCU\Software\ABBYY\PDFTransformer\12.00
-FileKey1=%CommonAppData%\ABBYY\PDFTransformer\*\Licenses|*.log
+FileKey1=%ProgramData%\ABBYY\PDFTransformer\*\Licenses|*.log
 FileKey2=%LocalAppData%\ABBYY\PDFTransformer\*|*.log
 FileKey3=%LocalAppData%\ABBYY\PDFTransformer\*\FontCache|*.*
 FileKey4=%ProgramFiles%\ABBYY PDF Transformer *.0|*.log
@@ -1647,8 +1647,8 @@ Detect1=HKCU\Software\ABBYY\Bonus.ScreenshotReader\9.00
 Detect2=HKCU\Software\ABBYY\Retail.ScreenshotReader\9.00
 Detect3=HKCU\Software\ABBYY\ScreenshotReader\9.00
 DetectFile=%ProgramFiles%\ABBYY Screenshot Reader
-FileKey1=%CommonAppData%\ABBYY\*.ScreenshotReader\*|*.xml
-FileKey2=%CommonAppData%\ABBYY\*.ScreenshotReader\*\Licenses|*.log
+FileKey1=%ProgramData%\ABBYY\*.ScreenshotReader\*|*.xml
+FileKey2=%ProgramData%\ABBYY\*.ScreenshotReader\*\Licenses|*.log
 FileKey3=%ProgramFiles%\ABBYY Screenshot Reader|*.log;*.rtf
 RegKey1=HKCU\Software\ABBYY\Bonus.ScreenshotReader\9.00\Options|LastSaveImagePath
 RegKey2=HKCU\Software\ABBYY\Bonus.ScreenshotReader\9.00\Options|SaveTablePath
@@ -1727,7 +1727,7 @@ FileKey4=%AppData%\Ableton\Live Reports\Ableton Crash Report*|*.*|REMOVESELF
 FileKey5=%AppData%\Ableton\Live Reports\Temp|*.*|REMOVESELF
 FileKey6=%AppData%\Ableton\Live Reports\Usage|*.*|REMOVESELF
 FileKey7=%AppData%\Ableton\Live*\Preferences\Crash|*.*|RECURSE
-FileKey8=%CommonAppData%\Ableton\*\Redist|vc*redist*.exe
+FileKey8=%ProgramData%\Ableton\*\Redist|vc*redist*.exe
 FileKey9=%LocalAppData%\Ableton\Cache\cache\decoding|*.*
 FileKey10=%ProgramFiles%\Ableton\*\Redist|vc*redist*.exe
 
@@ -1880,19 +1880,19 @@ RegKey1=HKCU\Software\Acelogix\Ace Utilities\Settings|UsageHistory
 [Acebyte Utilities *]
 LangSecRef=3024
 Detect=HKCU\Software\AceBIT
-FileKey1=%CommonAppData%\Acebyte\Acebyte Utilities*\Log|*.*|RECURSE
+FileKey1=%ProgramData%\Acebyte\Acebyte Utilities*\Log|*.*|RECURSE
 
 [Acer Arcade Deluxe *]
 Section=Games
 DetectFile=%LocalAppData%\Acer Arcade Deluxe
-FileKey1=%CommonAppData%|ArcadeDexluxe2.log
+FileKey1=%ProgramData%|ArcadeDexluxe2.log
 FileKey2=%LocalAppData%\Acer Arcade Deluxe|*.log
 
 [Acer Care Center *]
 LangSecRef=3024
 Detect1=HKLM\Software\OEM\AcerCareCenter
 Detect2=HKLM\Software\OEM\CareCenter
-FileKey1=%CommonAppData%\Acer\CareCenter\DebugLog\SurfaceCheck|log*.txt
+FileKey1=%ProgramData%\Acer\CareCenter\DebugLog\SurfaceCheck|log*.txt
 FileKey2=%ProgramFiles%\Acer\Care Center\DebugLog|*.log
 
 [Acer Clear.fi *]
@@ -1976,10 +1976,10 @@ FileKey2=%AppData%\Acustica\Stagearea\AquariusTemp|*.*
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Ad-Aware Antivirus
 FileKey1=%AppData%\Ad-Aware Antivirus\Logs|*.*|RECURSE
-FileKey2=%CommonAppData%\Ad-Aware Antivirus\Logs|*.*|RECURSE
-FileKey3=%CommonAppData%\Lavasoft\AntiMalware\Events|*.*|RECURSE
-FileKey4=%CommonAppData%\Lavasoft\AntiMalware\History|*.*|RECURSE
-FileKey5=%CommonAppData%\Lavasoft\AntiMalware\Logs|*.*|RECURSE
+FileKey2=%ProgramData%\Ad-Aware Antivirus\Logs|*.*|RECURSE
+FileKey3=%ProgramData%\Lavasoft\AntiMalware\Events|*.*|RECURSE
+FileKey4=%ProgramData%\Lavasoft\AntiMalware\History|*.*|RECURSE
+FileKey5=%ProgramData%\Lavasoft\AntiMalware\Logs|*.*|RECURSE
 
 [Adaptec's Audio CD *]
 LangSecRef=3024
@@ -1995,8 +1995,8 @@ FileKey1=%LocalAppData%\Adaware*\QtWebEngine\Default|Visited Links
 LangSecRef=3021
 DetectFile=%AppData%\Lavasoft\Web Companion
 FileKey1=%AppData%\Lavasoft\Web Companion|*log.txt
-FileKey2=%CommonAppData%\Lavasoft\Web Companion\Logs|*.*|RECURSE
-FileKey3=%CommonAppData%\Lavasoft\Web Companion\Options|Statistics.txt
+FileKey2=%ProgramData%\Lavasoft\Web Companion\Logs|*.*|RECURSE
+FileKey3=%ProgramData%\Lavasoft\Web Companion\Options|Statistics.txt
 
 [AdFender *]
 LangSecRef=3022
@@ -2012,7 +2012,7 @@ FileKey3=%AppData%\Adobe\Common\* Cache*|*.*|RECURSE
 FileKey4=%AppData%\Adobe\Common\Peak Files|*.*|RECURSE
 FileKey5=%AppData%\Adobe\CRLogs|*.*|RECURSE
 FileKey6=%AppData%\Adobe\LogTransport2\Logs|*.*|RECURSE
-FileKey7=%CommonAppData%\Adobe\ARM|*.*|RECURSE
+FileKey7=%ProgramData%\Adobe\ARM|*.*|RECURSE
 FileKey8=%CommonProgramFiles%\Adobe\Creative Cloud Libraries|*.log|RECURSE
 FileKey9=%CommonProgramFiles%\Adobe\Installers|*.log*|RECURSE
 FileKey10=%Documents%\Adobe|*.log|RECURSE
@@ -2196,11 +2196,11 @@ RegKey1=HKCU\Software\Adobe\MediaBrowser\MRU
 LangSecRef=3023
 Detect=HKCU\Software\Adobe\Elements Organizer
 FileKey1=%AppData%\Adobe\Elements Organizer\*\Organizer|*.txt;status.dat
-FileKey2=%CommonAppData%|StreamingMediaTechnologyLog.txt
-FileKey3=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog|*.thumb.*.cache
-FileKey4=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog\FaceAnalysis|FaceAnalysis.cache
-FileKey5=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog\WaldoData|waldo.cache
-FileKey6=%CommonAppData%\Adobe\Elements Organizer\Catalogs\My Catalog\Watch Folder|*.txt;*.xml
+FileKey2=%ProgramData%|StreamingMediaTechnologyLog.txt
+FileKey3=%ProgramData%\Adobe\Elements Organizer\Catalogs\My Catalog|*.thumb.*.cache
+FileKey4=%ProgramData%\Adobe\Elements Organizer\Catalogs\My Catalog\FaceAnalysis|FaceAnalysis.cache
+FileKey5=%ProgramData%\Adobe\Elements Organizer\Catalogs\My Catalog\WaldoData|waldo.cache
+FileKey6=%ProgramData%\Adobe\Elements Organizer\Catalogs\My Catalog\Watch Folder|*.txt;*.xml
 RegKey1=HKCU\Software\Adobe\Elements Organizer\11.0\CurrentMediaFilePath
 RegKey2=HKCU\Software\Adobe\Elements Organizer\13.0\CurrentMediaFilePath
 RegKey3=HKCU\Software\Adobe\Elements Organizer\14.0\CurrentMediaFilePath
@@ -2222,7 +2222,7 @@ FileKey5=%WinDir%\SysWOW64\Macromed\Temp|*
 LangSecRef=3023
 Detect=HKCU\Software\Adobe\Photoshop Elements
 FileKey1=%AppData%\Adobe\Photoshop Elements\*\Editor|*.txt
-FileKey2=%CommonAppData%\Adobe\Photoshop Elements\File Agent|WatchFolder.3.cache
+FileKey2=%ProgramData%\Adobe\Photoshop Elements\File Agent|WatchFolder.3.cache
 RegKey1=HKCU\Software\Adobe\Photoshop Elements\11.0\common\settings\Elements MRU
 RegKey2=HKCU\Software\Adobe\Photoshop Elements\11.0\CurrentMediaFilePath
 RegKey3=HKCU\Software\Adobe\Photoshop Elements\11.0\VisitedDirs|STARTUPIMAGEDIRECTORY
@@ -2398,8 +2398,8 @@ RegKey5=HKLM\Software\Microsoft\Microsoft Games\Age of Empires\2.0|Zone
 
 [Age of Oracles: Tara's Journey *]
 Section=Games
-DetectFile=%CommonAppData%\JollyBear\Age of Oracles Taras Journey
-FileKey1=%CommonAppData%\JollyBear\Age of Oracles Taras Journey|error.*
+DetectFile=%ProgramData%\JollyBear\Age of Oracles Taras Journey
+FileKey1=%ProgramData%\JollyBear\Age of Oracles Taras Journey|error.*
 
 [Age of Wonders II *]
 Section=Games
@@ -2410,16 +2410,16 @@ FileKey3=%ProgramFiles%\Age of Wonders*|*Log.txt
 
 [Agomo *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Piriform\Agomo
-FileKey1=%CommonAppData%\Piriform\Agomo\Logs|*.*
+DetectFile=%ProgramData%\Piriform\Agomo
+FileKey1=%ProgramData%\Piriform\Agomo\Logs|*.*
 FileKey2=%ProgramFiles%\Agomo\Logs|*.*
 FileKey3=%ProgramFiles%\Agomo\tmp_update|*.*
 
 [AHA Dialer *]
 LangSecRef=3022
 Detect=HKLM\System\CurrentControlSet\Services\HWDeviceService.exe
-DetectFile=%CommonAppData%\DatacardService
-FileKey1=%CommonAppData%\DatacardService\log|*.*
+DetectFile=%ProgramData%\DatacardService
+FileKey1=%ProgramData%\DatacardService\log|*.*
 
 [AhnLab V3 Lite *]
 LangSecRef=3024
@@ -2461,7 +2461,7 @@ FileKey1=%AppData%\aignes\website-watcher\bookmarks|*.*
 [Aimersoft *]
 LangSecRef=3023
 Detect=HKLM\Software\Aimersoft
-FileKey1=%CommonAppData%\Aimersoft\*\*Logs|*.*|RECURSE
+FileKey1=%ProgramData%\Aimersoft\*\*Logs|*.*|RECURSE
 FileKey2=%Public%\Documents\Aimersoft|*.*|REMOVESELF
 
 [Aimersoft DRM Media Converter *]
@@ -2808,9 +2808,9 @@ Detect3=HKLM\Software\ATI Technologies
 DetectFile1=%ProgramFiles%\AMD
 DetectFile2=%ProgramFiles%\ATI Technologies
 DetectFile3=%ProgramFiles%\RAIDXpert2
-FileKey1=%CommonAppData%\AMD AutoUpdate|*.log
-FileKey2=%CommonAppData%\AMD\Fuel|*.txt
-FileKey3=%CommonAppData%\AMD\KDB|*.log
+FileKey1=%ProgramData%\AMD AutoUpdate|*.log
+FileKey2=%ProgramData%\AMD\Fuel|*.txt
+FileKey3=%ProgramData%\AMD\KDB|*.log
 FileKey4=%LocalAppData%\AMD Ryzen Master\cache\qmlcache|*.*
 FileKey5=%LocalAppData%\AMD\*Cache|*.*|RECURSE
 FileKey6=%LocalAppData%\AMD\cn|*.log
@@ -2897,8 +2897,8 @@ FileKey5=%UserProfile%\amsn\displaypic\cache|*.*
 
 [AMYUNI PDF Converter *]
 LangSecRef=3021
-DetectFile=%CommonAppData%\Package Cache\3DBECED19CFC2819A7E0BE14463CF18FC8720D91\amyuni_pdfconverter_5_00
-FileKey1=%CommonAppData%\Package Cache\3DBECED19CFC2819A7E0BE14463CF18FC8720D91\amyuni_pdfconverter_5_00|*.log|RECURSE
+DetectFile=%ProgramData%\Package Cache\3DBECED19CFC2819A7E0BE14463CF18FC8720D91\amyuni_pdfconverter_5_00
+FileKey1=%ProgramData%\Package Cache\3DBECED19CFC2819A7E0BE14463CF18FC8720D91\amyuni_pdfconverter_5_00|*.log|RECURSE
 
 [AnalogX PortMapper *]
 LangSecRef=3024
@@ -2930,13 +2930,13 @@ FileKey3=%UserProfile%\.gradle|*.log|RECURSE
 
 [Anfibia Deskman *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\DNET*
-FileKey1=%CommonAppData%\DNET*|.log
+DetectFile=%ProgramData%\DNET*
+FileKey1=%ProgramData%\DNET*|.log
 
 [Anfibia Switch *]
 LangSecRef=3021
 Detect=HKCU\Software\Anfibia Switch
-FileKey1=%CommonAppData%\Anfibia Switch|*.log|RECURSE
+FileKey1=%ProgramData%\Anfibia Switch|*.log|RECURSE
 
 [Anim8or *]
 LangSecRef=3021
@@ -3066,7 +3066,7 @@ FileKey4=%LocalAppData%\AnyMusic\QtWebEngine\Default\GPUCache|*.*
 [AOMEI Backupper *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\AOMEI Backupper
-FileKey1=%CommonAppData%\AomeiBR|brlog.xml
+FileKey1=%ProgramData%\AomeiBR|brlog.xml
 FileKey2=%ProgramFiles%\AOMEI Backupper\AOMEI Image Deploy\log|*.*
 FileKey3=%ProgramFiles%\AOMEI Backupper\log|*.*
 
@@ -3177,7 +3177,7 @@ RegKey1=HKLM\Software\Silicon Joy Software\Applet Password Wizard\1\mainWindow|M
 LangSecRef=3024
 DetectFile=%AppData%\Appupdater
 FileKey1=%AppData%\Appupdater|appupdaterw.log
-FileKey2=%CommonAppData%\Appupdater|*.log
+FileKey2=%ProgramData%\Appupdater|*.log
 
 [AQQ *]
 LangSecRef=3022
@@ -3265,7 +3265,7 @@ RegKey1=HKCU\Software\ASCOMP\Cleaning Suite|ClientID
 LangSecRef=3024
 Detect=HKCU\Software\Ashampoo
 FileKey1=%AppData%\Ashampoo|*.log;*.txt;*.xml|RECURSE
-FileKey2=%CommonAppData%\Ashampoo|ico_ashampoo_deals.ico
+FileKey2=%ProgramData%\Ashampoo|ico_ashampoo_deals.ico
 FileKey3=%LocalAppData%\Ashampoo\BaNT|*.*|RECURSE
 FileKey4=%LocalAppData%\Ashampoo\boxshots|*.png
 
@@ -3292,7 +3292,7 @@ Detect18=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2016
 Detect19=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2017
 Detect20=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2018
 Detect21=HKCU\Software\Ashampoo\Ashampoo Burning Studio 2019
-FileKey1=%CommonAppData%\Ashampoo\drivers|driverdatabase.xml|REMOVESELF
+FileKey1=%ProgramData%\Ashampoo\drivers|driverdatabase.xml|REMOVESELF
 RegKey1=HKCU\Software\Ashampoo\Ashampoo Burning Studio 5\Burn Image Project\SelectImage
 RegKey2=HKCU\Software\Ashampoo\Ashampoo Burning Studio 5\Data Disc Project\AddDialog
 RegKey3=HKCU\Software\Ashampoo\Ashampoo Burning Studio 5\Data Disc Project\DumpImage
@@ -3538,8 +3538,8 @@ FileKey1=%LocalAppData%\Ashes of the Singularity\Stardock\Tachyon|*.txt
 
 [Ashley Jones and the Heart of Egypt *]
 Section=Games
-DetectFile=%CommonAppData%\Fenomen Games\Ashley Jones - The Heart Of Egypt
-FileKey1=%CommonAppData%\Fenomen Games\Ashley Jones - The Heart Of Egypt|*.log
+DetectFile=%ProgramData%\Fenomen Games\Ashley Jones - The Heart Of Egypt
+FileKey1=%ProgramData%\Fenomen Games\Ashley Jones - The Heart Of Egypt|*.log
 
 [Asmwsoft PC Optimizer *]
 LangSecRef=3024
@@ -3561,29 +3561,29 @@ FileKey2=%AppData%\AstroGrep\Log|*.log
 LangSecRef=3024
 Detect=HKLM\Software\ASUS\SmartCore
 DetectFile1=%AppData%\ASUS WebStorage
-DetectFile2=%CommonAppData%\ASUS
+DetectFile2=%ProgramData%\ASUS
 DetectFile3=%LocalAppData%\AcSdkInsLog
 DetectFile4=%ProgramFiles%\ASUS\AI Suite
 FileKey1=%AppData%\*WebStorage\Logs|*
-FileKey2=%CommonAppData%\ASUS|*Log.txt;*.bak;*.log*;Thumbs.db|RECURSE
-FileKey3=%CommonAppData%\ASUS\ARMOURY CRATE Diagnosis\ASUS Update\ACS|*.txt
-FileKey4=%CommonAppData%\ASUS\ARMOURY CRATE Diagnosis\LightingService|*
-FileKey5=%CommonAppData%\ASUS\ARMOURY CRATE Diagnosis\ROG Live Service\InstallLog|*.*|RECURSE
-FileKey6=%CommonAppData%\ASUS\ASUS System Control Interface\AsusSoftwareManager\AsusLiveUpdate\Log|*_logtrack.txt
-FileKey7=%CommonAppData%\ASUS\ASUS System Control Interface\AsusSoftwareManager\AsusLiveUpdate\Temp|*
-FileKey8=%CommonAppData%\ASUS\ASUS System Control Interface\AsusSystemDiagnosis|*.txt
-FileKey9=%CommonAppData%\ASUS\ASUS System Control Interface\log|*
+FileKey2=%ProgramData%\ASUS|*Log.txt;*.bak;*.log*;Thumbs.db|RECURSE
+FileKey3=%ProgramData%\ASUS\ARMOURY CRATE Diagnosis\ASUS Update\ACS|*.txt
+FileKey4=%ProgramData%\ASUS\ARMOURY CRATE Diagnosis\LightingService|*
+FileKey5=%ProgramData%\ASUS\ARMOURY CRATE Diagnosis\ROG Live Service\InstallLog|*.*|RECURSE
+FileKey6=%ProgramData%\ASUS\ASUS System Control Interface\AsusSoftwareManager\AsusLiveUpdate\Log|*_logtrack.txt
+FileKey7=%ProgramData%\ASUS\ASUS System Control Interface\AsusSoftwareManager\AsusLiveUpdate\Temp|*
+FileKey8=%ProgramData%\ASUS\ASUS System Control Interface\AsusSystemDiagnosis|*.txt
+FileKey9=%ProgramData%\ASUS\ASUS System Control Interface\log|*
 FileKey10=%LocalAppData%\AcLoader|*.log
 FileKey11=%LocalAppData%\AcSdkInsLog|*
 FileKey12=%ProgramFiles%\ASUS\*|*.log;*log*.txt;*.tmp|RECURSE
 FileKey13=%Public%\ASUSFlipLog|*
 FileKey14=%SystemDrive%|wifi.log
-ExcludeKey1=FILE|%CommonAppData%\ASUS\*\|install.log
+ExcludeKey1=FILE|%ProgramData%\ASUS\*\|install.log
 
 [ASUS USB Charger Plus *]
 LangSecRef=3021
-DetectFile=%CommonAppData%\USBChargerPlus
-FileKey1=%CommonAppData%|AsACPLog.*
+DetectFile=%ProgramData%\USBChargerPlus
+FileKey1=%ProgramData%|AsACPLog.*
 
 [Athentech Perfectly Clear *]
 LangSecRef=3021
@@ -3593,8 +3593,8 @@ FileKey1=%LocalAppData%\cache\Athentech|*.*|REMOVESELF
 [Atheros Driver *]
 LangSecRef=3024
 Detect=HKLM\Software\Atheros
-FileKey1=%CommonAppData%\Atheros|*.log|RECURSE
-FileKey2=%CommonAppData%\Qualcomm Atheros WiFi Driver Installation|*.Log|RECURSE
+FileKey1=%ProgramData%\Atheros|*.log|RECURSE
+FileKey2=%ProgramData%\Qualcomm Atheros WiFi Driver Installation|*.Log|RECURSE
 FileKey3=%CommonProgramFiles%\Atheros|InstallLog.txt
 FileKey4=%CommonProgramFiles%\Qualcomm|InstallLog.txt
 FileKey5=%CommonProgramFiles%\Qualcomm Atheros|*.log
@@ -3609,7 +3609,7 @@ FileKey1=%ProgramFiles%\GameTop.com\Atlantis Quest|Error.log
 LangSecRef=3021
 Detect=HKCU\Software\Atlantis Word Processor
 FileKey1=%AppData%\Atlantis|*.tmp|RECURSE
-FileKey2=%CommonAppData%\Atlantis|Update.log
+FileKey2=%ProgramData%\Atlantis|Update.log
 RegKey1=HKCU\Software\Atlantis Word Processor\ClipLib|AddGraphicClip_RecentFolder
 RegKey2=HKCU\Software\Atlantis Word Processor\ClipLib|AddTextClip_RecentFolder
 RegKey3=HKCU\Software\Atlantis Word Processor\ClipLib|RecentClip
@@ -3732,7 +3732,7 @@ RegKey1=HKCU\Software\Audacity\Audacity|DefaultOpenPath
 [Audials *]
 LangSecRef=3023
 DetectFile=%LocalAppData%\RapidSolution\Audials_*
-FileKey1=%CommonAppData%\RapidSolution\Audials_*\ChildMSILogs|*.txt
+FileKey1=%ProgramData%\RapidSolution\Audials_*\ChildMSILogs|*.txt
 FileKey2=%LocalAppData%\RapidSolution\Audials_*\Log|*.log;*.txt|RECURSE
 FileKey3=%LocalAppData%\RapidSolution\Audials_Software\RapidSolution\Audials_*\Log|*.log;*.txt|RECURSE
 
@@ -3768,7 +3768,7 @@ RegKey1=HKLM\Software\Auslogics\Google Analytics Package
 [Auslogics BoostSpeed *]
 LangSecRef=3024
 Detect=HKCU\Software\Auslogics\BoostSpeed
-FileKey1=%CommonAppData%\Auslogics\BoostSpeed\*.x|*.err;*.htm*;*.log;*.rsc;*.sta;*.xml|RECURSE
+FileKey1=%ProgramData%\Auslogics\BoostSpeed\*.x|*.err;*.htm*;*.log;*.rsc;*.sta;*.xml|RECURSE
 FileKey2=%ProgramFiles%\Auslogics\Auslogics BoostSpeed|rdboot.log
 RegKey1=HKCU\Software\Auslogics\BoostSpeed\5.x\Settings|DiskCleaner.AppLogic.ErrorsFailed
 RegKey2=HKCU\Software\Auslogics\BoostSpeed\5.x\Settings|DiskCleaner.AppLogic.ErrorsFound
@@ -3808,7 +3808,7 @@ Detect1=HKLM\Software\Auslogics\Disk Defrag
 Detect2=HKLM\Software\Auslogics\Disk Defrag Portable
 Detect3=HKLM\Software\Auslogics\Disk Defrag Professional
 FileKey1=%AppData%\Auslogics\*Disk*Defrag*\Reports|*.*|RECURSE
-FileKey2=%CommonAppData%\Auslogics\*Disk*Defrag*\*\*Reports|*.*|RECURSE
+FileKey2=%ProgramData%\Auslogics\*Disk*Defrag*\*\*Reports|*.*|RECURSE
 FileKey3=%ProgramFiles%\Auslogics\*Disk*Defrag*|ndefrg.log
 
 [Auslogics Duplicate File Finder *]
@@ -3823,10 +3823,10 @@ Detect1=HKCU\Software\Auslogics\Registry Cleaner
 Detect2=HKLM\Software\Auslogics\Registry Cleaner\3.x
 Detect3=HKLM\Software\Auslogics\Registry Cleaner\4.x
 Detect4=HKLM\Software\Auslogics\Registry Cleaner\5.X
-FileKey1=%CommonAppData%\Auslogics\Registry Cleaner\*.x|*.htm*;*.log|RECURSE
-FileKey2=%CommonAppData%\Auslogics\Registry Cleaner\*.x\DeliveredAction|*.tmp
-FileKey3=%CommonAppData%\Auslogics\Registry Cleaner\*.x\Reports|*.*|RECURSE
-FileKey4=%CommonAppData%\Auslogics\Registry Cleaner\*.x\Rescue\Auslogics Registry Cleaner|*.rsc
+FileKey1=%ProgramData%\Auslogics\Registry Cleaner\*.x|*.htm*;*.log|RECURSE
+FileKey2=%ProgramData%\Auslogics\Registry Cleaner\*.x\DeliveredAction|*.tmp
+FileKey3=%ProgramData%\Auslogics\Registry Cleaner\*.x\Reports|*.*|RECURSE
+FileKey4=%ProgramData%\Auslogics\Registry Cleaner\*.x\Rescue\Auslogics Registry Cleaner|*.rsc
 RegKey1=HKCU\Software\Auslogics\Registry Cleaner\2.x\Settings|RegCleaner.AppLogic.ErrorsFailed
 RegKey2=HKCU\Software\Auslogics\Registry Cleaner\2.x\Settings|RegCleaner.AppLogic.ErrorsFound
 RegKey3=HKCU\Software\Auslogics\Registry Cleaner\2.x\Settings|RegCleaner.AppLogic.ErrorsRemoved
@@ -3869,8 +3869,8 @@ Detect1=HKCU\Software\Auslogics\Registry Defrag
 Detect2=HKLM\Software\Auslogics\Registry Defrag
 FileKey1=%AppData%\Auslogics\Registry Defrag\Logs|*.*
 FileKey2=%AppData%\Auslogics\Registry Defrag\Reports|*.*
-FileKey3=%CommonAppData%\Auslogics\Registry Defrag\*.x\DeliveredAction|*.tmp
-FileKey4=%CommonAppData%\Auslogics\Registry Defrag\*.x\Reports|*.*
+FileKey3=%ProgramData%\Auslogics\Registry Defrag\*.x\DeliveredAction|*.tmp
+FileKey4=%ProgramData%\Auslogics\Registry Defrag\*.x\Reports|*.*
 
 [Auslogics System Information *]
 LangSecRef=3024
@@ -3879,10 +3879,10 @@ FileKey1=%AppData%\Auslogics\System Information|*.*
 
 [Auslogics Windows Slimmer *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Auslogics\Windows Slimmer
-FileKey1=%CommonAppData%\Auslogics\Windows Slimmer\*.x|*.err
-FileKey2=%CommonAppData%\Auslogics\Windows Slimmer\*.x\Logs|*.*
-FileKey3=%CommonAppData%\Auslogics\Windows Slimmer\*.x\Reports|*.*|RECURSE
+DetectFile=%ProgramData%\Auslogics\Windows Slimmer
+FileKey1=%ProgramData%\Auslogics\Windows Slimmer\*.x|*.err
+FileKey2=%ProgramData%\Auslogics\Windows Slimmer\*.x\Logs|*.*
+FileKey3=%ProgramData%\Auslogics\Windows Slimmer\*.x\Reports|*.*|RECURSE
 
 [Auto Text Expander *]
 LangSecRef=3021
@@ -3986,14 +3986,14 @@ FileKey1=%AppData%\AVAST Software\Avast\Cache|*-journal;LOG;LOG.old;Network Pers
 FileKey2=%AppData%\AVAST Software\Avast\Cache\*Cache|*.*|RECURSE
 FileKey3=%AppData%\AVAST Software\Avast\Cache\blob_storage|*.*|RECURSE
 FileKey4=%AppData%\AVAST Software\Avast\log|*.*
-FileKey5=%CommonAppData%\Alwil Software\Avast*\log|*.*
-FileKey6=%CommonAppData%\Alwil Software\Avast*\report|*.txt
-FileKey7=%CommonAppData%\AVAST Software\Avast|*.obsolete;*.old;backend.txt;Log.db
-FileKey8=%CommonAppData%\AVAST Software\Avast\backup|*.*|RECURSE
-FileKey9=%CommonAppData%\AVAST Software\Avast\log|*.*
-FileKey10=%CommonAppData%\AVAST Software\Avast\report|*.txt
-FileKey11=%CommonAppData%\AVAST Software\Browser|*.*|RECURSE
-FileKey12=%CommonAppData%\AVAST Software\Persistent Data\Avast\Logs|*.log
+FileKey5=%ProgramData%\Alwil Software\Avast*\log|*.*
+FileKey6=%ProgramData%\Alwil Software\Avast*\report|*.txt
+FileKey7=%ProgramData%\AVAST Software\Avast|*.obsolete;*.old;backend.txt;Log.db
+FileKey8=%ProgramData%\AVAST Software\Avast\backup|*.*|RECURSE
+FileKey9=%ProgramData%\AVAST Software\Avast\log|*.*
+FileKey10=%ProgramData%\AVAST Software\Avast\report|*.txt
+FileKey11=%ProgramData%\AVAST Software\Browser|*.*|RECURSE
+FileKey12=%ProgramData%\AVAST Software\Persistent Data\Avast\Logs|*.log
 FileKey13=%LocalAppData%\Background_Fault|debug.log
 FileKey14=%ProgramFiles%\Alwil Software\Avast*\Setup|*.log
 FileKey15=%ProgramFiles%\AVAST Software\Avast|*.tmp
@@ -4019,14 +4019,14 @@ LangSecRef=3024
 Detect=HKLM\Software\AVG
 FileKey1=%AppData%\AVG\Antivirus\cache|ChromeDWriteFontCache
 FileKey2=%AppData%\AVG\Antivirus\log|*.*|RECURSE
-FileKey3=%CommonAppData%\AVG\Antivirus|*.old
-FileKey4=%CommonAppData%\AVG\Antivirus\GrimeFighter2|*.txt
-FileKey5=%CommonAppData%\AVG\Antivirus\log|*.log
-FileKey6=%CommonAppData%\AVG\Antivirus\opm|*.*|RECURSE
-FileKey7=%CommonAppData%\AVG\Antivirus\report|*.*|RECURSE
-FileKey8=%CommonAppData%\Avg\Antivirus\SWCUData\Cache|*.*|RECURSE
-FileKey9=%CommonAppData%\Avg\Antivirus\SWCUData\icons|*.*|RECURSE
-FileKey10=%CommonAppData%\AVG\Persistent Data\Antivirus\Logs|*.*|RECURSE
+FileKey3=%ProgramData%\AVG\Antivirus|*.old
+FileKey4=%ProgramData%\AVG\Antivirus\GrimeFighter2|*.txt
+FileKey5=%ProgramData%\AVG\Antivirus\log|*.log
+FileKey6=%ProgramData%\AVG\Antivirus\opm|*.*|RECURSE
+FileKey7=%ProgramData%\AVG\Antivirus\report|*.*|RECURSE
+FileKey8=%ProgramData%\Avg\Antivirus\SWCUData\Cache|*.*|RECURSE
+FileKey9=%ProgramData%\Avg\Antivirus\SWCUData\icons|*.*|RECURSE
+FileKey10=%ProgramData%\AVG\Persistent Data\Antivirus\Logs|*.*|RECURSE
 FileKey11=%LocalAppData%\MFAData\logs|*.log*
 FileKey12=%ProgramFiles%\AVG\Antivirus|*.tmp|RECURSE
 FileKey13=%WinDir%\System32\config\systemprofile\AppData\Local\AvgSetupLog|*.*|REMOVESELF
@@ -4050,17 +4050,17 @@ FileKey4=%AppData%\AVG\AVG TuneUp\log|*.*
 FileKey5=%AppData%\AVG\AWL*\CrashDumps|*.*
 FileKey6=%AppData%\AVG\TuneUp\log|*.*
 FileKey7=%AppData%\TuneUp Software\TuneUp Utilities\CrashDumps|*.*
-FileKey8=%CommonAppData%|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
-FileKey9=%CommonAppData%\AVG\AVG TuneUp\Backups|*.rcb
-FileKey10=%CommonAppData%\AVG\AVG TuneUp\Cache|*.log
-FileKey11=%CommonAppData%\AVG\AVG TuneUp\log|*.*
-FileKey12=%CommonAppData%\AVG\AWL*|TUReportData.*.tudb
-FileKey13=%CommonAppData%\AVG\Icarus\Logs|*.*
-FileKey14=%CommonAppData%\AVG\TuneUp|*.bak;*.old
-FileKey15=%CommonAppData%\AVG\TuneUp\log|*.*|RECURSE
-FileKey16=%CommonAppData%\TuneUp Software\tu*|TUReportData.*.tudb
-FileKey17=%CommonAppData%\TuneUp Software\TuneUp Utilities*|*.log|RECURSE
-FileKey18=%CommonAppData%\TuneUp Software\TuneUp Utilities\Program Statistics|*.tudb
+FileKey8=%ProgramData%|NTUSER.DAT_tureg_new.LOG*;NTUSER.DAT_tureg_old
+FileKey9=%ProgramData%\AVG\AVG TuneUp\Backups|*.rcb
+FileKey10=%ProgramData%\AVG\AVG TuneUp\Cache|*.log
+FileKey11=%ProgramData%\AVG\AVG TuneUp\log|*.*
+FileKey12=%ProgramData%\AVG\AWL*|TUReportData.*.tudb
+FileKey13=%ProgramData%\AVG\Icarus\Logs|*.*
+FileKey14=%ProgramData%\AVG\TuneUp|*.bak;*.old
+FileKey15=%ProgramData%\AVG\TuneUp\log|*.*|RECURSE
+FileKey16=%ProgramData%\TuneUp Software\tu*|TUReportData.*.tudb
+FileKey17=%ProgramData%\TuneUp Software\TuneUp Utilities*|*.log|RECURSE
+FileKey18=%ProgramData%\TuneUp Software\TuneUp Utilities\Program Statistics|*.tudb
 FileKey19=%LocalAppData%\Avg\AWL*\Log|*.log
 FileKey20=%LocalAppData%\Avg\dumps\fmw1|*.*
 FileKey21=%LocalAppData%\Microsoft\Windows|USRCLASS.DAT_tureg_new.LOG*;*.DAT_tureg_old
@@ -4115,34 +4115,34 @@ FileKey1=%AppData%\avidemux|admlog.txt
 LangSecRef=3024
 Detect1=HKCU\Software\Avira\Antivirus
 Detect2=HKLM\Software\Avira\AntiVir Desktop
-FileKey1=%CommonAppData%\Avira\Antivir*\EVENTDB\Logs|*.*
-FileKey2=%CommonAppData%\Avira\AntiVir*\IPM|*.*|RECURSE
-FileKey3=%CommonAppData%\Avira\AntiVir*\REPORTS|*.*
-FileKey4=%CommonAppData%\Avira\OptimizerHost\Logs|*.*
+FileKey1=%ProgramData%\Avira\Antivir*\EVENTDB\Logs|*.*
+FileKey2=%ProgramData%\Avira\AntiVir*\IPM|*.*|RECURSE
+FileKey3=%ProgramData%\Avira\AntiVir*\REPORTS|*.*
+FileKey4=%ProgramData%\Avira\OptimizerHost\Logs|*.*
 FileKey5=%ProgramFiles%\Avira GmbH|*.log|RECURSE
 
 [Avira Launcher *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Avira\Launcher
-FileKey1=%CommonAppData%\Avira\Launcher|*.backup
-FileKey2=%CommonAppData%\Avira\Launcher\Logfiles*|*.*
-FileKey3=%CommonAppData%\Avira\Launcher\Temp|*.*|RECURSE
+FileKey1=%ProgramData%\Avira\Launcher|*.backup
+FileKey2=%ProgramData%\Avira\Launcher\Logfiles*|*.*
+FileKey3=%ProgramData%\Avira\Launcher\Temp|*.*|RECURSE
 FileKey4=%ProgramFiles%\Avira\Launcher|*.backup
 
 [Avira Phantom VPN *]
 LangSecRef=3022
-DetectFile=%CommonAppData%\Avira\VPN
-FileKey1=%CommonAppData%\Avira\VPN|*.log
+DetectFile=%ProgramData%\Avira\VPN
+FileKey1=%ProgramData%\Avira\VPN|*.log
 
 [Avira Privacy Pal *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Avira\PrivacyPal
-FileKey1=%CommonAppData%\Avira\PrivacyPal\Logs|*.*
+DetectFile=%ProgramData%\Avira\PrivacyPal
+FileKey1=%ProgramData%\Avira\PrivacyPal\Logs|*.*
 
 [Avira System Speedup *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Avira\SystemSpeedup
-FileKey1=%CommonAppData%\Avira\SystemSpeedup\Update|*.exe
+DetectFile=%ProgramData%\Avira\SystemSpeedup
+FileKey1=%ProgramData%\Avira\SystemSpeedup\Update|*.exe
 
 [AVS Audio Converter *]
 LangSecRef=3023
@@ -4204,8 +4204,8 @@ FileKey1=%ProgramFiles%\Axigen Mail Server\log|LOG_FILE.txt
 
 [AzureWave *]
 LangSecRef=3022
-DetectFile=%CommonAppData%\AzureWave
-FileKey1=%CommonAppData%\AzureWave|*.log
+DetectFile=%ProgramData%\AzureWave
+FileKey1=%ProgramData%\AzureWave|*.log
 
 [Babylon *]
 LangSecRef=3024
@@ -4233,7 +4233,7 @@ FileKey3=%AppData%\Badlion Client\logs\launcher|*.*
 [Baidu PC Faster *]
 LangSecRef=3024
 Detect=HKCU\Software\Baidu Security
-FileKey1=%CommonAppData%\Baidu Security\RpData|*.tmp
+FileKey1=%ProgramData%\Baidu Security\RpData|*.tmp
 FileKey2=%Documents%\Baidu Security\Bav\Dump|*.*|REMOVESELF
 FileKey3=%Documents%\Baidu Security\PC Faster\*\Dump|*.*|REMOVESELF
 FileKey4=%Documents%\Baidu Security\PC Faster\*\log|*.*|REMOVESELF
@@ -4295,13 +4295,13 @@ Section=Games
 Detect=HKCU\Software\Blizzard Entertainment\Battle.net
 DetectFile=%ProgramFiles%\Blizzard App
 FileKey1=%AppData%\Battle.net\Telemetry|*.*
-FileKey2=%CommonAppData%\Battle.net|*.log|RECURSE
-FileKey3=%CommonAppData%\Battle.net\*\Logs|*.*|RECURSE
-FileKey4=%CommonAppData%\Battle.net\Agent\Agent.*\Logs|*.*|RECURSE
-FileKey5=%CommonAppData%\Battle.net\Client\Blizzard Launcher.*\Logs|*.*|RECURSE
-FileKey6=%CommonAppData%\Battle.net\Setup\*\Logs|*.*
-FileKey7=%CommonAppData%\Battle.net\Telemetry|*.*
-FileKey8=%CommonAppData%\Blizzard Entertainment\Battle.net\Cache|*.*|RECURSE
+FileKey2=%ProgramData%\Battle.net|*.log|RECURSE
+FileKey3=%ProgramData%\Battle.net\*\Logs|*.*|RECURSE
+FileKey4=%ProgramData%\Battle.net\Agent\Agent.*\Logs|*.*|RECURSE
+FileKey5=%ProgramData%\Battle.net\Client\Blizzard Launcher.*\Logs|*.*|RECURSE
+FileKey6=%ProgramData%\Battle.net\Setup\*\Logs|*.*
+FileKey7=%ProgramData%\Battle.net\Telemetry|*.*
+FileKey8=%ProgramData%\Blizzard Entertainment\Battle.net\Cache|*.*|RECURSE
 FileKey9=%LocalAppData%\Battle.net\BrowserCache|*.*|RECURSE
 FileKey10=%LocalAppData%\Battle.net\Cache|*.*|RECURSE
 FileKey11=%LocalAppData%\Battle.net\Errors|*.*
@@ -4363,8 +4363,8 @@ RegKey1=HKCU\Software\Benthic\PLEdit32\RecentFiles
 
 [BestBuy Software Installer *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Best Buy Software Installer
-FileKey1=%CommonAppData%\Best Buy Software Installer\Resources\Cache|*.*
+DetectFile=%ProgramData%\Best Buy Software Installer
+FileKey1=%ProgramData%\Best Buy Software Installer\Resources\Cache|*.*
 
 [Betrayer *]
 Section=Games
@@ -4391,16 +4391,16 @@ RegKey1=HKCU\Software\Bluefive\Beyondo\RecentFiles
 Section=Games
 Detect1=HKCU\Software\JollyBear\Big City Adventure San Francisco
 Detect2=HKCU\Software\JollyBear\Big City Adventure Sydney
-FileKey1=%CommonAppData%\JollyBear\Big City Adventure *|error.*
+FileKey1=%ProgramData%\JollyBear\Big City Adventure *|error.*
 
 [Big Fish Games *]
 Section=Games
 Detect=HKCU\Software\Big Fish Games
-FileKey1=%CommonAppData%\Big Fish Games\Game Manager\resources-old|*.*|RECURSE
-FileKey2=%CommonAppData%\Big Fish\Game Manager\Addons\BFGameLauncher|*.log|RECURSE
-FileKey3=%CommonAppData%\BigFishCache|*.exe|RECURSE
-FileKey4=%CommonAppData%\BigFishCache\GameManager\log|*.txt|RECURSE
-FileKey5=%CommonAppData%\BigFishGamesCache\GameManager\log|*.*
+FileKey1=%ProgramData%\Big Fish Games\Game Manager\resources-old|*.*|RECURSE
+FileKey2=%ProgramData%\Big Fish\Game Manager\Addons\BFGameLauncher|*.log|RECURSE
+FileKey3=%ProgramData%\BigFishCache|*.exe|RECURSE
+FileKey4=%ProgramData%\BigFishCache\GameManager\log|*.txt|RECURSE
+FileKey5=%ProgramData%\BigFishGamesCache\GameManager\log|*.*
 
 [BiglyBT *]
 LangSecRef=3022
@@ -4447,7 +4447,7 @@ Detect2=HKLM\Software\Bitdefender\Bitdefender Total Security
 Detect3=HKLM\Software\Bitdefender\Bitdefender Total Security 2015
 Detect4=HKLM\Software\Softwin\Bitdefender Antivirus
 FileKey1=%AppData%\Bitdefender\Desktop\profiles\Logs\*|*.xml
-FileKey2=%CommonAppData%\Bitdefender\DTrace|*.log
+FileKey2=%ProgramData%\Bitdefender\DTrace|*.log
 FileKey3=%ProgramFiles%\Softwin\Bitdefender*\Logs|*.*
 FileKey4=%SystemDrive%|bdlog.txt
 
@@ -4500,7 +4500,7 @@ FileKey7=%LocalAppData%\Research In Motion\BlackBerry*Desktop\Logs|*.*|REMOVESEL
 LangSecRef=3023
 Detect=HKCU\SOFTWARE\Blackmagic Design\DaVinci Resolve
 FileKey1=%AppData%\Blackmagic Design\DaVinci Resolve\Support\logs|*|REMOVESELF
-FileKey2=%CommonAppData%\Blackmagic Design\DaVinci Resolve\Support\logs|*|REMOVESELF
+FileKey2=%ProgramData%\Blackmagic Design\DaVinci Resolve\Support\logs|*|REMOVESELF
 
 [Blade Symphony *]
 Section=Games
@@ -4567,10 +4567,10 @@ FileKey4=%ProgramFiles%\BlueSprig\JetClean\Update|*.*|REMOVESELF
 LangSecRef=3021
 Detect1=HKCU\Software\BlueStacks
 Detect2=HKLM\Software\BlueStacks
-FileKey1=%CommonAppData%\BlueStacks\CefData\Cache|*.*|RECURSE
-FileKey2=%CommonAppData%\BlueStacks\Engine\Android\Logs|*.log*
-FileKey3=%CommonAppData%\BlueStacks\Logs|*.log|RECURSE
-FileKey4=%CommonAppData%\BlueStacksSetup|*.apk
+FileKey1=%ProgramData%\BlueStacks\CefData\Cache|*.*|RECURSE
+FileKey2=%ProgramData%\BlueStacks\Engine\Android\Logs|*.log*
+FileKey3=%ProgramData%\BlueStacks\Logs|*.log|RECURSE
+FileKey4=%ProgramData%\BlueStacksSetup|*.apk
 FileKey5=%LocalAppData%\BlueStacks|*.log
 FileKey6=%LocalAppData%\BlueStacksSetup|BlueStacksInstaller*.exe
 FileKey7=%Pictures%\BlueStacks|*_Screenshot_*.jpg
@@ -4643,8 +4643,8 @@ FileKey1=%AppData%\Breevy\Backups|*.*
 
 [Bricks of Egypt *]
 Section=Games
-DetectFile=%CommonAppData%\Arcade Lab
-FileKey1=%CommonAppData%\Arcade Lab|log.txt
+DetectFile=%ProgramData%\Arcade Lab
+FileKey1=%ProgramData%\Arcade Lab|log.txt
 
 [Broadcom Wireless LAN Driver *]
 LangSecRef=3021
@@ -4653,8 +4653,8 @@ FileKey1=%SystemDrive%\Drivers\Broadcom Wireless LAN Driver|*.log|RECURSE
 
 [BroadWave Streaming Audio *]
 LangSecRef=3022
-DetectFile=%CommonAppData%\NCH Software\BroadWave
-FileKey1=%CommonAppData%\NCH Software\BroadWave\Logs|*.*
+DetectFile=%ProgramData%\NCH Software\BroadWave
+FileKey1=%ProgramData%\NCH Software\BroadWave\Logs|*.*
 
 [Broforce *]
 Section=Games
@@ -4669,8 +4669,8 @@ FileKey1=%ProgramFiles%\ConsumerSoft\Broken Shortcut Fixer|ht.htm
 [Brother *]
 LangSecRef=3024
 Detect=HKLM\Software\Brother
-DetectFile=%CommonAppData%\Brother
-FileKey1=%CommonAppData%\Brother\BrLog|*.log
+DetectFile=%ProgramData%\Brother
+FileKey1=%ProgramData%\Brother\BrLog|*.log
 FileKey2=%ProgramFiles%\Brother|*.tmp|RECURSE
 
 [Brother P-touch *]
@@ -4755,7 +4755,7 @@ FileKey1=%AppData%\PDF Writer\Bullzip PDF Printer|user.ini
 Section=Games
 Detect1=HKCU\Software\GoBit\BurgerShop
 Detect2=HKCU\Software\GoBit\BurgerShop2
-FileKey1=%CommonAppData%\GoBit Games\BurgerShop2\*\cached|*.*|REMOVESELF
+FileKey1=%ProgramData%\GoBit Games\BurgerShop2\*\cached|*.*|REMOVESELF
 FileKey2=%ProgramFiles%\Burger Shop|*.db;*.txt|RECURSE
 FileKey3=%ProgramFiles%\Burger Shop\cached|*.*|REMOVESELF
 FileKey4=%ProgramFiles%\GoBit Games\Burger Shop 2|*.db;*.txt|RECURSE
@@ -4779,13 +4779,13 @@ FileKey1=%ProgramFiles%\Business Objects\Business Objects Enterprise 11\Logging|
 [ByteFence Anti-Malware *]
 LangSecRef=3024
 Detect=HKCU\Software\ByteFence\RTOP
-FileKey1=%CommonAppData%\ByteFence\RTOP|uclogfile.bin
+FileKey1=%ProgramData%\ByteFence\RTOP|uclogfile.bin
 FileKey2=%ProgramFiles%\ByteFence\Logs|*.*
 
 [CA Security Center *]
 LangSecRef=3021
 Detect=HKLM\Software\CA\CAPF
-FileKey1=%CommonAppData%\CA|*.log;*.txt|RECURSE
+FileKey1=%ProgramData%\CA|*.log;*.txt|RECURSE
 FileKey2=%LocalLowAppData%\CA\Consumer\APH|*.log
 
 [Calendar Magic *]
@@ -4814,7 +4814,7 @@ FileKey1=%LocalLowAppData%\Peachy Keen Games\Calico|*log
 [Call of Atlantis *]
 Section=Games
 Detect=HKLM\Software\Playrix\Call of Atlantis
-FileKey1=%CommonAppData%\Playrix Entertainment\Call of Atlantis*\Log|*.*
+FileKey1=%ProgramData%\Playrix Entertainment\Call of Atlantis*\Log|*.*
 
 [Call of Juarez *]
 Section=Games
@@ -4837,7 +4837,7 @@ FileKey1=%Documents%\My CamStudio Temp Files|*.*
 LangSecRef=3023
 Detect=HKCU\Software\TechSmith\Camtasia Studio
 FileKey1=%AppData%\TechSmith\CamtasiaStudio\Logs|*.*|RECURSE
-FileKey2=%CommonAppData%\TechSmith\Camtasia Studio *\Library *\Temp|*.*|RECURSE
+FileKey2=%ProgramData%\TechSmith\Camtasia Studio *\Library *\Temp|*.*|RECURSE
 FileKey3=%LocalAppData%\TechSmith\Camtasia Studio\*\Trackerbird_Files|tblog.log
 FileKey4=%LocalAppData%\TechSmith\Logs|*.*|RECURSE
 RegKey1=HKCU\Software\TechSmith\Camtasia Studio\9.0\Camtasia Recorder\9.0\General|lstLastSaveDir
@@ -4855,9 +4855,9 @@ RegKey12=HKCU\Software\TechSmith\Camtasia Studio\18.0\Camtasia Studio\18.0|Recen
 
 [Canon *]
 LangSecRef=3021
-DetectFile1=%CommonAppData%\CanonBJ\IJPrinter\CNMWindows\drvlog*
-DetectFile2=%CommonAppData%\CanonBJ\IJPrinter\CNMWindows\plmlog*
-FileKey1=%CommonAppData%\CanonBJ\IJPrinter\CNMWindows|drvlog*.*;plmlog*.*|RECURSE
+DetectFile1=%ProgramData%\CanonBJ\IJPrinter\CNMWindows\drvlog*
+DetectFile2=%ProgramData%\CanonBJ\IJPrinter\CNMWindows\plmlog*
+FileKey1=%ProgramData%\CanonBJ\IJPrinter\CNMWindows|drvlog*.*;plmlog*.*|RECURSE
 
 [Canon Digital Photo Professional 4 *]
 LangSecRef=3021
@@ -4867,7 +4867,7 @@ FileKey1=%AppData%\Canon_Inc_IC\DPP4\Application\Temp|*.*|RECURSE
 FileKey2=%AppData%\Canon_Inc_IC\DPP4\DppMWare\Cache|*.*|RECURSE
 FileKey3=%AppData%\Canon_Inc_IC\ServiceLog\AutoUpdateService|*.txt
 FileKey4=%AppData%\Canon_Inc_IC\ServiceLog\imagebrowserexservice|*.txt
-FileKey5=%CommonAppData%\Canon_Inc_IC\UniversalInstaller\ServiceLog|*.TXT
+FileKey5=%ProgramData%\Canon_Inc_IC\UniversalInstaller\ServiceLog|*.TXT
 
 [Canon Inkjet Print Utility *]
 LangSecRef=3031
@@ -4911,8 +4911,8 @@ LangSecRef=3024
 Detect1=HKCU\Software\Future Systems Solutions\Casper
 Detect2=HKCU\Software\Future Systems Solutions\Casper 10
 Detect3=HKCU\Software\Future Systems Solutions\Casper 11
-FileKey1=%CommonAppData%\Caphyon|*.*|REMOVESELF
-FileKey2=%CommonAppData%\Future Systems Solutions\Casper\Minidump|*.*
+FileKey1=%ProgramData%\Caphyon|*.*|REMOVESELF
+FileKey2=%ProgramData%\Future Systems Solutions\Casper\Minidump|*.*
 
 [Castle of Illusion *]
 Section=Games
@@ -4923,7 +4923,7 @@ FileKey1=%ProgramFiles%\Castle of Illusion\_CommonRedist\vcredist\*|vc*redist_x*
 Section=Games
 DetectFile=%AppData%\CasualArts
 FileKey1=%AppData%\casualArts\*|logfile.*;*.txt|RECURSE
-FileKey2=%CommonAppData%\casualArts|*.*|REMOVESELF
+FileKey2=%ProgramData%\casualArts|*.*|REMOVESELF
 
 [Cave Story+ *]
 Section=Games
@@ -4945,7 +4945,7 @@ FileKey1=%ProgramFiles%\CCleaner|winapp.ini;winreg.ini;winsys.ini;regkeys.output
 LangSecRef=3024
 Detect=HKCU\Software\Piriform\CCleaner
 DetectFile=%ProgramFiles%\CCleaner Network\Management Server
-FileKey1=%CommonAppData%\Gibraltar\Local Logs\CCleaner Network|*.glf
+FileKey1=%ProgramData%\Gibraltar\Local Logs\CCleaner Network|*.glf
 FileKey2=%ProgramFiles%\CCleaner|*.dmp;*.log;CCleaner_log*.txt;gcapi_*.dll|RECURSE
 FileKey3=%ProgramFiles%\CCleaner Network\Management Server\Logs|*.*
 FileKey4=%ProgramFiles%\CCleaner\Data\log|*.*
@@ -5016,8 +5016,8 @@ FileKey2=%ProgramFiles%\CFE Exam Prep Course\Log|*.*|RECURSE
 
 [cFosSpeed *]
 LangSecRef=3022
-DetectFile=%CommonAppData%\cFos\cFosSpeed
-FileKey1=%CommonAppData%\cFos\cFosSpeed\Logs|*.ini
+DetectFile=%ProgramData%\cFos\cFosSpeed
+FileKey1=%ProgramData%\cFos\cFosSpeed\Logs|*.ini
 
 [Chameleon *]
 LangSecRef=3024
@@ -5063,10 +5063,10 @@ FileKey1=%ProgramFiles%\Chicken Hunter|debug.txt
 [Chicken Invaders *]
 Section=Games
 DetectFile1=%AppData%\InterAction studios\CI3demo
-DetectFile2=%CommonAppData%\InterAction studios\CI2rmdemo
+DetectFile2=%ProgramData%\InterAction studios\CI2rmdemo
 DetectFile3=%ProgramFiles%\Chicken*Invaders*
 FileKey1=%AppData%\InterAction studios|*.log|RECURSE
-FileKey2=%CommonAppData%\InterAction studios|*.log|RECURSE
+FileKey2=%ProgramData%\InterAction studios|*.log|RECURSE
 FileKey3=%ProgramFiles%\*\Chicken Invaders*|*.log;*.html;*.png|RECURSE
 FileKey4=%ProgramFiles%\Chicken*Invaders*|*.log|RECURSE
 
@@ -5082,10 +5082,10 @@ FileKey1=%Documents%\My Games\Chivalry Medieval Warfare*\UDKGame\Logs|*.*
 
 [Chocolatey *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\chocolatey
+DetectFile=%ProgramData%\chocolatey
 FileKey1=%AppData%\ChocolateyGUI\Logs|*.*
-FileKey2=%CommonAppData%\chocolatey\lib\*|*.txt
-FileKey3=%CommonAppData%\chocolatey\logs|*.log
+FileKey2=%ProgramData%\chocolatey\lib\*|*.txt
+FileKey3=%ProgramData%\chocolatey\logs|*.log
 
 [ChomikBox *]
 LangSecRef=3022
@@ -5150,8 +5150,8 @@ FileKey1=%ProgramFiles%\Cinema Tycoon*|flashplayer7_winax.exe;*.txt
 
 [Cisco Connect *]
 LangSecRef=3022
-DetectFile=%CommonAppData%\Cisco Systems\Cisco Connect
-FileKey1=%CommonAppData%\Cisco Systems\Cisco Connect\Log|*.*
+DetectFile=%ProgramData%\Cisco Systems\Cisco Connect
+FileKey1=%ProgramData%\Cisco Systems\Cisco Connect\Log|*.*
 
 [Cisco HostScan *]
 LangSecRef=3021
@@ -5177,7 +5177,7 @@ FileKey1=%Documents%\Cities in Motion|log_metro.txt
 [Citrix Online Plug-in Web Setup Files *]
 LangSecRef=3021
 Detect=HKLM\Software\Citrix\ICA Client
-FileKey1=%CommonAppData%\Citrix\Citrix Online Plug-in - Web|*.msi;*.cab;eula*.rtf
+FileKey1=%ProgramData%\Citrix\Citrix Online Plug-in - Web|*.msi;*.cab;eula*.rtf
 
 [Citrix Receiver *]
 LangSecRef=3021
@@ -5236,7 +5236,7 @@ Detect1=HKCU\Software\ClamWin
 Detect2=HKLM\Software\ClamWin
 DetectFile=%SystemDrive%\PortableApps\ClamWinPortable
 FileKey1=%AppData%\.clamwin\log|*.*|RECURSE
-FileKey2=%CommonAppData%\.clamwin\log|*.*|RECURSE
+FileKey2=%ProgramData%\.clamwin\log|*.*|RECURSE
 FileKey3=%ProgramFiles%\ClamWin\bin|*.txt
 FileKey4=%SystemDrive%\PortableApps\ClamWinPortable\Data\db\clamav*|*.*|REMOVESELF
 FileKey5=%SystemDrive%\PortableApps\ClamWinPortable\Data\db\tmp.*|*.*|REMOVESELF
@@ -5289,8 +5289,8 @@ FileKey1=%LocalAppData%\click.to|*.txt|RECURSE
 
 [ClickFree Full Imaging Backup *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\ClickFree\FullImagingBackup
-FileKey1=%CommonAppData%\ClickFree\FullImagingBackup|*.log
+DetectFile=%ProgramData%\ClickFree\FullImagingBackup
+FileKey1=%ProgramData%\ClickFree\FullImagingBackup|*.log
 
 [ClipGrab *]
 LangSecRef=3023
@@ -5362,8 +5362,8 @@ RegKey3=HKCU\Software\CodeGear\BDS\6.0\Session
 
 [CodeMeter *]
 LangSecRef=3023
-DetectFile=%CommonAppData%\CodeMeter
-FileKey1=%CommonAppData%\CodeMeter\Logs|*.*
+DetectFile=%ProgramData%\CodeMeter
+FileKey1=%ProgramData%\CodeMeter\Logs|*.*
 
 [CoffeeCup GIF Animator *]
 LangSecRef=3024
@@ -5418,11 +5418,11 @@ LangSecRef=3024
 Detect=HKCU\Software\ComodoGroup
 FileKey1=%AppData%\Comodo\CCE\Logs|*.*
 FileKey2=%AppData%\ComodoGroup\CSC\Cache|*.*
-FileKey3=%CommonAppData%\Comodo Downloader|*.*
-FileKey4=%CommonAppData%\Comodo\Cis\Quarantine\Temp\TempFiles|*.*
-FileKey5=%CommonAppData%\Comodo\CisDumps|*.*
-FileKey6=%CommonAppData%\Comodo\Firewall Pro|cislogs.sdb
-FileKey7=%CommonAppData%\Comodo\Installer|*.*
+FileKey3=%ProgramData%\Comodo Downloader|*.*
+FileKey4=%ProgramData%\Comodo\Cis\Quarantine\Temp\TempFiles|*.*
+FileKey5=%ProgramData%\Comodo\CisDumps|*.*
+FileKey6=%ProgramData%\Comodo\Firewall Pro|cislogs.sdb
+FileKey7=%ProgramData%\Comodo\Installer|*.*
 FileKey8=%LocalAppData%\COMODO|*.tmp
 FileKey9=%ProgramFiles%\COMODO\COMODO Internet Security|*.tmp;CRASH.DMP;cmdagent.zip
 
@@ -5467,8 +5467,8 @@ FileKey1=%AppData%\Rizonesoft\ComIntRep\Logging|*.*|RECURSE
 [Conceiva Mezzmo *]
 LangSecRef=3023
 Detect=HKLM\Software\Conceiva\Mezzmo
-FileKey1=%CommonAppData%\Conceiva\*|*.bat;*.exe;*.txt
-FileKey2=%CommonAppData%\Conceiva\Mezzmo\CER|*.zip
+FileKey1=%ProgramData%\Conceiva\*|*.bat;*.exe;*.txt
+FileKey2=%ProgramData%\Conceiva\Mezzmo\CER|*.zip
 FileKey3=%LocalAppData%\Conceiva\Logs|*.*|REMOVESELF
 FileKey4=%LocalAppData%\Conceiva\Mezzmo|DebugCERwrite.txt
 FileKey5=%LocalAppData%\Conceiva\Mezzmo\Temporary_*_Files|*.*|REMOVESELF
@@ -5502,13 +5502,13 @@ FileKey18=%WinDir%\System32|ConduitEngine.tmp
 [Conexant *]
 LangSecRef=3024
 Detect=HKCU\Software\Conexant
-FileKey1=%CommonAppData%\Conexant\UCILogs\COINST|*.log
+FileKey1=%ProgramData%\Conexant\UCILogs\COINST|*.log
 FileKey2=%Public%|CAFADEBUG.log
 
 [Connectify Hotspot *]
 LangSecRef=3022
 Detect=HKLM\Software\Connectify
-FileKey1=%CommonAppData%\Connectify\cache|*.time;*.cache;*.runtime
+FileKey1=%ProgramData%\Connectify\cache|*.time;*.cache;*.runtime
 FileKey2=%ProgramFiles%\Connectify\Installer|*.*|REMOVESELF
 FileKey3=%ProgramFiles%\Connectify\Portal|*.*|REMOVESELF
 
@@ -5609,9 +5609,9 @@ RegKey40=HKCU\Software\kishDesign\CopyTo\settings3|target09
 [CopyTrans *]
 LangSecRef=3023
 DetectFile1=%AppData%\WindSolutions\CopyTrans*
-DetectFile2=%CommonAppData%\WindSolutions\CopyTrans*
-FileKey1=%CommonAppData%\WindSolutions|*.txt|RECURSE
-FileKey2=%CommonAppData%\WindSolutions\CopyTrans*\Logs|*.*|RECURSE
+DetectFile2=%ProgramData%\WindSolutions\CopyTrans*
+FileKey1=%ProgramData%\WindSolutions|*.txt|RECURSE
+FileKey2=%ProgramData%\WindSolutions\CopyTrans*\Logs|*.*|RECURSE
 
 [Core Temp *]
 LangSecRef=3024
@@ -5626,8 +5626,8 @@ FileKey2=%LocalAppData%\Corel\AfterShot Pro *\Cache|*.*|RECURSE
 
 [Corel Downloads *]
 LangSecRef=3021
-DetectFile=%CommonAppData%\Corel\Downloads
-FileKey1=%CommonAppData%\Corel\Downloads|*.*|RECURSE
+DetectFile=%ProgramData%\Corel\Downloads
+FileKey1=%ProgramData%\Corel\Downloads|*.*|RECURSE
 
 [Corel PaintShop Pro *]
 LangSecRef=3023
@@ -5677,7 +5677,7 @@ RegKey6=HKCU\Software\Corel\User Assistant\X4\Recent Work\Presentations
 [CorelDRAW Graphics Suite X7 *]
 LangSecRef=3021
 Detect=HKCU\Software\Corel\CorelDRAW\17.0
-FileKey1=%CommonAppData%\Bitstream\Font Navigator\6.0\Cache|*.*|RECURSE
+FileKey1=%ProgramData%\Bitstream\Font Navigator\6.0\Cache|*.*|RECURSE
 FileKey2=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Config|corelpdf.ini;capture.ini
 FileKey3=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Connect|Connect.config
 FileKey4=%LocalAppData%\Corel\CorelDRAW Graphics Suite X7\Draw|FindAndReplaceMRU.xml
@@ -5696,9 +5696,9 @@ RegKey7=HKCU\Software\Corel\CorelDRAW\17.0\PHOTO-PAINT\Application Preferences\F
 
 [Corsair iCue *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Corsair\CUE\Service logs
-FileKey1=%CommonAppData%\Corsair\CorsairLLAccessService|*.log
-FileKey2=%CommonAppData%\Corsair\CUE\Service logs|Service_Trace*.log
+DetectFile=%ProgramData%\Corsair\CUE\Service logs
+FileKey1=%ProgramData%\Corsair\CorsairLLAccessService|*.log
+FileKey2=%ProgramData%\Corsair\CUE\Service logs|Service_Trace*.log
 FileKey3=%LocalAppData%\Corsair\CUE\logs|*.log
 
 [Cortana *]
@@ -5738,7 +5738,7 @@ FileKey4=%ProgramFiles%\Counter-Strike*\valve\bin|*.log
 [CounterSpy *]
 LangSecRef=3024
 Detect=HKLM\Software\Sunbelt Software\CounterSpy
-FileKey1=%CommonAppData%\Sunbelt Software\CounterSpy\Logs|*.*
+FileKey1=%ProgramData%\Sunbelt Software\CounterSpy\Logs|*.*
 
 [CrashRpt *]
 LangSecRef=3024
@@ -5775,8 +5775,8 @@ LangSecRef=3024
 Detect1=HKLM\Software\CREATIVE TECH\Software Installed\Software Update
 Detect2=HKLM\Software\CREATIVE TECH\Sound Blaster X-Fi MB
 Detect3=HKLM\Software\CREATIVE TECH\Sound Blaster Z-Series Control Panel
-FileKey1=%CommonAppData%\Creative\Software Update\Cache|*.*|RECURSE
-FileKey2=%CommonAppData%\Creative\Software Update\Log|*.*
+FileKey1=%ProgramData%\Creative\Software Update\Cache|*.*|RECURSE
+FileKey2=%ProgramData%\Creative\Software Update\Log|*.*
 
 [Cricut Design Space *]
 LangSecRef=3021
@@ -5901,11 +5901,11 @@ FileKey2=%LocalAppData%\ZookaWare\ScanLogs|*.log
 LangSecRef=3023
 Detect=HKCU\Software\CyberLink
 FileKey1=%AppData%\CyberLink\MediaCache|*.*|RECURSE
-FileKey2=%CommonAppData%\CyberLink\Boomerang\*|*.xml;*.dmp
-FileKey3=%CommonAppData%\CyberLink\CBE\*|*.*|RECURSE
-FileKey4=%CommonAppData%\CyberLink\Downloader|*.*|RECURSE
-FileKey5=%CommonAppData%\install_backup|*.*|REMOVESELF
-FileKey6=%CommonAppData%\install_clap|*.*|REMOVESELF
+FileKey2=%ProgramData%\CyberLink\Boomerang\*|*.xml;*.dmp
+FileKey3=%ProgramData%\CyberLink\CBE\*|*.*|RECURSE
+FileKey4=%ProgramData%\CyberLink\Downloader|*.*|RECURSE
+FileKey5=%ProgramData%\install_backup|*.*|REMOVESELF
+FileKey6=%ProgramData%\install_clap|*.*|REMOVESELF
 RegKey1=HKCU\Software\CyberLink\DSSharedMediaInfo\SharedInfoCache
 RegKey2=HKCU\Software\CyberLink\MediaCache\Data4
 RegKey3=HKCU\Software\CyberLink\MediaCache\Thumbnail4
@@ -6040,7 +6040,7 @@ RegKey56=HKCU\Software\CyberLink\WaveEditor\2.0|WorkDir
 LangSecRef=3023
 Detect=HKCU\Software\Cyberlink\PowerCinema
 DetectFile=%LocalAppData%\PowerCinema
-FileKey1=%CommonAppData%|{*-*-*-*-*}.log
+FileKey1=%ProgramData%|{*-*-*-*-*}.log
 FileKey2=%LocalAppData%\PowerCinema|trace.*
 
 [CyberLink PowerDirector *]
@@ -6095,9 +6095,9 @@ Detect7=HKCU\Software\CyberLink\PowerDVD20
 Detect8=HKCU\Software\CyberLink\PowerDVD21
 Detect9=HKCU\Software\CyberLink\PowerDVD22
 FileKey1=%AppData%\CyberLink\Webview|*.old|RECURSE
-FileKey2=%CommonAppData%\Cyberlink\Evoparser|*.xml
-FileKey3=%CommonAppData%\CyberLink\PowerDVD*\Boomerang\*|*.xml;*.dmp
-FileKey4=%CommonAppData%\SUPPORTDIR\*|*.log
+FileKey2=%ProgramData%\Cyberlink\Evoparser|*.xml
+FileKey3=%ProgramData%\CyberLink\PowerDVD*\Boomerang\*|*.xml;*.dmp
+FileKey4=%ProgramData%\SUPPORTDIR\*|*.log
 FileKey5=%LocalAppData%\Cyberlink\DigitalHome|*.log|RECURSE
 FileKey6=%LocalAppData%\Cyberlink\PowerDVD*|*.log|RECURSE
 FileKey7=%LocalAppData%\Cyberlink\PowerDVD*\*\PowerDVDMainAP|*.*|RECURSE
@@ -6178,7 +6178,7 @@ Detect3=HKLM\Software\Disc Soft
 Detect4=HKLM\Software\DT Soft
 FileKey1=%AppData%\DAEMON Tools*|ImgList.dat
 FileKey2=%AppData%\DAEMON Tools*\*Cache|*.*|RECURSE
-FileKey3=%CommonAppData%\DAEMON Tools*\Temp|*.*|RECURSE
+FileKey3=%ProgramData%\DAEMON Tools*\Temp|*.*|RECURSE
 RegKey1=HKCU\Software\Disc Soft\DAEMON Tools Pro\GuiNamespace|MountFolder
 RegKey2=HKCU\Software\DT Soft\DAEMON Tools Pro\GuiNamespace|MountFolder
 
@@ -6363,7 +6363,7 @@ FileKey1=%Documents%\Skyfallen Entertaiment\DeathTrack\Logs|*.*
 [Debenu *]
 LangSecRef=3021
 Detect=HKCU\Software\Debenu
-FileKey1=%CommonAppData%\Debenu\PDF Tools\Reports\App Log|*.*
+FileKey1=%ProgramData%\Debenu\PDF Tools\Reports\App Log|*.*
 RegKey1=HKCU\Software\Debenu\Debenu PDF Maximus 2\MaximusViewerRecentDocs
 RegKey2=HKCU\Software\Debenu\Debenu PDF Maximus 2\MaximusViewerRecentFolders
 
@@ -6414,23 +6414,23 @@ LangSecRef=3024
 Detect1=HKLM\Software\Dell
 Detect2=HKLM\Software\PC-Doctor
 DetectFile1=%AppData%\Creative\DELL Webcam Center
-DetectFile2=%CommonAppData%\Dell
+DetectFile2=%ProgramData%\Dell
 DetectFile3=%LocalAppData%\Dell
 DetectFile4=%LocalAppData%\SupportSoft\DellSupportCenter
 DetectFile5=%ProgramFiles%\Dell*
 FileKey1=%AppData%\Creative\DELL Webcam Center|MO_Log.txt
 FileKey2=%AppData%\PCDr\*\Logs|*
-FileKey3=%CommonAppData%\Dell\*\Log*|*|RECURSE
-FileKey4=%CommonAppData%\Dell\BiosVerification|*.log
-FileKey5=%CommonAppData%\Dell\D3\pla\*\*|*.log;*.txt|REMOVESELF
-FileKey6=%CommonAppData%\Dell\D3\Resources\Logs\serilog|*
-FileKey7=%CommonAppData%\Dell\Drivers\*|*.log;*.tmp|RECURSE
-FileKey8=%CommonAppData%\Dell\orca\deviceq|*
-FileKey9=%CommonAppData%\Dell\SupportAssist|*|RECURSE
-FileKey10=%CommonAppData%\Dell\TrustedDevice|*.log
-FileKey11=%CommonAppData%\Dell\Update|*.txt
-FileKey12=%CommonAppData%\Dell\UpdateService|*.log;*.txt|RECURSE
-FileKey13=%CommonAppData%\PCDr\*\Logs|*
+FileKey3=%ProgramData%\Dell\*\Log*|*|RECURSE
+FileKey4=%ProgramData%\Dell\BiosVerification|*.log
+FileKey5=%ProgramData%\Dell\D3\pla\*\*|*.log;*.txt|REMOVESELF
+FileKey6=%ProgramData%\Dell\D3\Resources\Logs\serilog|*
+FileKey7=%ProgramData%\Dell\Drivers\*|*.log;*.tmp|RECURSE
+FileKey8=%ProgramData%\Dell\orca\deviceq|*
+FileKey9=%ProgramData%\Dell\SupportAssist|*|RECURSE
+FileKey10=%ProgramData%\Dell\TrustedDevice|*.log
+FileKey11=%ProgramData%\Dell\Update|*.txt
+FileKey12=%ProgramData%\Dell\UpdateService|*.log;*.txt|RECURSE
+FileKey13=%ProgramData%\PCDr\*\Logs|*
 FileKey14=%LocalAppData%\Dell\*\Log|*
 FileKey15=%LocalAppData%\Dell\DellMobileConnect|*.log
 FileKey16=%LocalAppData%\SupportSoft\DellSupportCenter\*\state\logs|*
@@ -6479,13 +6479,13 @@ FileKey6=%LocalAppData%\Packages\ScreenovateTechnologies.DellMobileConnect_*\Tem
 
 [Dell PC Doctor *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\PCDr
-FileKey1=%CommonAppData%\PCDr|*.dmp|RECURSE
-FileKey2=%CommonAppData%\PCDr\*\Cache|*.xml
-FileKey3=%CommonAppData%\PCDr\*\Cache\archives|*.*|RECURSE
-FileKey4=%CommonAppData%\PCDr\*\Cache\BUMA|*.*
-FileKey5=%CommonAppData%\PCDr\*\Cache\DriverScan|*.*
-FileKey6=%CommonAppData%\PCDr\*\Snapshots\*|*.*
+DetectFile=%ProgramData%\PCDr
+FileKey1=%ProgramData%\PCDr|*.dmp|RECURSE
+FileKey2=%ProgramData%\PCDr\*\Cache|*.xml
+FileKey3=%ProgramData%\PCDr\*\Cache\archives|*.*|RECURSE
+FileKey4=%ProgramData%\PCDr\*\Cache\BUMA|*.*
+FileKey5=%ProgramData%\PCDr\*\Cache\DriverScan|*.*
+FileKey6=%ProgramData%\PCDr\*\Snapshots\*|*.*
 
 [Dell Power Manager *]
 LangSecRef=3031
@@ -6527,13 +6527,13 @@ FileKey7=%LocalAppData%\Dell\VideoStage\Library\*|kthumb*.db;log.*
 LangSecRef=3031
 Detect1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\DellInc.DellSupportAssistforPCs_htrsf667h5kn2
 Detect2=HKLM\Software\Dell\SupportAssistAgent
-FileKey1=%CommonAppData%\SupportAssist\Client\Agent\Downloads|*.*|RECURSE
-FileKey2=%CommonAppData%\SupportAssist\Client\Agent\Logs\*|*.*|REMOVESELF
-FileKey3=%CommonAppData%\SupportAssist\Client\SRE|*.log
-FileKey4=%CommonAppData%\SupportAssist\Client\SRE\ExtendedLogs|*.*
-FileKey5=%CommonAppData%\SupportAssist\Client\TechnicianToolkit\Library\Logs|*.*|RECURSE
-FileKey6=%CommonAppData%\SupportAssist\Client\TechnicianToolkit\Library\RegBackup|*.*
-FileKey7=%CommonAppData%\SupportAssist\Client\TechnicianToolkit\Library\Temp|*.*|RECURSE
+FileKey1=%ProgramData%\SupportAssist\Client\Agent\Downloads|*.*|RECURSE
+FileKey2=%ProgramData%\SupportAssist\Client\Agent\Logs\*|*.*|REMOVESELF
+FileKey3=%ProgramData%\SupportAssist\Client\SRE|*.log
+FileKey4=%ProgramData%\SupportAssist\Client\SRE\ExtendedLogs|*.*
+FileKey5=%ProgramData%\SupportAssist\Client\TechnicianToolkit\Library\Logs|*.*|RECURSE
+FileKey6=%ProgramData%\SupportAssist\Client\TechnicianToolkit\Library\RegBackup|*.*
+FileKey7=%ProgramData%\SupportAssist\Client\TechnicianToolkit\Library\Temp|*.*|RECURSE
 FileKey8=%LocalAppData%\Packages\DellInc.DellSupportAssistforPCs_*\AC\AppCache|*.*|RECURSE
 FileKey9=%LocalAppData%\Packages\DellInc.DellSupportAssistforPCs_*\AC\Inet*|*.*|RECURSE
 FileKey10=%LocalAppData%\Packages\DellInc.DellSupportAssistforPCs_*\AC\Microsoft\CryptnetUrlCache|*.*|RECURSE
@@ -6547,7 +6547,7 @@ FileKey16=%LocalAppData%\Packages\DellInc.DellSupportAssistforPCs_*\TempState|*.
 [Dell Update *]
 LangSecRef=3031
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\DellInc.DellUpdate_htrsf667h5kn2
-FileKey1=%CommonAppData%\Dell\UpdateService\Downloads\*|*.*|REMOVESELF
+FileKey1=%ProgramData%\Dell\UpdateService\Downloads\*|*.*|REMOVESELF
 FileKey2=%LocalAppData%\Packages\DellInc.DellUpdate_*\AC\Temp|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\DellInc.DellUpdate_*\LocalCache\Local\Microsoft\CLR_v4.0\UsageLogs|*.log
 FileKey4=%LocalAppData%\Packages\DellInc.DellUpdate_*\LocalCache\Local\Microsoft\Windows\Caches|*.*
@@ -6627,7 +6627,7 @@ FileKey2=%LocalAppData%\DFX\*\Tmp|*.*|REMOVESELF
 Section=Games
 Detect1=HKCU\Software\Blizzard Entertainment\D3
 Detect2=HKCU\Software\Blizzard Entertainment\Diablo II
-FileKey1=%CommonAppData%\Battle.net\Setup\diablo3_engb\Log|*.*
+FileKey1=%ProgramData%\Battle.net\Setup\diablo3_engb\Log|*.*
 FileKey2=%Documents%\Diablo II\GameLogs|*.txt
 FileKey3=%ProgramFiles%\Diablo II|*.log;BnetLog.txt;D*.txt
 FileKey4=%ProgramFiles%\Diablo III*\Logs|*.*
@@ -6640,8 +6640,8 @@ FileKey1=%ProgramFiles%\Diagnose Windows|*.log
 
 [Digi Net Mobile *]
 LangSecRef=3021
-DetectFile=%CommonAppData%\Digi Net Mobile
-FileKey1=%CommonAppData%\Digi Net Mobile\log|*.log;*.txt
+DetectFile=%ProgramData%\Digi Net Mobile
+FileKey1=%ProgramData%\Digi Net Mobile\log|*.log;*.txt
 
 [Digital Janitor *]
 LangSecRef=3024
@@ -6724,7 +6724,7 @@ FileKey2=%AppData%\KoshyJohn.com\DiskMax\bin|*.log
 LangSecRef=3024
 Detect=HKCU\Software\Binary Fortress Software\DisplayFusion
 FileKey1=%AppData%\DisplayFusion|DisplayFusionSetup.exe;DisplayFusion*.log;DebugInfo.*
-FileKey2=%CommonAppData%\Binary Fortress Software\DisplayFusion|DisplayFusionSetup.exe;*.log
+FileKey2=%ProgramData%\Binary Fortress Software\DisplayFusion|DisplayFusionSetup.exe;*.log
 FileKey3=%LocalAppData%\DisplayFusion|*.log
 
 [DivFix++ *]
@@ -6740,7 +6740,7 @@ Detect2=HKLM\Software\DivXNetworks
 FileKey1=%AppData%\DivX|Font Cache.*|RECURSE
 FileKey2=%AppData%\DivX\DivX Codec|statistics.xml
 FileKey3=%AppData%\DivX\DMS\logs|*.*
-FileKey4=%CommonAppData%\DivX|*.log|RECURSE
+FileKey4=%ProgramData%\DivX|*.log|RECURSE
 FileKey5=%Video%\DivX Movies|*.*|RECURSE
 RegKey1=HKCU\Software\DivX\Settings\Converter|lastBrowseDir
 RegKey2=HKCU\Software\DivX\Settings\Converter|outputDir
@@ -6868,7 +6868,7 @@ FileKey1=%ProgramFiles%\Sincell\Double Vision 3.0.0\Logs|*.*
 LangSecRef=3022
 Detect=HKCU\Software\SpeedBit\Download Accelerator
 DetectFile=%ProgramFiles%\DAP
-FileKey1=%CommonAppData%\SpeedBit\DAP\Plugins\Log|*.*
+FileKey1=%ProgramData%\SpeedBit\DAP\Plugins\Log|*.*
 
 [Download Free Music *]
 LangSecRef=3022
@@ -6913,7 +6913,7 @@ FileKey2=%LocalAppData%\Dassault Systemes\DraftSight\cache|*.*|RECURSE
 Section=Games
 Detect1=HKCU\Software\BioWare\Dragon Age
 Detect2=HKLM\Software\BioWare\Dragon Age
-FileKey1=%CommonAppData%\BioWare\Dragon Age\DA Updater\Logs|*.*
+FileKey1=%ProgramData%\BioWare\Dragon Age\DA Updater\Logs|*.*
 FileKey2=%Documents%|DAO Ultimate Addins Updater.log
 FileKey3=%Documents%\BioWare\Dragon Age\Logs|*.*
 
@@ -7007,10 +7007,10 @@ FileKey2=%Documents%\DriverEasy|*.*|RECURSE
 LangSecRef=3024
 Detect=HKLM\Software\Driver-Soft\DriverGenius
 DetectFile=%ProgramFiles%\Driver-Soft\DriverGenius
-FileKey1=%CommonAppData%\DriverGenius|*.log
-FileKey2=%CommonAppData%\DriverGenius\Downloads|*.*
-FileKey3=%CommonAppData%\DriverGenius\InstalledUpdates|*.*
-FileKey4=%CommonAppData%\DriverGenius\Temp|*.*
+FileKey1=%ProgramData%\DriverGenius|*.log
+FileKey2=%ProgramData%\DriverGenius\Downloads|*.*
+FileKey3=%ProgramData%\DriverGenius\InstalledUpdates|*.*
+FileKey4=%ProgramData%\DriverGenius\Temp|*.*
 FileKey5=%LocalAppData%\DriverGenius|ScanLog.log
 
 [DriverMax *]
@@ -7057,7 +7057,7 @@ FileKey3=%AppData%\Dropbox\Cache|*.*|RECURSE
 FileKey4=%AppData%\Dropbox\installer|*.*|RECURSE
 FileKey5=%AppData%\Dropbox\logs|*.*|RECURSE
 FileKey6=%AppData%\DropBoxOem\Log|*.*|RECURSE
-FileKey7=%CommonAppData%\Dropbox\Update\Log|*.*
+FileKey7=%ProgramData%\Dropbox\Update\Log|*.*
 FileKey8=%Documents%\Dropbox\.dropbox.cache|*.*|RECURSE
 FileKey9=%LocalAppData%\Dropbox\Crashpad\reports|*.dmp
 FileKey10=%LocalAppData%\Dropbox\CrashReports|*.*|RECURSE
@@ -7076,7 +7076,7 @@ FileKey1=%ProgramFiles%\DSDCS|*.log|RECURSE
 [DU Meter *]
 LangSecRef=3022
 Detect=HKCU\Software\Hagel\DU Meter
-FileKey1=%CommonAppData%\Hagel Technologies\DU Meter|*.csv;error.elf
+FileKey1=%ProgramData%\Hagel Technologies\DU Meter|*.csv;error.elf
 
 [DuckieTV *]
 LangSecRef=3023
@@ -7154,8 +7154,8 @@ FileKey4=%SystemDrive%\dvbdream\Logs|*.*
 LangSecRef=3023
 Detect=HKLM\Software\CM&V\DVBViewer
 FileKey1=%AppData%\CMUV\DVBViewer*|*.bak;*.log
-FileKey2=%CommonAppData%\CMUV\DVBViewer*|*.bak;*.log
-FileKey3=%CommonAppData%\CMUV\DVBViewer\backup|*.*|REMOVESELF
+FileKey2=%ProgramData%\CMUV\DVBViewer*|*.bak;*.log
+FileKey3=%ProgramData%\CMUV\DVBViewer\backup|*.*|REMOVESELF
 FileKey4=%ProgramFiles%\DVBViewer\backup|*.*|REMOVESELF
 FileKey5=%ProgramFiles%\DVBViewer\GraphPresets|*.fgp
 FileKey6=%ProgramFiles%\DVBViewer\Remotes|*.*
@@ -7167,7 +7167,7 @@ LangSecRef=3023
 Detect1=HKCU\Software\Dvd-cloner
 Detect2=HKCU\Software\DVD-Cloner Gold
 FileKey1=%AppData%\DVD-Cloner*|*.log
-FileKey2=%CommonAppData%\DVD-Cloner*|*.log
+FileKey2=%ProgramData%\DVD-Cloner*|*.log
 FileKey3=%Documents%|Smart.log;Smart_result.log
 FileKey4=%ProgramFiles%\DVD-Cloner Platinum\*\readcache|*.*
 FileKey5=%ProgramFiles%\DVD-Cloner*|*.log|RECURSE
@@ -7177,8 +7177,8 @@ FileKey7=%WinDir%\System32|dvdtest10024.dat
 [DVD-Ranger *]
 LangSecRef=3021
 Detect=HKLM\Software\DVD-Ranger
-FileKey1=%CommonAppData%\DVDRanger\DDF626ADdvdcss|*.*
-FileKey2=%CommonAppData%\DVDRanger\Logs|*.*
+FileKey1=%ProgramData%\DVDRanger\DDF626ADdvdcss|*.*
+FileKey2=%ProgramData%\DVDRanger\Logs|*.*
 FileKey3=%Documents%\DVDRanger\Screenshots|*.*|RECURSE
 FileKey4=%Documents%\DVDRanger\Temp|*.*|REMOVESELF
 FileKey5=%SystemDrive%\DVDRanger|*.*|REMOVESELF
@@ -7191,7 +7191,7 @@ FileKey1=%AppData%\DVD Flick|dvdflick.log;report.txt
 [DVD Shrink *]
 LangSecRef=3023
 Detect=HKCU\Software\DVD Shrink
-FileKey1=%CommonAppData%\DVD Shrink|*.*
+FileKey1=%ProgramData%\DVD Shrink|*.*
 
 [dvdcss *]
 LangSecRef=3023
@@ -7278,7 +7278,7 @@ FileKey2=%Documents%\Dying*Light\Out\Screenshots|screen_*.tga
 [Dyn Updater *]
 LangSecRef=3022
 Detect=HKCU\Software\Dyn\Dyn Updater
-FileKey1=%CommonAppData%\Dyn\Updater|*.log;*.msi
+FileKey1=%ProgramData%\Dyn\Updater|*.log;*.msi
 
 [Dynamo *]
 LangSecRef=3021
@@ -7291,11 +7291,11 @@ Detect1=HKCU\Software\EA Games\EA Core
 Detect2=HKLM\Software\EA Games\EA Core
 Detect3=HKLM\SOFTWARE\Electronic Arts\EA Desktop
 Detect4=HKLM\Software\Electronic Arts\EADM
-FileKey1=%CommonAppData%\EA Core\Cache|*|REMOVESELF
-FileKey2=%CommonAppData%\EA Desktop\Logs|*
-FileKey3=%CommonAppData%\EA Logs|*
-FileKey4=%CommonAppData%\Electronic Arts\EA Core\logs|*
-FileKey5=%CommonAppData%\Origin\Logs|*
+FileKey1=%ProgramData%\EA Core\Cache|*|REMOVESELF
+FileKey2=%ProgramData%\EA Desktop\Logs|*
+FileKey3=%ProgramData%\EA Logs|*
+FileKey4=%ProgramData%\Electronic Arts\EA Core\logs|*
+FileKey5=%ProgramData%\Origin\Logs|*
 FileKey6=%LocalAppData%\EA Core\Cache|*|REMOVESELF
 FileKey7=%LocalAppData%\EADesktop\cache|*|REMOVESELF
 FileKey8=%LocalAppData%\EADesktop\QtWebEngine\Default|*state;quota*;visited*
@@ -7374,7 +7374,7 @@ FileKey1=%ProgramFiles%\EaseUS\Todo Backup\bin|easeus.log;TbLogsysClient.tblog
 [East-Tec Eraser *]
 LangSecRef=3024
 Detect=HKLM\Software\East-Tec\east-tec Eraser
-FileKey1=%CommonAppData%\East-Tec\east-tec Eraser\Updates|*.*|RECURSE
+FileKey1=%ProgramData%\East-Tec\east-tec Eraser\Updates|*.*|RECURSE
 FileKey2=%ProgramFiles%\east-tec Eraser|except.log
 
 [Easy Anti-Cheat *]
@@ -7481,7 +7481,7 @@ Detect6=HKCU\Software\ElcomSoft\Elcomsoft Phone Password Breaker
 Detect7=HKCU\Software\ElcomSoft\Elcomsoft Proactive Password Auditor
 Detect8=HKCU\Software\ElcomSoft\Elcomsoft Wireless Security Auditor
 FileKey1=%AppData%\Elcomsoft\Elcomsoft Phone Password Breaker|*.log
-FileKey2=%CommonAppData%\Elcomsoft Password Recovery\Distributed Password Recovery\Logs|*.*
+FileKey2=%ProgramData%\Elcomsoft Password Recovery\Distributed Password Recovery\Logs|*.*
 FileKey3=%ProgramFiles%\Elcomsoft Password Recovery\*|*.log;*log.txt
 RegKey1=HKCU\Software\ElcomSoft\Advanced Archive Password Recovery\Paths
 RegKey2=HKCU\Software\ElcomSoft\Advanced Archive Password Recovery\Recent Files
@@ -7499,8 +7499,8 @@ RegKey13=HKCU\Software\ElcomSoft\Advanced PDF Password Recovery\Recent Files
 
 [Electric Sheep *]
 LangSecRef=3021
-DetectFile=%CommonAppData%\ElectricSheep
-FileKey1=%CommonAppData%\ElectricSheep\Logs|*.*
+DetectFile=%ProgramData%\ElectricSheep
+FileKey1=%ProgramData%\ElectricSheep\Logs|*.*
 
 [ElsterFormular *]
 LangSecRef=3021
@@ -7508,7 +7508,7 @@ DetectFile=%AppData%\elsterformular
 FileKey1=%AppData%\elsterformular\*\log|*.log*
 FileKey2=%AppData%\elsterformular\*\tmp|*.*|RECURSE
 FileKey3=%AppData%\elsterformular\pluginmanager\data|*_cpy.zip
-FileKey4=%CommonAppData%\elsterformular\log|*.log
+FileKey4=%ProgramData%\elsterformular\log|*.log
 FileKey5=%LocalAppData%\.elfohilfe|*.*|REMOVESELF
 FileKey6=%LocalAppData%\elfopatch|*.*|REMOVESELF
 
@@ -7534,8 +7534,8 @@ FileKey1=%LocalLowAppData%\EmailTray|*.log|RECURSE
 
 [EMCO Software *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\EMCO
-FileKey1=%CommonAppData%\EMCO\Setup|*.*|REMOVESELF
+DetectFile=%ProgramData%\EMCO
+FileKey1=%ProgramData%\EMCO\Setup|*.*|REMOVESELF
 
 [EmEditor *]
 LangSecRef=3024
@@ -7570,8 +7570,8 @@ FileKey2=%ProgramFiles%\Emsisoft HiJackFree\Logs|*.*
 [eMule *]
 LangSecRef=3022
 Detect=HKCU\Software\eMule
-FileKey1=%CommonAppData%\eMule\config|*.bak;*.old
-FileKey2=%CommonAppData%\eMule\logs|*.*
+FileKey1=%ProgramData%\eMule\config|*.bak;*.old
+FileKey2=%ProgramData%\eMule\logs|*.*
 FileKey3=%LocalAppData%\eMule\config|*.bak;*.old
 FileKey4=%LocalAppData%\eMule\logs|*.*
 FileKey5=%ProgramFiles%\eMule\config|*.bak;*.old
@@ -7596,7 +7596,7 @@ FileKey1=%Documents%\Endless Space*\Temporary Files|*.html
 LangSecRef=3021
 Detect=HKLM\Software\ISI ResearchSoft\EndNote
 FileKey1=%AppData%\EndNote|*.log;*.16
-FileKey2=%CommonAppData%\Thomson.ResearchSoft.Installers|*.*|REMOVESELF
+FileKey2=%ProgramData%\Thomson.ResearchSoft.Installers|*.*|REMOVESELF
 FileKey3=%CommonProgramFiles%\Risxtd|*.LOG;*.txt
 FileKey4=%Documents%\My EndNote Library.Data\Trash|*.*|RECURSE
 FileKey5=%ProgramFiles%\EndNote X6\Product-Support\ThirdParty\Apache2|NOTICE
@@ -7643,9 +7643,9 @@ FileKey1=%ProgramFiles%\Eraser*|schedlog.txt
 [ESET *]
 LangSecRef=3021
 Detect=HKLM\Software\ESET\ESET Security
-FileKey1=%CommonAppData%\ESET\ESET*\Logs|*.*|RECURSE
-FileKey2=%CommonAppData%\ESET\ESET*\Oldfiles|*.*|RECURSE
-FileKey3=%CommonAppData%\ESET\ESET*\Updfiles|*.*|REMOVESELF
+FileKey1=%ProgramData%\ESET\ESET*\Logs|*.*|RECURSE
+FileKey2=%ProgramData%\ESET\ESET*\Oldfiles|*.*|RECURSE
+FileKey3=%ProgramData%\ESET\ESET*\Updfiles|*.*|REMOVESELF
 FileKey4=%ProgramFiles%\ESET\ESET Online Scanner|log.txt
 FileKey5=%ProgramFiles%\ESET\ESET Online Scanner\Modules\data\updfiles\temp|*.*
 FileKey6=%ProgramFiles%\ESET\ESET Online Scanner\Quarantine|*.*
@@ -7816,7 +7816,7 @@ RegKey1=HKCU\Software\Exifer\Browse\History
 [ExifPro *]
 LangSecRef=3024
 Detect=HKCU\Software\MKowalski\ExifPro
-FileKey1=%CommonAppData%\MiK\ExifPro|Cache*
+FileKey1=%ProgramData%\MiK\ExifPro|Cache*
 RegKey1=HKCU\Software\MKowalski\ExifPro\1.0\Browser\View 0|LastPath
 RegKey2=HKCU\Software\MKowalski\ExifPro\1.0\HTMLAlbumGen\RecentDestPaths
 RegKey3=HKCU\Software\MKowalski\ExifPro\1.0\RecentPaths
@@ -8012,7 +8012,7 @@ FileKey1=%AppData%\FastStone\FSIV|FSViewer.db
 [FatBatt *]
 LangSecRef=3024
 Detect=HKCU\Software\MiserWare, Inc.\FatBatt
-FileKey1=%CommonAppData%\MiserWare\FatBatt\logs|*.log
+FileKey1=%ProgramData%\MiserWare\FatBatt\logs|*.log
 
 [FBReader *]
 LangSecRef=3021
@@ -8040,8 +8040,8 @@ FileKey2=%AppData%\FFsplit\logs|*.*
 LangSecRef=3024
 Detect=HKCU\Software\Fighters
 FileKey1=%AppData%\Fighters\*\Logs|*.log;*log.txt
-FileKey2=%CommonAppData%\Common Toolkit Suite\Tools\Logs|*.log
-FileKey3=%CommonAppData%\Fighters\*\Logs|*.log
+FileKey2=%ProgramData%\Common Toolkit Suite\Tools\Logs|*.log
+FileKey3=%ProgramData%\Fighters\*\Logs|*.log
 
 [File Renamer Basic *]
 LangSecRef=3024
@@ -8148,7 +8148,7 @@ FileKey3=%AppData%\Flashpoint-Launcher\blob_storage|*.*|RECURSE
 LangSecRef=3021
 Detect1=HKCU\Software\FlexNet
 Detect2=HKLM\System\CurrentControlSet\services\FLEXnet Licensing Service
-FileKey1=%CommonAppData%\FLEXnet|*.data_backup.*;*.log
+FileKey1=%ProgramData%\FLEXnet|*.data_backup.*;*.log
 
 [FlipBooks *]
 LangSecRef=3021
@@ -8293,7 +8293,7 @@ FileKey3=%AppData%\Foxit Software\Foxit PDF Editor\cacheData|*.dat
 FileKey4=%AppData%\Foxit Software\Foxit PDF Editor\FormFiller|AutoComplete.ds
 FileKey5=%AppData%\Foxit Software\Foxit PDF Editor\StartPage\*\Start\en-US|index.html
 FileKey6=%AppData%\Foxit Software\RMS|FXRMS_Log.txt
-FileKey7=%CommonAppData%\Foxit Software\Foxit PDF Editor\Foxit*\Log|*.*|RECURSE
+FileKey7=%ProgramData%\Foxit Software\Foxit PDF Editor\Foxit*\Log|*.*|RECURSE
 FileKey8=%LocalLowAppData%\Foxit\Search|*.*|RECURSE
 RegKey1=HKCU\Software\Foxit Software\Foxit PDF Editor 11.0\CommentPanel\Filter
 RegKey2=HKCU\Software\Foxit Software\Foxit PDF Editor 11.0\MRU\File MRU
@@ -8350,8 +8350,8 @@ DetectFile=%AppData%\Foxit Software\Foxit Reader
 FileKey1=%AppData%\Foxit Software\Foxit PDF Creator\Foxit Reader PDF Printer|*_foxittemp.xml
 FileKey2=%AppData%\Foxit Software\Foxit Reader\StartPage*\Advertisement|*.*|REMOVESELF
 FileKey3=%AppData%\Foxit Software\Foxit Reader\StartPage*\Start|history.txt
-FileKey4=%CommonAppData%\Foxit Software\Foxit PDF Reader\FoxitSensor\Log|*.*
-FileKey5=%CommonAppData%\Foxit Software\Foxit*Reader\Foxit Service\Log|*.*
+FileKey4=%ProgramData%\Foxit Software\Foxit PDF Reader\FoxitSensor\Log|*.*
+FileKey5=%ProgramData%\Foxit Software\Foxit*Reader\Foxit Service\Log|*.*
 FileKey6=%LocalAppData%\Foxit Reader|*.TXT;*.zip;*.reg
 FileKey7=%ProgramFiles%\Foxit Software\Foxit Reader\Release Note|*.*|REMOVESELF
 FileKey8=%SystemDrive%\Documents and Settings\NetworkService*\Application Data\Foxit Software\Foxit Cloud|*log.txt
@@ -8455,9 +8455,9 @@ FileKey3=%LocalAppData%\FreeFixer\Logs|*.*|RECURSE
 
 [Freemake Video Converter *]
 LangSecRef=3023
-DetectFile=%CommonAppData%\Freemake\FreemakeVideoConverter
-FileKey1=%CommonAppData%\Freemake\FreemakeUtilsService\ErrorReports\Logs|*.*
-FileKey2=%CommonAppData%\Freemake\FreemakeUtilsService\Statistics\Targets|FVC_Statistics.ini
+DetectFile=%ProgramData%\Freemake\FreemakeVideoConverter
+FileKey1=%ProgramData%\Freemake\FreemakeUtilsService\ErrorReports\Logs|*.*
+FileKey2=%ProgramData%\Freemake\FreemakeUtilsService\Statistics\Targets|FVC_Statistics.ini
 FileKey3=%ProgramFiles%\Freemake|DotNet*.exe
 
 [Freemake Video Downloader *]
@@ -8522,7 +8522,7 @@ FileKey1=%ProgramFiles%\Full Tilt Poker.net\Cache|*.*
 [G-Data *]
 LangSecRef=3023
 Detect=HKCU\Software\G Data
-FileKey1=%CommonAppData%\G Data\AVK\Log|*.*|RECURSE
+FileKey1=%ProgramData%\G Data\AVK\Log|*.*|RECURSE
 FileKey2=%CommonProgramFiles%\G Data\AVKScanP\G Data|*.log;*old
 FileKey3=%ProgramFiles%\G Data\AntiVirus\AVK\UpdatePGM|*.log
 
@@ -8540,9 +8540,9 @@ FileKey2=%AppData%\Gajim\Avatars|*.*
 [Galaxy *]
 Section=Games
 Detect=HKCU\Software\GOG.com\Galaxy
-FileKey1=%CommonAppData%\GOG.com\Galaxy\logs|*.log
-FileKey2=%CommonAppData%\GOG.com\Galaxy\temp\desktop-galaxy-updater|*.*|REMOVESELF
-FileKey3=%CommonAppData%\GOG.com\Galaxy\webcache|*.*|REMOVESELF
+FileKey1=%ProgramData%\GOG.com\Galaxy\logs|*.log
+FileKey2=%ProgramData%\GOG.com\Galaxy\temp\desktop-galaxy-updater|*.*|REMOVESELF
+FileKey3=%ProgramData%\GOG.com\Galaxy\webcache|*.*|REMOVESELF
 
 [Game-Cloner *]
 Section=Games
@@ -8629,18 +8629,18 @@ FileKey1=%AppData%\Playrix Entertainment\Gardenscapes|log.html
 Section=Games
 Detect=HKCU\Software\Garena\im
 DetectFile=%ProgramFiles%\Garena Plus
-FileKey1=%CommonAppData%\GarenaMessenger|im.log*
-FileKey2=%CommonAppData%\GarenaMessenger\cache\clan|*|RECURSE
-FileKey3=%CommonAppData%\GarenaMessenger\cache\customAvatar\buddy|*
-FileKey4=%CommonAppData%\GarenaMessenger\cache\emoticon|*
-FileKey5=%CommonAppData%\GarenaMessenger\cache\screencapture|*
-FileKey6=%CommonAppData%\GarenaMessenger\garena.game.plugins|*.tmp
-FileKey7=%CommonAppData%\GarenaMessenger\update*|*|RECURSE
+FileKey1=%ProgramData%\GarenaMessenger|im.log*
+FileKey2=%ProgramData%\GarenaMessenger\cache\clan|*|RECURSE
+FileKey3=%ProgramData%\GarenaMessenger\cache\customAvatar\buddy|*
+FileKey4=%ProgramData%\GarenaMessenger\cache\emoticon|*
+FileKey5=%ProgramData%\GarenaMessenger\cache\screencapture|*
+FileKey6=%ProgramData%\GarenaMessenger\garena.game.plugins|*.tmp
+FileKey7=%ProgramData%\GarenaMessenger\update*|*|RECURSE
 
 [Garmin Express *]
 LangSecRef=3024
 Detect=HKCU\Software\Garmin\Express
-FileKey1=%CommonAppData%\Garmin\Logs|*.log;*.txt|RECURSE
+FileKey1=%ProgramData%\Garmin\Logs|*.log;*.txt|RECURSE
 FileKey2=%Documents%\Garmin\Backups\*|*.*|RECURSE
 
 [Garmin MapSource *]
@@ -8675,14 +8675,14 @@ FileKey1=%AppData%\34BE82C4-E596-4e99-A191-52C6199EBF69|*.*|REMOVESELF
 FileKey2=%AppData%\188F1432-103A-4ffb-80F1-36B633C5C9E1|*.*|REMOVESELF
 FileKey3=%AppData%\9223B3E6-70DD-4e2f-965B-DD8E02D2E20B|*.*|REMOVESELF
 FileKey4=%AppData%\Downloaded Installations|*.*|REMOVESELF
-FileKey5=%CommonAppData%\{755AC846-7372-4AC8-8550-C52491DAA8BD}|*.*|REMOVESELF
-FileKey6=%CommonAppData%\34BE82C4-E596-4e99-A191-52C6199EBF69|*.*|REMOVESELF
-FileKey7=%CommonAppData%\188F1432-103A-4ffb-80F1-36B633C5C9E1|*.*|REMOVESELF
-FileKey8=%CommonAppData%\9223B3E6-70DD-4e2f-965B-DD8E02D2E20B|*.*|REMOVESELF
-FileKey9=%CommonAppData%\9727E41D-AD6A-47cd-B9BC-CF630B6013FD|*.*|REMOVESELF
-FileKey10=%CommonAppData%\A73B37F8-7A4D-41f4-98A8-7F608CE8B98F|*.*|REMOVESELF
-FileKey11=%CommonAppData%\B0FFCDD9-5261-4e59-B29A-17A4FABDEBAB|*.log|RECURSE
-FileKey12=%CommonAppData%\E1864A66-75E3-486a-BD95-D1B7D99A84A7|*.*|REMOVESELF
+FileKey5=%ProgramData%\{755AC846-7372-4AC8-8550-C52491DAA8BD}|*.*|REMOVESELF
+FileKey6=%ProgramData%\34BE82C4-E596-4e99-A191-52C6199EBF69|*.*|REMOVESELF
+FileKey7=%ProgramData%\188F1432-103A-4ffb-80F1-36B633C5C9E1|*.*|REMOVESELF
+FileKey8=%ProgramData%\9223B3E6-70DD-4e2f-965B-DD8E02D2E20B|*.*|REMOVESELF
+FileKey9=%ProgramData%\9727E41D-AD6A-47cd-B9BC-CF630B6013FD|*.*|REMOVESELF
+FileKey10=%ProgramData%\A73B37F8-7A4D-41f4-98A8-7F608CE8B98F|*.*|REMOVESELF
+FileKey11=%ProgramData%\B0FFCDD9-5261-4e59-B29A-17A4FABDEBAB|*.log|RECURSE
+FileKey12=%ProgramData%\E1864A66-75E3-486a-BD95-D1B7D99A84A7|*.*|REMOVESELF
 FileKey13=%LocalAppData%\Downloaded Installations|*.*|REMOVESELF
 FileKey14=%ProgramFiles%\34BE82C4-E596-4e99-A191-52C6199EBF69|*.*|REMOVESELF
 FileKey15=%ProgramFiles%\38FDB89C-1EBD-4366-84B2-336D12CC3209|*.*|REMOVESELF
@@ -8698,10 +8698,10 @@ FileKey1=%AppData%\Geek Uninstaller|*.log;*cache.dat
 
 [GeekSquad *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Geek Squad
-FileKey1=%CommonAppData%\Geek Squad\MRI|EventLog.gsl|RECURSE
-FileKey2=%CommonAppData%\Geek Squad\MRI\Automation Reports|*.*|REMOVESELF
-FileKey3=%CommonAppData%\Geek Squad\MRI\Downloads|*.*|REMOVESELF
+DetectFile=%ProgramData%\Geek Squad
+FileKey1=%ProgramData%\Geek Squad\MRI|EventLog.gsl|RECURSE
+FileKey2=%ProgramData%\Geek Squad\MRI\Automation Reports|*.*|REMOVESELF
+FileKey3=%ProgramData%\Geek Squad\MRI\Downloads|*.*|REMOVESELF
 
 [Genie-Soft *]
 LangSecRef=3024
@@ -8783,11 +8783,11 @@ FileKey2=%LocalLowAppData%\Bennett Foddy\Getting Over It\Crashes|*.*
 
 [GFI LanGuard *]
 LangSecRef=3022
-DetectFile1=%CommonAppData%\GFI Software\LanGuard*
+DetectFile1=%ProgramData%\GFI Software\LanGuard*
 DetectFile2=%ProgramFiles%\GFI\LANguard*
-FileKey1=%CommonAppData%\GFI Software\LanGuard*|newfileslog.*
-FileKey2=%CommonAppData%\GFI Software\LanGuard*\*Logs|*.*|RECURSE
-FileKey3=%CommonAppData%\GFI Software\LanGuard*\Cache|*.*|REMOVESELF
+FileKey1=%ProgramData%\GFI Software\LanGuard*|newfileslog.*
+FileKey2=%ProgramData%\GFI Software\LanGuard*\*Logs|*.*|RECURSE
+FileKey3=%ProgramData%\GFI Software\LanGuard*\Cache|*.*|REMOVESELF
 FileKey4=%ProgramFiles%\GFI\LANguard*\DebugLogs|*.*
 FileKey5=%WinDir%\Patches|*.log.txt;*.log
 
@@ -8865,8 +8865,8 @@ RegKey1=HKCU\Software\GlarySoft\Glary Utilities 5\RegistryRepair|History
 
 [Globus Privacy *]
 LangSecRef=3022
-DetectFile=%CommonAppData%\Globus Privacy
-FileKey1=%CommonAppData%\Globus Privacy\install_log|*.log
+DetectFile=%ProgramData%\Globus Privacy
+FileKey1=%ProgramData%\Globus Privacy\install_log|*.log
 
 [GMote *]
 LangSecRef=3024
@@ -8926,8 +8926,8 @@ RegKey1=HKCU\Software\GRETECH\GomPlayer\OPTION|sRecentPLFolder
 
 [Goodix Fingerprint Driver *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Goodix
-FileKey1=%CommonAppData%\Goodix|*.log;*.bak
+DetectFile=%ProgramData%\Goodix
+FileKey1=%ProgramData%\Goodix|*.log;*.bak
 
 [GoodSync *]
 LangSecRef=3024
@@ -9092,7 +9092,7 @@ FileKey3=%LocalAppData%\Growl\*\Log|*.*|RECURSE
 [GS RichCopy 360 *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\GuruSquad\GS RichCopy 360
-FileKey1=%CommonAppData%|Microsoft.SqlServer.Compact.400.*.bc
+FileKey1=%ProgramData%|Microsoft.SqlServer.Compact.400.*.bc
 FileKey2=%ProgramFiles%\GuruSquad\GS RichCopy 360\Log|*.*
 FileKey3=%SystemDrive%\GSRichCopy360Log|*.*|RECURSE
 
@@ -9124,7 +9124,7 @@ FileKey2=%ProgramFiles%\Guild Wars*|*.tmp
 Section=Games
 Detect=HKCU\Software\CDProjektRED\Gwent
 DetectFile=%LocalLowAppData%\CDProjektRED\Gwent
-FileKey1=%CommonAppData%\CDProjekt RED\Gwent\Logs|*.log
+FileKey1=%ProgramData%\CDProjekt RED\Gwent\Logs|*.log
 FileKey2=%LocalLowAppData%\CDProjektRED\Gwent|*_log.txt
 
 [Hacknet *]
@@ -9167,8 +9167,8 @@ FileKey1=%AppData%\Novosoft\Handy Backup\logs|*.*
 [Happy Cloud *]
 Section=Games
 Detect=HKCU\Software\HappyCloud
-FileKey1=%CommonAppData%\HappyCloud|*.log
-FileKey2=%CommonAppData%\HappyCloud\cache|*.*
+FileKey1=%ProgramData%\HappyCloud|*.log
+FileKey2=%ProgramData%\HappyCloud\cache|*.*
 
 [Hard Disk Sentinel *]
 LangSecRef=3024
@@ -9177,8 +9177,8 @@ FileKey1=%ProgramFiles%\Hard Disk Sentinel|*.bak;*Log.txt
 
 [Hard Drive Inspector *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\AltrixSoft\Hard Drive Inspector
-FileKey1=%CommonAppData%\AltrixSoft\Hard Drive Inspector|log.err
+DetectFile=%ProgramData%\AltrixSoft\Hard Drive Inspector
+FileKey1=%ProgramData%\AltrixSoft\Hard Drive Inspector|log.err
 
 [Hauppauge WinTV *]
 LangSecRef=3024
@@ -9208,7 +9208,7 @@ FileKey1=%ProgramFiles%\HDD Regenerator|*.log|RECURSE
 [HDD Thermometer *]
 LangSecRef=3024
 Detect=HKCU\Software\RSD Software, Inc.\HDD Thermometer
-FileKey1=%CommonAppData%\HDD Thermometer|*.log|RECURSE
+FileKey1=%ProgramData%\HDD Thermometer|*.log|RECURSE
 
 [HDDExpert *]
 LangSecRef=3024
@@ -9382,8 +9382,8 @@ FileKey2=%AppData%\HexChat\scrollback|*.*|REMOVESELF
 [Hi-Rez Studios *]
 Section=Games
 Detect=HKLM\Software\Hi-Rez Studios
-FileKey1=%CommonAppData%\Hi-Rez Studios\BrowserCacheTribes\Default|*.*|RECURSE
-FileKey2=%CommonAppData%\Hi-Rez Studios\HiPatchService\log|*.*
+FileKey1=%ProgramData%\Hi-Rez Studios\BrowserCacheTribes\Default|*.*|RECURSE
+FileKey2=%ProgramData%\Hi-Rez Studios\HiPatchService\log|*.*
 FileKey3=%ProgramFiles%\Hi-Rez Studios\hireztemp|*.*
 FileKey4=%SystemDrive%|HiRezUpdateInstallLog.txt
 
@@ -9408,7 +9408,7 @@ Detect1=HKCU\Software\HitMan Pro
 Detect2=HKCU\Software\HitMan Pro 2
 Detect3=HKCU\Software\HitMan Pro 3
 Detect4=HKLM\Software\HitmanPro
-FileKey1=%CommonAppData%\HitmanPro\Logs|*.*
+FileKey1=%ProgramData%\HitmanPro\Logs|*.*
 FileKey2=%ProgramFiles%\Hitman Pro*\downloads|*.*
 FileKey3=%ProgramFiles%\Hitman Pro*\logs|*.htm
 FileKey4=%ProgramFiles%\Hitman Pro*\updates|*.*
@@ -9495,7 +9495,7 @@ FileKey1=%AppData%\Merscom\Hostile Makeover|logfile.txt
 
 [HostsMan Backups *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\abelhadigital.com\HostsMan
+DetectFile=%ProgramData%\abelhadigital.com\HostsMan
 FileKey1=%Public%\Documents\HostsMan Backups|*.*|REMOVESELF
 FileKey2=%WinDir%\System32\drivers\etc|HOSTS.bak;HOSTS.tmp
 
@@ -9534,8 +9534,8 @@ FileKey1=%ProgramFiles%\HoverDesk\User|hdcmdrec.txt
 LangSecRef=3021
 Detect=HKCU\Software\HP
 DetectFile1=%AppData%\hpqlog
-DetectFile2=%CommonAppData%\Hewlett-Packard
-DetectFile3=%CommonAppData%\HP
+DetectFile2=%ProgramData%\Hewlett-Packard
+DetectFile3=%ProgramData%\HP
 DetectFile4=%LocalAppData%\Hewlett-Packard
 DetectFile5=%LocalAppData%\TouchSmartData
 DetectFile6=%ProgramFiles%\HPQ\Shared\Sierra Wireless
@@ -9543,16 +9543,16 @@ DetectFile7=%UserProfile%\HPRemote\RGReceiver
 FileKey1=%AppData%\hp active health\app analytics\*logs|*.*|RECURSE
 FileKey2=%AppData%\HP\*Logs|*Log.txt
 FileKey3=%AppData%\hpqlog|*.log
-FileKey4=%CommonAppData%|hpzinstall.log
-FileKey5=%CommonAppData%\Hewlett-Packard|*.log*.*;*Log.txt|RECURSE
-FileKey6=%CommonAppData%\Hewlett-Packard\HP*\Log*|*.*|RECURSE
-FileKey7=%CommonAppData%\HP Audio Switch|*.log*
-FileKey8=%CommonAppData%\HP\HP Audio Switch|*.log
-FileKey9=%CommonAppData%\HP\HP Touchpoint Analytics Client\Logs|*.*
-FileKey10=%CommonAppData%\HP\HP Touchpoint Analytics Client\Monitor-History|*.*
-FileKey11=%CommonAppData%\HP\HP Touchpoint Analytics Client\MRU|*.*
-FileKey12=%CommonAppData%\HP\logs|*.*|RECURSE
-FileKey13=%CommonAppData%\HP\StreamLog|*.*|RECURSE
+FileKey4=%ProgramData%|hpzinstall.log
+FileKey5=%ProgramData%\Hewlett-Packard|*.log*.*;*Log.txt|RECURSE
+FileKey6=%ProgramData%\Hewlett-Packard\HP*\Log*|*.*|RECURSE
+FileKey7=%ProgramData%\HP Audio Switch|*.log*
+FileKey8=%ProgramData%\HP\HP Audio Switch|*.log
+FileKey9=%ProgramData%\HP\HP Touchpoint Analytics Client\Logs|*.*
+FileKey10=%ProgramData%\HP\HP Touchpoint Analytics Client\Monitor-History|*.*
+FileKey11=%ProgramData%\HP\HP Touchpoint Analytics Client\MRU|*.*
+FileKey12=%ProgramData%\HP\logs|*.*|RECURSE
+FileKey13=%ProgramData%\HP\StreamLog|*.*|RECURSE
 FileKey14=%LocalAppData%\Hewlett-Packard\HP Support Framework\Profile\Upload|*.log
 FileKey15=%LocalAppData%\HP\AtInstall|*.log;*log.txt|REMOVESELF
 FileKey16=%LocalAppData%\TouchSmartData\Log|*.*
@@ -9578,11 +9578,11 @@ FileKey2=%LocalAppData%\HP Guide\mp_cache|*.*
 [HP Installation Files *]
 LangSecRef=3024
 Detect=HKCU\Software\HP
-DetectFile1=%CommonAppData%\HP
+DetectFile1=%ProgramData%\HP
 DetectFile2=%SystemDrive%\HP Universal Print Driver
 DetectFile3=%SystemDrive%\swsetup
-FileKey1=%CommonAppData%\HP\Installer\Temp|*.*
-FileKey2=%CommonAppData%\HP\Temp|*.*
+FileKey1=%ProgramData%\HP\Installer\Temp|*.*
+FileKey2=%ProgramData%\HP\Temp|*.*
 FileKey3=%ProgramFiles%\HP\Temp|*.*|RECURSE
 FileKey4=%SystemDrive%\HP Universal Print Driver|*.*|REMOVESELF
 FileKey5=%SystemDrive%\swsetup|*.*|REMOVESELF
@@ -9656,7 +9656,7 @@ FileKey1=%AppData%\HTC\Logs|*.log
 [Huawei *]
 LangSecRef=3023
 Detect=HKLM\Software\Huawei technologies
-FileKey1=%CommonAppData%\MobileBrServ\log|*.*|REMOVESELF
+FileKey1=%ProgramData%\MobileBrServ\log|*.*|REMOVESELF
 FileKey2=%ProgramFiles%\BILDmobil\Log|*.*
 FileKey3=%ProgramFiles%\HUAWEI Modem Driver|*.log
 
@@ -9725,7 +9725,7 @@ FileKey4=%ProgramFiles%\i2p\eepsite\logs|*.*
 LangSecRef=3022
 Detect=HKCU\Software\Trusteer\Rapport
 FileKey1=%AppData%\Trusteer\Rapport\user\Logs|*.*
-FileKey2=%CommonAppData%\Trusteer\Rapport\logs|*.*
+FileKey2=%ProgramData%\Trusteer\Rapport\logs|*.*
 FileKey3=%LocalAppData%\Trusteer\Rapport\user\logs|*.*
 FileKey4=%WinDir%\System32\config\systemprofile\AppData\Local\Trusteer\Rapport\user\logs|*.*
 
@@ -9794,7 +9794,7 @@ FileKey1=%AppData%\KC Softwares\IDPhotoStudio|*.log
 LangSecRef=3021
 DetectFile1=%LocalAppData%\IDrive
 DetectFile2=%ProgramFiles%\IDriveWindows
-FileKey1=%CommonAppData%\IDrive\IBCOMMON|Tracefile.txt
+FileKey1=%ProgramData%\IDrive\IBCOMMON|Tracefile.txt
 FileKey2=%LocalAppData%\IDrive\IBCOMMON|SerTraceFile.txt
 FileKey3=%ProgramFiles%\IDriveWindows\IBCOMMON|SerTraceFile.txt
 
@@ -9862,7 +9862,7 @@ RegKey2=HKCU\Software\ImgBurn|ISOREAD_RecentFolders_Destination
 LangSecRef=3021
 Detect=HKLM\Software\Immunet Protect
 FileKey1=%AppData%\Immunet|*.*|REMOVESELF
-FileKey2=%CommonAppData%\Immunet|*.log
+FileKey2=%ProgramData%\Immunet|*.log
 FileKey3=%ProgramFiles%\Immunet|*.log|RECURSE
 
 [Imo Messenger *]
@@ -9907,7 +9907,7 @@ FileKey1=%ProgramFiles%\ImTOO\iPad Video Converter|*.log;ERRORLOG.TXT
 [ImTOO Video Converter Ultimate *]
 LangSecRef=3023
 Detect=HKCU\Software\ImTOO\Video Converter Ultimate
-FileKey1=%CommonAppData%\ImTOO\Video Converter Ultimate\customdata|settings.old
+FileKey1=%ProgramData%\ImTOO\Video Converter Ultimate\customdata|settings.old
 RegKey1=HKCU\Software\ImTOO\Video Converter Ultimate\Settings|last_openfile_dir
 RegKey2=HKCU\Software\ImTOO\Video Converter Ultimate\Settings|last_output_dir
 RegKey3=HKCU\Software\ImTOO\Video Converter Ultimate\Settings|last_profile_group
@@ -9961,7 +9961,7 @@ RegKey6=HKCU\Software\Iceni Technology Limited\Infix\Watermark dialog|Replace Sa
 LangSecRef=3021
 DetectFile=%AppData%\inFlow Inventory
 FileKey1=%AppData%\inFlow Inventory|log.txt
-FileKey2=%CommonAppData%\inFlow Inventory\Logs|*.*
+FileKey2=%ProgramData%\inFlow Inventory\Logs|*.*
 
 [Infonautics File Date Corrector *]
 LangSecRef=3024
@@ -10014,10 +10014,10 @@ FileKey4=%SystemDrive%\Programs\InnoExtractor|Historial.dat
 
 [InnoTab *]
 LangSecRef=3021
-DetectFile=%CommonAppData%\VTech\DA
-FileKey1=%CommonAppData%\VTech\DA|*.log;InnoTab.txt;IntallLog.txt|RECURSE
-FileKey2=%CommonAppData%\VTech\DA\InnoTab\ConsoleLog|*.*
-FileKey3=%CommonAppData%\VTech\DA\InnoTab\Games\tmp|*.*|REMOVESELF
+DetectFile=%ProgramData%\VTech\DA
+FileKey1=%ProgramData%\VTech\DA|*.log;InnoTab.txt;IntallLog.txt|RECURSE
+FileKey2=%ProgramData%\VTech\DA\InnoTab\ConsoleLog|*.*
+FileKey3=%ProgramData%\VTech\DA\InnoTab\Games\tmp|*.*|REMOVESELF
 
 [Inpaint *]
 LangSecRef=3021
@@ -10078,13 +10078,13 @@ Detect1=HKCU\Software\Intel
 Detect2=HKLM\Software\Intel
 Detect3=HKLM\Software\RivetNetworks
 FileKey1=%AppData%\Intel\Wireless\CrashDumps|*
-FileKey2=%CommonAppData%\Intel|*.log;*.bak;*Log*.txt|RECURSE
-FileKey3=%CommonAppData%\Intel(R) Update Manager\AppData|ium.log
-FileKey4=%CommonAppData%\Intel\*\Log*|*
-FileKey5=%CommonAppData%\Intel\GCC|gcc_svc_log_*.txt
-FileKey6=%CommonAppData%\Intel\Logs|*
-FileKey7=%CommonAppData%\RivetNetworks\ImageCache|*
-FileKey8=%CommonAppData%\RivetNetworks\Killer|*.log
+FileKey2=%ProgramData%\Intel|*.log;*.bak;*Log*.txt|RECURSE
+FileKey3=%ProgramData%\Intel(R) Update Manager\AppData|ium.log
+FileKey4=%ProgramData%\Intel\*\Log*|*
+FileKey5=%ProgramData%\Intel\GCC|gcc_svc_log_*.txt
+FileKey6=%ProgramData%\Intel\Logs|*
+FileKey7=%ProgramData%\RivetNetworks\ImageCache|*
+FileKey8=%ProgramData%\RivetNetworks\Killer|*.log
 FileKey9=%LocalAppData%\Intel\GCC|*log*
 FileKey10=%LocalAppData%\Intel\SUR\QueenCreek\Collected Data|*error_stack-*.txt
 FileKey11=%LocalLowAppData%\Intel\ShaderCache|*
@@ -10108,7 +10108,7 @@ FileKey27=%WinDir%\SysWOW64\config\systemprofile\Intel\Logs|*|REMOVESELF
 [Intel Graphics Command Center *]
 LangSecRef=3024
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\AppUp.IntelGraphicsExperience_8j3eq9eme6ctt
-FileKey1=%CommonAppData%\Packages\AppUp.IntelGraphicsExperience_*\*\SystemAppData\Helium\Cache|*
+FileKey1=%ProgramData%\Packages\AppUp.IntelGraphicsExperience_*\*\SystemAppData\Helium\Cache|*
 FileKey2=%LocalAppData%\Intel\GCC|gcc*_log_*.txt
 FileKey3=%LocalAppData%\Packages\AppUp.IntelGraphicsExperience_*\AC\BackgroundTransferApi|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\AppUp.IntelGraphicsExperience_*\AC\INet*|*.*|RECURSE
@@ -10129,9 +10129,9 @@ FileKey1=%ProgramFiles%\Intel Corporation\Intel Processor Diagnostic Tool 64bit|
 
 [Intel Shader Cache *]
 LangSecRef=3024
-DetectFile1=%CommonAppData%\Intel\ShaderCache
+DetectFile1=%ProgramData%\Intel\ShaderCache
 DetectFile2=%LocalLowAppData%\Intel\ShaderCache
-FileKey1=%CommonAppData%\Intel\ShaderCache|*.*
+FileKey1=%ProgramData%\Intel\ShaderCache|*.*
 FileKey2=%LocalLowAppData%\Intel\ShaderCache|*.*
 
 [Inter-Tel Device *]
@@ -10231,13 +10231,13 @@ RegKey76=HKCU\Software\DownloadManager\maxID
 [Intuit Data Protect *]
 LangSecRef=3024
 DetectFile=%LocalAppData%\Intuit\Intuit Data Protect
-FileKey1=%CommonAppData%\Intuit\Intuit Data Protect|*.log
+FileKey1=%ProgramData%\Intuit\Intuit Data Protect|*.log
 FileKey2=%LocalAppData%\Intuit\Intuit Data Protect|*.log
 
 [Intuit Entitlement Client *]
 LangSecRef=3021
-DetectFile=%CommonAppData%\Intuit\Entitlement Client
-FileKey1=%CommonAppData%\Intuit\Entitlement Client\*|IntuitEntitlementLog*.*
+DetectFile=%ProgramData%\Intuit\Entitlement Client
+FileKey1=%ProgramData%\Intuit\Entitlement Client\*|IntuitEntitlementLog*.*
 
 [Intuit Proline Tax Import *]
 LangSecRef=3021
@@ -10247,10 +10247,10 @@ FileKey1=%AppData%\Intuit\PTI\Log|*.*
 [Intuit QuickBooks *]
 LangSecRef=3021
 Detect=HKLM\Software\Intuit\QuickBooks
-FileKey1=%CommonAppData%\Common Files\Intuit\Quickbooks\qbupdate\log|*.*
-FileKey2=%CommonAppData%\Intuit\QBWebConnector\log|*.*
-FileKey3=%CommonAppData%\Intuit\Quickbooks|*.log;qbsdklog.txt
-FileKey4=%CommonAppData%\Intuit\QuickBooks DB Server Manager|*.log;*.old
+FileKey1=%ProgramData%\Common Files\Intuit\Quickbooks\qbupdate\log|*.*
+FileKey2=%ProgramData%\Intuit\QBWebConnector\log|*.*
+FileKey3=%ProgramData%\Intuit\Quickbooks|*.log;qbsdklog.txt
+FileKey4=%ProgramData%\Intuit\QuickBooks DB Server Manager|*.log;*.old
 FileKey5=%CommonProgramFiles%\Intuit\Quickbooks\QBUpdate\Log|*.*
 FileKey6=%LocalAppData%\Intuit\QuickBooks\Log|*.*|RECURSE
 
@@ -10260,16 +10260,16 @@ Detect1=HKLM\Software\Intuit\Quicken
 Detect2=HKLM\Software\Quicken
 FileKey1=%AppData%\Intuit\Quicken\Log|*.txt;*.log
 FileKey2=%AppData%\Quicken\Log|*.txt;*.log
-FileKey3=%CommonAppData%\Intuit\Quicken\Log|*.log
-FileKey4=%CommonAppData%\Intuit\Quicken\Log\installer|*.*|REMOVESELF
-FileKey5=%CommonAppData%\Intuit\SendError|*.log
-FileKey6=%CommonAppData%\Quicken\Inet\QWWebData|LOG.old|RECURSE
-FileKey7=%CommonAppData%\Quicken\Inet\QWWebData\Cache|*.*
-FileKey8=%CommonAppData%\Quicken\Inet\QWWebData\GPUCache|*.*|REMOVESELF
-FileKey9=%CommonAppData%\Quicken\Inet\QWWebData\Local Storage\leveldb|*tmp
-FileKey10=%CommonAppData%\Quicken\Log|*.log
-FileKey11=%CommonAppData%\Quicken\Log\installer|*.*|REMOVESELF
-FileKey12=%CommonAppData%\Quicken\SendError|*.log
+FileKey3=%ProgramData%\Intuit\Quicken\Log|*.log
+FileKey4=%ProgramData%\Intuit\Quicken\Log\installer|*.*|REMOVESELF
+FileKey5=%ProgramData%\Intuit\SendError|*.log
+FileKey6=%ProgramData%\Quicken\Inet\QWWebData|LOG.old|RECURSE
+FileKey7=%ProgramData%\Quicken\Inet\QWWebData\Cache|*.*
+FileKey8=%ProgramData%\Quicken\Inet\QWWebData\GPUCache|*.*|REMOVESELF
+FileKey9=%ProgramData%\Quicken\Inet\QWWebData\Local Storage\leveldb|*tmp
+FileKey10=%ProgramData%\Quicken\Log|*.log
+FileKey11=%ProgramData%\Quicken\Log\installer|*.*|REMOVESELF
+FileKey12=%ProgramData%\Quicken\SendError|*.log
 FileKey13=%Documents%\Quicken\GPUCache|*.*|REMOVESELF
 FileKey14=%LocalAppData%\Intuit\Common\Authorization\V1\Logs|*.txt
 FileKey15=%LocalAppData%\Quicken\Common\Authorization\V1\Logs|*.txt
@@ -10279,19 +10279,19 @@ FileKey16=%ProgramFiles%\Quicken\PDFDrv|install.log;InstallPDFConverter.log
 LangSecRef=3021
 DetectFile=%ProgramFiles%\TurboTax*
 FileKey1=%AppData%\Intuit*|*.log|RECURSE
-FileKey2=%CommonAppData%|*.bc
-FileKey3=%CommonAppData%\Intuit*|*.log|RECURSE
-FileKey4=%CommonAppData%\Intuit\Common\Metrix\*\Logs|*.*
-FileKey5=%CommonAppData%\Intuit\Common\QuickBaseClient\*\Logs|*.*
-FileKey6=%CommonAppData%\Intuit\Common\Update Service\*\Logs|*.*
-FileKey7=%CommonAppData%\Intuit\TurboTax\MSI\*\Logs|*.*
+FileKey2=%ProgramData%|*.bc
+FileKey3=%ProgramData%\Intuit*|*.log|RECURSE
+FileKey4=%ProgramData%\Intuit\Common\Metrix\*\Logs|*.*
+FileKey5=%ProgramData%\Intuit\Common\QuickBaseClient\*\Logs|*.*
+FileKey6=%ProgramData%\Intuit\Common\Update Service\*\Logs|*.*
+FileKey7=%ProgramData%\Intuit\TurboTax\MSI\*\Logs|*.*
 FileKey8=%CommonProgramFiles%\Intuit\Internet Client|Msdun13.exe
 FileKey9=%ProgramFiles%\TurboTax*|*.txt
 
 [IObit Advanced SystemCare *]
 LangSecRef=3024
 DetectFile1=%AppData%\IObit\Advanced SystemCare*
-DetectFile2=%CommonAppData%\IObit\Advanced SystemCare*
+DetectFile2=%ProgramData%\IObit\Advanced SystemCare*
 DetectFile3=%ProgramFiles%\IObit\Advanced SystemCare Ultimate
 FileKey1=%AppData%\IObit\Advanced SystemCare*|*.log;*_UndeleteReg.dat
 FileKey2=%AppData%\IObit\Advanced SystemCare*\Backup|*.reg
@@ -10302,9 +10302,9 @@ FileKey6=%AppData%\IObit\Advanced SystemCare*\Homepage*|*.new;*.old
 FileKey7=%AppData%\IObit\Advanced SystemCare*\Log|*.*|RECURSE
 FileKey8=%AppData%\IObit\Advanced SystemCare*\LogBackup*|*.*|RECURSE
 FileKey9=%AppData%\IObit\Advanced SystemCare*\TrayProductData|StatCache.db
-FileKey10=%CommonAppData%\IObit\Advanced SystemCare*\Homepage*|*.log
-FileKey11=%CommonAppData%\IObit\Advanced SystemCare*\Log|*.*|REMOVESELF
-FileKey12=%CommonAppData%\IObit\ASCDownloader|*.log
+FileKey10=%ProgramData%\IObit\Advanced SystemCare*\Homepage*|*.log
+FileKey11=%ProgramData%\IObit\Advanced SystemCare*\Log|*.*|REMOVESELF
+FileKey12=%ProgramData%\IObit\ASCDownloader|*.log
 FileKey13=%ProgramFiles%\IObit\Advanced SystemCare Ultimate\Antivirus\BackupRec|*.*|RECURSE
 FileKey14=%ProgramFiles%\IObit\Advanced SystemCare*|*.log;*.tmp;*.txt|RECURSE
 FileKey15=%ProgramFiles%\IObit\Advanced SystemCare*\*.cab_Temp|*.*|REMOVESELF
@@ -10330,8 +10330,8 @@ FileKey4=%ProgramFiles%\IObit\Driver Booster\Update|*.tmp
 
 [IObit KB Downloader *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\IObit\KBDownloader
-FileKey1=%CommonAppData%\IObit\KBDownloader|*.*|RECURSE
+DetectFile=%ProgramData%\IObit\KBDownloader
+FileKey1=%ProgramData%\IObit\KBDownloader|*.*|RECURSE
 
 [IObit LiveUpdate *]
 LangSecRef=3024
@@ -10379,7 +10379,7 @@ FileKey1=%AppData%\IP Hider Pro\Logs|*.*
 [Iperius Backup *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Iperius Backup
-FileKey1=%CommonAppData%\IperiusBackup\Logs|*.*|RECURSE
+FileKey1=%ProgramData%\IperiusBackup\Logs|*.*|RECURSE
 
 [IPinside LWS Agent *]
 LangSecRef=3021
@@ -10412,8 +10412,8 @@ RegKey2=HKLM\Software\Wow6432Node\iSkysoft\iSkysoft Helper Compact
 LangSecRef=3023
 Detect1=HKLM\Software\iSkysoft\iSkysoft Video Converter
 Detect2=HKLM\Software\iSkysoft\iSkysoft Video Converter Ultimate
-FileKey1=%CommonAppData%\iSkysoft Video Converter*|*.dat.bak
-FileKey2=%CommonAppData%\iSkysoft Video Converter*\Temp*Dir|*.*|RECURSE
+FileKey1=%ProgramData%\iSkysoft Video Converter*|*.dat.bak
+FileKey2=%ProgramData%\iSkysoft Video Converter*\Temp*Dir|*.*|RECURSE
 FileKey3=%ProgramFiles%\iSkysoft\Video Converter*\Log|*.*|RECURSE
 FileKey4=%ProgramFiles%\iSkysoft\Video Converter*\TempThumbDir|*.*|RECURSE
 
@@ -10460,7 +10460,7 @@ Detect2=HKLM\Software\Apple Computer, Inc.\iTunes
 FileKey1=%AppData%\Apple Computer\iTunes|*.ipcc;*.ipsw;*.log
 FileKey2=%AppData%\Apple Computer\iTunes\Cookies|Cookies.binarycookies
 FileKey3=%AppData%\Apple Computer\Logs*|*.*|RECURSE
-FileKey4=%CommonAppData%\Apple Computer\iTunes\iPhone Temporary Files|*.*|RECURSE
+FileKey4=%ProgramData%\Apple Computer\iTunes\iPhone Temporary Files|*.*|RECURSE
 FileKey5=%LocalAppData%\Apple Computer\iTunes|Cache.db
 FileKey6=%LocalAppData%\Packages\AppleInc.iTunes_*\AC\INet*|*.*|RECURSE
 FileKey7=%LocalAppData%\Packages\AppleInc.iTunes_*\AC\Temp|*.*|RECURSE
@@ -10551,11 +10551,11 @@ LangSecRef=3022
 Detect1=HKLM\Software\JavaSoft\Java Plug-in
 Detect2=HKLM\Software\JavaSoft\Java Runtime Environment
 Detect3=HKLM\Software\JavaSoft\Java Web Start
-DetectFile=%CommonAppData%\Oracle\Java
+DetectFile=%ProgramData%\Oracle\Java
 FileKey1=%AppData%\Sun\Java\Deployment\SystemCache|*.*|RECURSE
 FileKey2=%AppData%\Sun\Java\jre*|*.*|REMOVESELF
-FileKey3=%CommonAppData%\Oracle\Java\.oracle_jre_usage|*.*
-FileKey4=%CommonAppData%\Oracle\Java\installcache|*.*|RECURSE
+FileKey3=%ProgramData%\Oracle\Java\.oracle_jre_usage|*.*
+FileKey4=%ProgramData%\Oracle\Java\installcache|*.*|RECURSE
 FileKey5=%LocalAppData%\javasharedresources|*.*
 FileKey6=%LocalAppData%\Sun\Java\Deployment\*Cache|*.*|RECURSE
 FileKey7=%LocalLowAppData%\Oracle\Java\jdk*|*.*|REMOVESELF
@@ -10797,26 +10797,26 @@ FileKey2=%LocalAppData%\Kaseto\Logs|*.*
 [Kaspersky *]
 LangSecRef=3024
 Detect=HKCU\Software\KasperskyLab
-FileKey1=%CommonAppData%\Kaspersky Lab|*.dmp;*.dmp.stat;*.log
-FileKey2=%CommonAppData%\Kaspersky Lab\*\Bases|hdhm_temp_drives_*
-FileKey3=%CommonAppData%\Kaspersky Lab\*\Bases\*|log*;strg*|RECURSE
-FileKey4=%CommonAppData%\Kaspersky Lab\*\Bases\*\Cache|*.*|RECURSE
-FileKey5=%CommonAppData%\Kaspersky Lab\*\Bases\Cache|*.*|RECURSE
-FileKey6=%CommonAppData%\Kaspersky Lab\*\Data|*.bak*;*.db-shm;*.db-wal;*.kvdb-shm;*.kvdb-wal|RECURSE
-FileKey7=%CommonAppData%\Kaspersky Lab\*\Data\KDSCRL|log*
-FileKey8=%CommonAppData%\Kaspersky Lab\*\Data\Updater\Temporary Files|*.*|RECURSE
-FileKey9=%CommonAppData%\Kaspersky Lab\*\Logs|*.*|RECURSE
-FileKey10=%CommonAppData%\Kaspersky Lab\*\Report|*.*|RECURSE
-FileKey11=%CommonAppData%\Kaspersky Lab\*\Temp|*.*|RECURSE
-FileKey12=%CommonAppData%\Kaspersky Lab\Kaspersky Password Manager*\Logs|*.*
-FileKey13=%CommonAppData%\Kaspersky Lab\UCPStorage|ucp_agent.bin.bak
+FileKey1=%ProgramData%\Kaspersky Lab|*.dmp;*.dmp.stat;*.log
+FileKey2=%ProgramData%\Kaspersky Lab\*\Bases|hdhm_temp_drives_*
+FileKey3=%ProgramData%\Kaspersky Lab\*\Bases\*|log*;strg*|RECURSE
+FileKey4=%ProgramData%\Kaspersky Lab\*\Bases\*\Cache|*.*|RECURSE
+FileKey5=%ProgramData%\Kaspersky Lab\*\Bases\Cache|*.*|RECURSE
+FileKey6=%ProgramData%\Kaspersky Lab\*\Data|*.bak*;*.db-shm;*.db-wal;*.kvdb-shm;*.kvdb-wal|RECURSE
+FileKey7=%ProgramData%\Kaspersky Lab\*\Data\KDSCRL|log*
+FileKey8=%ProgramData%\Kaspersky Lab\*\Data\Updater\Temporary Files|*.*|RECURSE
+FileKey9=%ProgramData%\Kaspersky Lab\*\Logs|*.*|RECURSE
+FileKey10=%ProgramData%\Kaspersky Lab\*\Report|*.*|RECURSE
+FileKey11=%ProgramData%\Kaspersky Lab\*\Temp|*.*|RECURSE
+FileKey12=%ProgramData%\Kaspersky Lab\Kaspersky Password Manager*\Logs|*.*
+FileKey13=%ProgramData%\Kaspersky Lab\UCPStorage|ucp_agent.bin.bak
 FileKey14=%ProgramFiles%\Kaspersky Lab\Kaspersky Password Manager*|*.bak*
 FileKey15=%ProgramFiles%\Kaspersky Lab\NetworkAgent\~dumps|*.*
 
 [Kate's Video Toolkit *]
 LangSecRef=3023
 Detect=HKCU\Software\Web Solution Mart\Kate's Video Toolkit
-FileKey1=%CommonAppData%\Web Solution Mart\*|*.log|RECURSE
+FileKey1=%ProgramData%\Web Solution Mart\*|*.log|RECURSE
 
 [Kazaa Lite Resurrection *]
 LangSecRef=3022
@@ -10836,7 +10836,7 @@ FileKey1=%UserProfile%\.kde\cache*|*.*|RECURSE
 [Kerish Doctor *]
 LangSecRef=3024
 Detect=HKLM\Software\Kerish Products\Kerish Doctor
-FileKey1=%CommonAppData%\Kerish Products\Kerish Doctor\Reports|*.*
+FileKey1=%ProgramData%\Kerish Products\Kerish Doctor\Reports|*.*
 RegKey1=HKLM\Software\Kerish Products\Kerish Doctor|InstallDate
 RegKey2=HKLM\Software\Kerish Products\Kerish Doctor|LastScan
 RegKey3=HKLM\Software\Kerish Products\Kerish Doctor|LastStart
@@ -10851,8 +10851,8 @@ FileKey1=%ProgramFiles%\Reset Local Password Pro|*.log
 
 [Keyboard Tracer *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Keyboard Tracer
-FileKey1=%CommonAppData%\Keyboard Tracer|*.log
+DetectFile=%ProgramData%\Keyboard Tracer
+FileKey1=%ProgramData%\Keyboard Tracer|*.log
 
 [KeyMapper *]
 LangSecRef=3024
@@ -10915,12 +10915,12 @@ FileKey1=%AppData%\com.mcgraphix.KlokworkTeamConsole\local store|debug.txt
 
 [KMS Emulator *]
 LangSecRef=3024
-DetectFile1=%CommonAppData%\KMSAuto*
-DetectFile2=%CommonAppData%\Online_KMS_Activation
+DetectFile1=%ProgramData%\KMSAuto*
+DetectFile2=%ProgramData%\Online_KMS_Activation
 DetectFile3=%ProgramFiles%\KMSpico
 DetectFile4=%WinDir%\AutoKMS
-FileKey1=%CommonAppData%\KMSAuto*\bin|*.log
-FileKey2=%CommonAppData%\Online_KMS_Activation|Logs.txt
+FileKey1=%ProgramData%\KMSAuto*\bin|*.log
+FileKey2=%ProgramData%\Online_KMS_Activation|Logs.txt
 FileKey3=%ProgramFiles%\KMSpico\Logs|*.*
 FileKey4=%WinDir%\AutoKMS|*.log
 
@@ -10936,8 +10936,8 @@ Detect2=HKLM\Software\Eastman Kodak Company\KODAK AiO Home Center
 Detect3=HKLM\Software\Kodak\Kodak AiO Software
 DetectFile=%AppData%\Kodak\Share Button App
 FileKey1=%AppData%\Kodak\Share Button App|*.log
-FileKey2=%CommonAppData%\Kodak\Diagnostics|*.*
-FileKey3=%CommonAppData%\Kodak\Inkjet Logging|*.*|RECURSE
+FileKey2=%ProgramData%\Kodak\Diagnostics|*.*
+FileKey3=%ProgramData%\Kodak\Inkjet Logging|*.*|RECURSE
 FileKey4=%LocalAppData%|LaunchHomeCenter.log
 FileKey5=%LocalAppData%\Kodak\Diagnostics|UploadLog.xml
 FileKey6=%LocalAppData%\Kodak\Inkjet Logging|Status Monitor Log.*
@@ -11056,11 +11056,11 @@ FileKey3=%UserProfile%\riotsGamesLogs|*.*
 [Leapfrog Connect *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\LeapFrog\LeapFrog Connect
-FileKey1=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\cookies|*.*
-FileKey2=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\data7\*|*.*
-FileKey3=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\http*|*.*
-FileKey4=%CommonAppData%\Leapfrog\LeapFrog Connect\cache\*\prepared|*.*
-FileKey5=%CommonAppData%\Leapfrog\LeapFrog Connect\DownloadCache|*.*
+FileKey1=%ProgramData%\Leapfrog\LeapFrog Connect\cache\*\cookies|*.*
+FileKey2=%ProgramData%\Leapfrog\LeapFrog Connect\cache\*\data7\*|*.*
+FileKey3=%ProgramData%\Leapfrog\LeapFrog Connect\cache\*\http*|*.*
+FileKey4=%ProgramData%\Leapfrog\LeapFrog Connect\cache\*\prepared|*.*
+FileKey5=%ProgramData%\Leapfrog\LeapFrog Connect\DownloadCache|*.*
 
 [LeapFTP *]
 LangSecRef=3022
@@ -11129,14 +11129,14 @@ FileKey1=%SystemDrive%\SWTOOLS|*.*|REMOVESELF
 
 [Lenovo System Update *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Lenovo\SystemUpdate\sessionSE\Repository
-FileKey1=%CommonAppData%\Lenovo\SystemUpdate\sessionSE\Repository|*.*|RECURSE
-FileKey2=%CommonAppData%\Lenovo\SystemUpdate\sessionSE\system\SSClientCommon|*.xml
+DetectFile=%ProgramData%\Lenovo\SystemUpdate\sessionSE\Repository
+FileKey1=%ProgramData%\Lenovo\SystemUpdate\sessionSE\Repository|*.*|RECURSE
+FileKey2=%ProgramData%\Lenovo\SystemUpdate\sessionSE\system\SSClientCommon|*.xml
 
 [Letasoft Sound Booster *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Letasoft\Sound Booster
-FileKey1=%CommonAppData%\Letasoft\Sound Booster\Logs|*.*
+DetectFile=%ProgramData%\Letasoft\Sound Booster
+FileKey1=%ProgramData%\Letasoft\Sound Booster\Logs|*.*
 
 [Leviev Sales Information Portal *]
 LangSecRef=3021
@@ -11146,8 +11146,8 @@ FileKey2=%ProgramFiles%\Leviev Sales Information Portal|JMSErrors.txt
 
 [Lexmark *]
 LangSecRef=3021
-DetectFile=%CommonAppData%\gn_logs
-FileKey1=%CommonAppData%\gn_logs\*|*.*
+DetectFile=%ProgramData%\gn_logs
+FileKey1=%ProgramData%\gn_logs\*|*.*
 
 [Lexmark Inkjet *]
 LangSecRef=3021
@@ -11167,9 +11167,9 @@ RegKey1=HKCU\Software\LexmarkPhoto\Lexmark Photo Software\pheditor\Recent File L
 LangSecRef=3021
 DetectFile=%LocalAppData%\Lexware
 FileKey1=%AppData%\Lexware|*.log|RECURSE
-FileKey2=%CommonAppData%\Lexware|*.log*|RECURSE
-FileKey3=%CommonAppData%\Lexware\elster\Log|*|REMOVESELF
-FileKey4=%CommonAppData%\Lexware\logs|*|REMOVESELF
+FileKey2=%ProgramData%\Lexware|*.log*|RECURSE
+FileKey3=%ProgramData%\Lexware\elster\Log|*|REMOVESELF
+FileKey4=%ProgramData%\Lexware\logs|*|REMOVESELF
 FileKey5=%CommonProgramFiles%\Lexware|*.log|RECURSE
 FileKey6=%LocalAppData%\Lexware|*.log*|RECURSE
 FileKey7=%ProgramFiles%\Lexware|*.log*|RECURSE
@@ -11211,7 +11211,7 @@ FileKey7=%ProgramFiles%\LibreOffice*\program_old*|*.*|REMOVESELF
 [LightScribe *]
 LangSecRef=3023
 Detect=HKCU\Software\LightScribe
-FileKey1=%CommonAppData%\LightScribe\log|*.xml
+FileKey1=%ProgramData%\LightScribe\log|*.xml
 
 [LightShot *]
 LangSecRef=3022
@@ -11281,7 +11281,7 @@ RegKey5=HKCU\Software\Update\Locate32\Recent Strings
 LangSecRef=3024
 Detect=HKCU\Software\LockHunter
 FileKey1=%AppData%\LockHunter|*.txt;*.log
-FileKey2=%CommonAppData%\LHService|*.txt;*.log
+FileKey2=%ProgramData%\LHService|*.txt;*.log
 
 [Logitech *]
 LangSecRef=3024
@@ -11291,10 +11291,10 @@ FileKey1=%AppData%\Logishrd|*.log|RECURSE
 FileKey2=%AppData%\Logishrd\sp*_Log|*.*|REMOVESELF
 FileKey3=%AppData%\Logishrd\Updater|UpdateList.csv
 FileKey4=%AppData%\LogiTune|*.log;LOG.old|RECURSE
-FileKey5=%CommonAppData%\Logishrd|*.log|RECURSE
-FileKey6=%CommonAppData%\Logishrd\LogiBolt|*.*|REMOVESELF
-FileKey7=%CommonAppData%\Logishrd\unifying|EngineLog.*;*.txt
-FileKey8=%CommonAppData%\Logitech\KHAL\Battery|*.log
+FileKey5=%ProgramData%\Logishrd|*.log|RECURSE
+FileKey6=%ProgramData%\Logishrd\LogiBolt|*.*|REMOVESELF
+FileKey7=%ProgramData%\Logishrd\unifying|EngineLog.*;*.txt
+FileKey8=%ProgramData%\Logitech\KHAL\Battery|*.log
 FileKey9=%CommonProgramFiles%\Logishrd|*.log|RECURSE
 FileKey10=%LocalAppData%\LogiBolt|*.*|REMOVESELF
 FileKey11=%LocalAppData%\Logishrd\Vid|*.*|RECURSE
@@ -11311,7 +11311,7 @@ FileKey2=%AppData%\LGHUB\*Storage|*.old;LOG|RECURSE
 FileKey3=%AppData%\LGHUB\blob_storage|*|REMOVESELF
 FileKey4=%AppData%\LGHUB\logs|*.log
 FileKey5=%AppData%\LGHUB\Network|*
-FileKey6=%CommonAppData%\LGHUB\cache|*
+FileKey6=%ProgramData%\LGHUB\cache|*
 
 [Logitech Harmony *]
 LangSecRef=3024
@@ -11398,9 +11398,9 @@ RegKey2=HKCU\Software\MacheteSoft\Machete\Recent File List
 [Macrium Reflect *]
 LangSecRef=3024
 Detect=HKCU\Software\Macrium\Reflect
-FileKey1=%CommonAppData%\Macrium|*.log|RECURSE
-FileKey2=%CommonAppData%\Macrium\Reflect|*.html;*.tmp;*.vsslog;loaderrors.txt
-FileKey3=%CommonAppData%\Macrium\waik|waiklog.txt
+FileKey1=%ProgramData%\Macrium|*.log|RECURSE
+FileKey2=%ProgramData%\Macrium\Reflect|*.html;*.tmp;*.vsslog;loaderrors.txt
+FileKey3=%ProgramData%\Macrium\waik|waiklog.txt
 FileKey4=%SystemDrive%|Recovery.txt;ref~tmp~.txt;Reflect_Install.log;rescuepe.log
 
 [Magic: The Gathering Arena *]
@@ -11432,8 +11432,8 @@ FileKey2=%ProgramFiles%\Sony\ACID Pro 5.0|Acid*.log
 [MAGIX Installation Manager *]
 LangSecRef=3023
 Detect=HKCU\Software\Magix\MAGIX Installation manager
-FileKey1=%CommonAppData%\MAGIX\*|*.log;*.reg
-FileKey2=%CommonAppData%\MAGIX\*\download|*.*|RECURSE
+FileKey1=%ProgramData%\MAGIX\*|*.log;*.reg
+FileKey2=%ProgramData%\MAGIX\*\download|*.*|RECURSE
 
 [MAGIX Photostory *]
 LangSecRef=3023
@@ -11491,14 +11491,14 @@ LangSecRef=3024
 Detect1=HKCU\Software\Malwarebytes
 Detect2=HKLM\Software\Malwarebytes
 FileKey1=%AppData%\Malwarebytes\Malwarebytes*Anti-Malware\Logs|*.*
-FileKey2=%CommonAppData%\Malwarebytes Anti-Exploit|*.log;mbae*.bak
-FileKey3=%CommonAppData%\Malwarebytes\Malwarebytes*Anti-Malware|mbam-setup.exe
-FileKey4=%CommonAppData%\Malwarebytes\Malwarebytes*Anti-Malware\Logs|*.*
-FileKey5=%CommonAppData%\Malwarebytes\MBAMService|*.log;*.bak;*.regtrans-ms;*.TM.blf;*-ntuser.dat;*.LOG*;*-UsrClass.dat
-FileKey6=%CommonAppData%\Malwarebytes\MBAMService\config|*.bak
-FileKey7=%CommonAppData%\Malwarebytes\MBAMService\logs|*.*
-FileKey8=%CommonAppData%\Malwarebytes\MBAMService\ScanResults|*.*
-FileKey9=%CommonAppData%\Malwarebytes\MBAMService\tmp|*.*
+FileKey2=%ProgramData%\Malwarebytes Anti-Exploit|*.log;mbae*.bak
+FileKey3=%ProgramData%\Malwarebytes\Malwarebytes*Anti-Malware|mbam-setup.exe
+FileKey4=%ProgramData%\Malwarebytes\Malwarebytes*Anti-Malware\Logs|*.*
+FileKey5=%ProgramData%\Malwarebytes\MBAMService|*.log;*.bak;*.regtrans-ms;*.TM.blf;*-ntuser.dat;*.LOG*;*-UsrClass.dat
+FileKey6=%ProgramData%\Malwarebytes\MBAMService\config|*.bak
+FileKey7=%ProgramData%\Malwarebytes\MBAMService\logs|*.*
+FileKey8=%ProgramData%\Malwarebytes\MBAMService\ScanResults|*.*
+FileKey9=%ProgramData%\Malwarebytes\MBAMService\tmp|*.*
 FileKey10=%LocalAppData%\Crashdumps\Malwarebytes|*.*|REMOVESELF
 FileKey11=%LocalAppData%\MBAM*\Cache\qmlcache|*.*
 FileKey12=%LocalLowAppData%\IGDump|*.*|REMOVESELF
@@ -11527,8 +11527,8 @@ RegKey5=HKCU\Software\ManiacTools\MusicDuplicate|SavedFoldersList
 
 [ManiaPlanet *]
 Section=Games
-DetectFile=%CommonAppData%\ManiaPlanet
-FileKey1=%CommonAppData%\ManiaPlanet\Cache|*.*
+DetectFile=%ProgramData%\ManiaPlanet
+FileKey1=%ProgramData%\ManiaPlanet\Cache|*.*
 
 [ManyCam *]
 LangSecRef=3023
@@ -11656,24 +11656,24 @@ FileKey1=%AppData%\Maxthon5\Users\*|Web Data
 LangSecRef=3024
 Detect1=HKCU\Software\SiteAdvisor
 Detect2=HKLM\Software\McAfee
-DetectFile=%CommonAppData%\McAfee
-FileKey1=%CommonAppData%\McAfee\AMCore\datreputation\Logs|*|RECURSE
-FileKey2=%CommonAppData%\McAfee\Common Framework\AgentEvents|*
-FileKey3=%CommonAppData%\McAfee\CSP\ETW|*.bak
-FileKey4=%CommonAppData%\McAfee\Jcm|*.tmp
-FileKey5=%CommonAppData%\McAfee\MCLOGS|*.bak;*.log|RECURSE
-FileKey6=%CommonAppData%\McAfee\MHN|*.bak
-FileKey7=%CommonAppData%\McAfee\modulecoreservice.exe|*.txt
-FileKey8=%CommonAppData%\McAfee\MPF|*.tmp
-FileKey9=%CommonAppData%\McAfee\MPF\data|*|RECURSE
-FileKey10=%CommonAppData%\McAfee\MSC\Cache|McSubDB.Bak
-FileKey11=%CommonAppData%\McAfee\MSC\Logs|*.log
-FileKey12=%CommonAppData%\McAfee\SiteAdvisor|*.txt;*.log;*.tmp|RECURSE
-FileKey13=%CommonAppData%\McAfee\Uninstall.exe|log.txt
-FileKey14=%CommonAppData%\McAfee\Update|*|RECURSE
-FileKey15=%CommonAppData%\McAfee\VirusScan\Data|*.log;*.old
-FileKey16=%CommonAppData%\McAfee\VirusScan\Logs|*|RECURSE
-FileKey17=%CommonAppData%\Network Associates\Common Framework\AgentEvents|*
+DetectFile=%ProgramData%\McAfee
+FileKey1=%ProgramData%\McAfee\AMCore\datreputation\Logs|*|RECURSE
+FileKey2=%ProgramData%\McAfee\Common Framework\AgentEvents|*
+FileKey3=%ProgramData%\McAfee\CSP\ETW|*.bak
+FileKey4=%ProgramData%\McAfee\Jcm|*.tmp
+FileKey5=%ProgramData%\McAfee\MCLOGS|*.bak;*.log|RECURSE
+FileKey6=%ProgramData%\McAfee\MHN|*.bak
+FileKey7=%ProgramData%\McAfee\modulecoreservice.exe|*.txt
+FileKey8=%ProgramData%\McAfee\MPF|*.tmp
+FileKey9=%ProgramData%\McAfee\MPF\data|*|RECURSE
+FileKey10=%ProgramData%\McAfee\MSC\Cache|McSubDB.Bak
+FileKey11=%ProgramData%\McAfee\MSC\Logs|*.log
+FileKey12=%ProgramData%\McAfee\SiteAdvisor|*.txt;*.log;*.tmp|RECURSE
+FileKey13=%ProgramData%\McAfee\Uninstall.exe|log.txt
+FileKey14=%ProgramData%\McAfee\Update|*|RECURSE
+FileKey15=%ProgramData%\McAfee\VirusScan\Data|*.log;*.old
+FileKey16=%ProgramData%\McAfee\VirusScan\Logs|*|RECURSE
+FileKey17=%ProgramData%\Network Associates\Common Framework\AgentEvents|*
 
 [McAfee Real Protect *]
 LangSecRef=3024
@@ -11796,7 +11796,7 @@ RegKey15=HKCU\Software\JBSoftware\MemoMaster5|FileMRU15
 LangSecRef=3022
 DetectFile=%AppData%\MemoQ
 FileKey1=%AppData%\MemoQ\Log|*.log
-FileKey2=%CommonAppData%\MemoQ Server\Log|*.log
+FileKey2=%ProgramData%\MemoQ Server\Log|*.log
 
 [MEmu Android Emulator *]
 LangSecRef=3021
@@ -11913,7 +11913,7 @@ LangSecRef=3022
 DetectFile=%AppData%\SoftGrid Client
 FileKey1=%AppData%\SoftGrid Client|*.tmp|RECURSE
 FileKey2=%AppData%\SoftGrid Client\Icon Cache|*.*
-FileKey3=%CommonAppData%\Microsoft\Application Virtualization Client\SoftGrid Client|*.tmp|RECURSE
+FileKey3=%ProgramData%\Microsoft\Application Virtualization Client\SoftGrid Client|*.tmp|RECURSE
 FileKey4=%LocalAppData%\SoftGrid Client|*.tmp|RECURSE
 
 [Microsoft Backup *]
@@ -11980,7 +11980,7 @@ Detect1=HKCU\Software\Microsoft\HTML Help Workshop
 Detect2=HKCU\Software\Microsoft\Microsoft Help Workshop
 Detect3=HKLM\Software\Microsoft\HTMLHelp
 FileKey1=%AppData%\Microsoft\HTML Help|hh.dat;hhcolreg.dat;*.chw
-FileKey2=%CommonAppData%\Microsoft\HTML Help|hh.dat;hhcolreg.dat
+FileKey2=%ProgramData%\Microsoft\HTML Help|hh.dat;hhcolreg.dat
 FileKey3=%SystemDrive%\Documents and Settings\LocalService\Application Data\Microsoft\HTML Help|hh.dat
 FileKey4=%WinDir%\Application Data\Microsoft\HTML Help|hh.dat
 FileKey5=%WinDir%\Help|*.cnt;*.chw
@@ -12254,11 +12254,11 @@ FileKey1=%AppData%\Microsoft\Picture It!*|piorg.db
 [Microsoft PlayReady *]
 LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.Media.PlayReadyClient_8wekyb3d8bbwe
-FileKey1=%CommonAppData%\Microsoft\PlayReady|*.hds
-FileKey2=%CommonAppData%\Microsoft\PlayReady\Cache|*.*
-FileKey3=%CommonAppData%\Microsoft\Windows\DRM|*.log
-FileKey4=%CommonAppData%\Microsoft\Windows\DRM\Cache|*.*|RECURSE
-FileKey5=%CommonAppData%\Microsoft\Windows\DRM\PreUpgrade|*.log
+FileKey1=%ProgramData%\Microsoft\PlayReady|*.hds
+FileKey2=%ProgramData%\Microsoft\PlayReady\Cache|*.*
+FileKey3=%ProgramData%\Microsoft\Windows\DRM|*.log
+FileKey4=%ProgramData%\Microsoft\Windows\DRM\Cache|*.*|RECURSE
+FileKey5=%ProgramData%\Microsoft\Windows\DRM\PreUpgrade|*.log
 FileKey6=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\*Cache|*|RECURSE
 FileKey7=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\INet*|*|RECURSE
 FileKey8=%LocalAppData%\Packages\Microsoft.Media.PlayReadyClient_*\AC\Microsoft\CLR_v4.0\UsageLogs|*|RECURSE
@@ -12303,7 +12303,7 @@ FileKey5=%LocalAppData%\Packages\Microsoft.MicrosoftSolitaireCollection_*\TempSt
 [Microsoft Standalone System Sweeper Tool *]
 LangSecRef=3024
 Detect=HKCU\Software\Microsoft\Microsoft Standalone System Sweeper Tool
-FileKey1=%CommonAppData%\Microsoft\Microsoft Standalone System Sweeper Tool\Support|*.log
+FileKey1=%ProgramData%\Microsoft\Microsoft Standalone System Sweeper Tool\Support|*.log
 
 [Microsoft Store *]
 LangSecRef=3025
@@ -12784,8 +12784,8 @@ FileKey1=%AppData%\Microsoft\VCExpress\10.0|*.winprf_backup
 [Microsoft Visual Studio Installation Packages *]
 LangSecRef=3021
 Detect=HKCU\Software\Microsoft\VisualStudio
-FileKey1=%CommonAppData%\Microsoft\VisualStudio\Packages|*.*|RECURSE
-ExcludeKey1=PATH|%CommonAppData%\Microsoft\VisualStudio\Packages\_Instances\|*.*
+FileKey1=%ProgramData%\Microsoft\VisualStudio\Packages|*.*|RECURSE
+ExcludeKey1=PATH|%ProgramData%\Microsoft\VisualStudio\Packages\_Instances\|*.*
 
 [Microsoft VS Code *]
 LangSecRef=3021
@@ -12841,7 +12841,7 @@ FileKey2=%LocalAppData%\Midori|cookies.db;history.*;session.xbel
 [MiKTeX *]
 LangSecRef=3021
 Detect=HKCU\Software\MiKTeX.org\MiKTeX
-FileKey1=%CommonAppData%\MiKTeX\*\miktex\log|*.log
+FileKey1=%ProgramData%\MiKTeX\*\miktex\log|*.log
 FileKey2=%LocalAppData%\MiKTeX\*\miktex\log|*.log
 FileKey3=%ProgramFiles%\MiKTeX\miktex\config|*.log
 
@@ -12894,7 +12894,7 @@ RegKey14=HKCU\Software\MindGems\Fast Duplicate File Finder\Settings|QuickCheckFi
 [MindGems Folder Size *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Folder Size
-FileKey1=%CommonAppData%\MindGems\FolderSize|FolderSizeLog.txt
+FileKey1=%ProgramData%\MindGems\FolderSize|FolderSizeLog.txt
 
 [MindGems Visual Similarity Duplicate Image Finder *]
 LangSecRef=3023
@@ -12984,8 +12984,8 @@ FileKey1=%AppData%\mirkes.de\Tiny Hexer\*|*.bak
 
 [MirrorFolder *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Techsoft\MirrorFolder
-FileKey1=%CommonAppData%\Techsoft\MirrorFolder\Log|*.*
+DetectFile=%ProgramData%\Techsoft\MirrorFolder
+FileKey1=%ProgramData%\Techsoft\MirrorFolder\Log|*.*
 
 [Mirrors Edge Catalyst Backup *]
 Section=Games
@@ -13211,8 +13211,8 @@ FileKey1=%ProgramFiles%\Motherboard Monitor 5\Log|*.*|REMOVESELF
 LangSecRef=3024
 Detect=HKLM\Software\Motorola
 FileKey1=%AppData%\Motorola\MotoHelper|*.log
-FileKey2=%CommonAppData%\Motorola\SUE|*.log
-FileKey3=%CommonAppData%\Motorola\SUE\Firmwares|*.*
+FileKey2=%ProgramData%\Motorola\SUE|*.log
+FileKey3=%ProgramData%\Motorola\SUE\Firmwares|*.*
 FileKey4=%ProgramFiles%\Motorola|*.log|RECURSE
 FileKey5=%ProgramFiles%\Motorola Mobility\DeviceSoftwareUpdate|*.log
 FileKey6=%ProgramFiles%\Motorola Mobility\Motorola Device Manager|*.log
@@ -13402,10 +13402,10 @@ RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 [MTA: San Andreas *]
 Section=Games
 Detect=HKLM\Software\Multi Theft Auto: San Andreas All
-FileKey1=%CommonAppData%\MTA San Andreas All\1.*|report.log
-FileKey2=%CommonAppData%\MTA San Andreas All\1.*\temp|*.*|RECURSE
-FileKey3=%CommonAppData%\MTA San Andreas All\1.*\upcache|*.*|RECURSE
-FileKey4=%CommonAppData%\MTA San Andreas All\Common\Installer|nsis.log
+FileKey1=%ProgramData%\MTA San Andreas All\1.*|report.log
+FileKey2=%ProgramData%\MTA San Andreas All\1.*\temp|*.*|RECURSE
+FileKey3=%ProgramData%\MTA San Andreas All\1.*\upcache|*.*|RECURSE
+FileKey4=%ProgramData%\MTA San Andreas All\Common\Installer|nsis.log
 FileKey5=%ProgramFiles%\MTA San Andreas 1.*\mods\deathmatch\resources|*.*|RECURSE
 FileKey6=%ProgramFiles%\MTA San Andreas 1.*\MTA|core.dmp;core.log
 FileKey7=%ProgramFiles%\MTA San Andreas 1.*\MTA\CEF|cefdebug.txt
@@ -13428,8 +13428,8 @@ FileKey2=%ProgramFiles%\MTA San Andreas 1.*\server\mods\deathmatch\resource-cach
 [Mullvad VPN *]
 LangSecRef=3022
 Detect=HKLM\Software\Mullvad VPN
-FileKey1=%CommonAppData%\Mullvad VPN|*.log
-FileKey2=%CommonAppData%\Mullvad VPN\cache|*.*
+FileKey1=%ProgramData%\Mullvad VPN|*.log
+FileKey2=%ProgramData%\Mullvad VPN\cache|*.*
 FileKey3=%LocalAppData%\Mullvad VPN|Network Persistent State
 FileKey4=%LocalAppData%\Mullvad VPN\*Cache|*.*|RECURSE
 FileKey5=%LocalAppData%\Mullvad VPN\Local Storage|*.*|RECURSE
@@ -13528,10 +13528,10 @@ FileKey3=%ProgramFiles%\Atari\W!Games\My Horse and Me|*log.txt;*.log|RECURSE
 
 [My Movies Collection *]
 LangSecRef=3023
-DetectFile=%CommonAppData%\My Movies
-FileKey1=%CommonAppData%\My Movies|vc*redist*.*;*log.txt
-FileKey2=%CommonAppData%\My Movies\File Storage\Temp|*.*|RECURSE
-FileKey3=%CommonAppData%\My Movies\Temp|*.*|RECURSE
+DetectFile=%ProgramData%\My Movies
+FileKey1=%ProgramData%\My Movies|vc*redist*.*;*log.txt
+FileKey2=%ProgramData%\My Movies\File Storage\Temp|*.*|RECURSE
+FileKey3=%ProgramData%\My Movies\Temp|*.*|RECURSE
 
 [My Riding Stables *]
 Section=Games
@@ -13724,11 +13724,11 @@ FileKey11=%AppData%\Nero\Nero*\Nero Recode\AnalysisData|*.dat
 FileKey12=%AppData%\Nero\Nero*\Nero Recode\Thumbs|*.*
 FileKey13=%AppData%\Nero\Nero*\Nero Vision|*.txt;*.bin
 FileKey14=%AppData%\Nero\Nero*\Nero Vision\NVFACache|*.*
-FileKey15=%CommonAppData%\Ahead\Nero BackItUp*\Cache|*.*
-FileKey16=%CommonAppData%\Nero|*.log|RECURSE
-FileKey17=%CommonAppData%\Nero\Nero BackItUp*\Cache|*.*
-FileKey18=%CommonAppData%\Nero\NeroUpdate\Logs|*.*
-FileKey19=%CommonAppData%\Nero\PeakFiles|*.tmp
+FileKey15=%ProgramData%\Ahead\Nero BackItUp*\Cache|*.*
+FileKey16=%ProgramData%\Nero|*.log|RECURSE
+FileKey17=%ProgramData%\Nero\Nero BackItUp*\Cache|*.*
+FileKey18=%ProgramData%\Nero\NeroUpdate\Logs|*.*
+FileKey19=%ProgramData%\Nero\PeakFiles|*.tmp
 FileKey20=%LocalAppData%\Nero\Nero*\Nero Vision\Cache|*.*
 FileKey21=%LocalAppData%\Nero\Nero*\Nero Vision\Cache\GraphicObjectCache|*.*
 FileKey22=%LocalAppData%\Nero\NeroKnowHowPLUS|*.log
@@ -13814,18 +13814,18 @@ RegKey77=HKU\.DEFAULT\Software\Ahead\Nero Wave Editor\Recent File List
 
 [Nero TuneItUp *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Nero\Nero TuneItUp
-FileKey1=%CommonAppData%\Nero\Nero TuneItUp|Setup Log*.log
-FileKey2=%CommonAppData%\Nero\Nero TuneItUp\cache|*.*|RECURSE
-FileKey3=%CommonAppData%\Nero\Nero TuneItUp\DriverUpdate|*.log
-FileKey4=%CommonAppData%\Nero\Nero TuneItUp\ExceptionHandlerDll|*.dmp;*.*log
-FileKey5=%CommonAppData%\Nero\Nero TuneItUp\RegCleanerDll\Log|*.log
-FileKey6=%CommonAppData%\Nero\Nero TuneItUp\RegDefragDll\Log|*.log
-FileKey7=%CommonAppData%\Nero\Nero TuneItUp\Reports|*.html|RECURSE
-FileKey8=%CommonAppData%\Nero\Nero TuneItUp\Services|*.log
-FileKey9=%CommonAppData%\Nero\Nero TuneItUp\SoftwareProducts|*.log
-FileKey10=%CommonAppData%\Nero\Nero TuneItUp\Startup|*.log
-FileKey11=%CommonAppData%\Nero\Nero TuneItUp\TemperatureMonitoringModule|*.log
+DetectFile=%ProgramData%\Nero\Nero TuneItUp
+FileKey1=%ProgramData%\Nero\Nero TuneItUp|Setup Log*.log
+FileKey2=%ProgramData%\Nero\Nero TuneItUp\cache|*.*|RECURSE
+FileKey3=%ProgramData%\Nero\Nero TuneItUp\DriverUpdate|*.log
+FileKey4=%ProgramData%\Nero\Nero TuneItUp\ExceptionHandlerDll|*.dmp;*.*log
+FileKey5=%ProgramData%\Nero\Nero TuneItUp\RegCleanerDll\Log|*.log
+FileKey6=%ProgramData%\Nero\Nero TuneItUp\RegDefragDll\Log|*.log
+FileKey7=%ProgramData%\Nero\Nero TuneItUp\Reports|*.html|RECURSE
+FileKey8=%ProgramData%\Nero\Nero TuneItUp\Services|*.log
+FileKey9=%ProgramData%\Nero\Nero TuneItUp\SoftwareProducts|*.log
+FileKey10=%ProgramData%\Nero\Nero TuneItUp\Startup|*.log
+FileKey11=%ProgramData%\Nero\Nero TuneItUp\TemperatureMonitoringModule|*.log
 
 [NesterJ *]
 LangSecRef=3024
@@ -13835,7 +13835,7 @@ RegKey1=HKCU\Software\nesterJ\Recent
 [Net-Peeker *]
 LangSecRef=3024
 Detect=HKLM\Software\eMingSoftware\NetPeeker
-FileKey1=%CommonAppData%\eMingSoftware\NetPeeker\Log|*.*
+FileKey1=%ProgramData%\eMingSoftware\NetPeeker\Log|*.*
 RegKey1=HKCU\Software\eMingSoftware\Net-Peeker Group Console\Recent File List
 RegKey2=HKLM\Software\eMingSoftware\NetPeeker|ConsoleName
 
@@ -14048,7 +14048,7 @@ FileKey1=%ProgramFiles%\nLite\Presets|*.*
 [No-IP DUC *]
 LangSecRef=3022
 Detect=HKCU\Software\Vitalwerks\DUC
-FileKey1=%CommonAppData%\Vitalwerks\DUC|*.log
+FileKey1=%ProgramData%\Vitalwerks\DUC|*.log
 FileKey2=%LocalAppData%\Vitalwerks\DUC|*.log
 
 [NoBot *]
@@ -14084,9 +14084,9 @@ FileKey1=%LocalAppData%\Nokia\Nokia Music*|*.log
 LangSecRef=3021
 Detect1=HKCU\Software\Nokia\NSU3
 Detect2=HKLM\Software\Nokia\Nokia Suite
-DetectFile1=%CommonAppData%\Nokia\Nokia Service Layer\A
+DetectFile1=%ProgramData%\Nokia\Nokia Service Layer\A
 DetectFile2=%CommonProgramFiles%\Nokia\Service Layer\A
-FileKey1=%CommonAppData%\Nokia\Nokia Service Layer\A|*.*|REMOVESELF
+FileKey1=%ProgramData%\Nokia\Nokia Service Layer\A|*.*|REMOVESELF
 FileKey2=%CommonProgramFiles%\Nokia\Service Layer\A|*.*|REMOVESELF
 FileKey3=%LocalAppData%\Nokia\NSU3\NOSSU2|*.*|RECURSE
 ExcludeKey1=FILE|%LocalAppData%\Nokia\NSU3\NOSSU2\|usergroups.cfg
@@ -14097,7 +14097,7 @@ LangSecRef=3021
 DetectFile=%AppData%\Nokia Suite
 FileKey1=%AppData%\Nokia Suite\Nokia Connector|*.log
 FileKey2=%AppData%\Nokia\intellisync\*\configuration|*.log
-FileKey3=%CommonAppData%\NokiaInstallerCache\PackageCache|*.*|RECURSE
+FileKey3=%ProgramData%\NokiaInstallerCache\PackageCache|*.*|RECURSE
 
 [NordVPN *]
 LangSecRef=3022
@@ -14119,22 +14119,22 @@ FileKey4=%ProgramFiles%\Norman\Temp|*.*
 
 [Norton *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Norton
+DetectFile=%ProgramData%\Norton
 FileKey1=%AppData%\Norton\logs|*.*
-FileKey2=%CommonAppData%\Norton|*.log;*.txt
-FileKey3=%CommonAppData%\Norton\LocalDumps|*.dmp
-FileKey4=%CommonAppData%\NortonInstaller\Logs|*.*|RECURSE
-FileKey5=%CommonAppData%\VPNService|*.log
+FileKey2=%ProgramData%\Norton|*.log;*.txt
+FileKey3=%ProgramData%\Norton\LocalDumps|*.dmp
+FileKey4=%ProgramData%\NortonInstaller\Logs|*.*|RECURSE
+FileKey5=%ProgramData%\VPNService|*.log
 
 [Norton Online Backup *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Symantec\Norton Online Backup
-FileKey1=%CommonAppData%\Symantec\Norton Online Backup|*.log*|RECURSE
+DetectFile=%ProgramData%\Symantec\Norton Online Backup
+FileKey1=%ProgramData%\Symantec\Norton Online Backup|*.log*|RECURSE
 
 [Norton Power Eraser *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Norton\NPE\NPEsettings.dat
-FileKey1=%CommonAppData%\Norton\NPE|*.*|REMOVESELF
+DetectFile=%ProgramData%\Norton\NPE\NPEsettings.dat
+FileKey1=%ProgramData%\Norton\NPE|*.*|REMOVESELF
 FileKey2=%LocalAppData%\NPE|*.*|REMOVESELF
 FileKey3=%UserProfile%\Desktop|NPE.exe
 
@@ -14150,7 +14150,7 @@ DetectFile1=%ProgramFiles%\Norton SystemWorks Premier Edition\Norton Utilities
 DetectFile2=%ProgramFiles%\Norton Utilities*
 FileKey1=%AppData%\Norton Utilities *\cleanreports|pgscan_*.html
 FileKey2=%AppData%\Norton Utilities\log|pgscan_*.html
-FileKey3=%CommonAppData%\Norton\NortonUtility\logs|*.log
+FileKey3=%ProgramData%\Norton\NortonUtility\logs|*.log
 FileKey4=%ProgramFiles%\Norton SystemWorks Premier Edition\Norton Utilities|*.log;*.tmp
 
 [Notepad *]
@@ -14272,17 +14272,17 @@ FileKey4=%ProgramFiles%\Steam\SteamApps\common\Nuclear Dawn\nucleardawn\sound\vo
 LangSecRef=3024
 Detect=HKLM\Software\NVIDIA Corporation
 FileKey1=%AppData%\NVIDIA\*Cache|*|RECURSE
-FileKey2=%CommonAppData%|DisplaySessionContainer*.log*;NvcDispCorePlugin.log*;NVDisplay.Container*.log*
-FileKey3=%CommonAppData%\NVIDIA|*.bak;Resource.old;*.log*|RECURSE
-FileKey4=%CommonAppData%\NVIDIA Corporation|*.log*;*.bak;*.old;*.stat|RECURSE
-FileKey5=%CommonAppData%\NVIDIA Corporation\CrashDumps|*
-FileKey6=%CommonAppData%\NVIDIA Corporation\Downloader|*|RECURSE
-FileKey7=%CommonAppData%\NVIDIA Corporation\GeForce Experience\Update|*|RECURSE
-FileKey8=%CommonAppData%\NVIDIA Corporation\NV_Cache|*
-FileKey9=%CommonAppData%\NVIDIA Corporation\NvFBCPlugin|log*.txt
-FileKey10=%CommonAppData%\NVIDIA\NvBackend\Updatus\DownloadManager|*
-FileKey11=%CommonAppData%\NVIDIA\Updatus|*.bak;*.log
-FileKey12=%CommonAppData%\NVIDIA\Updatus\DownloadManager|*
+FileKey2=%ProgramData%|DisplaySessionContainer*.log*;NvcDispCorePlugin.log*;NVDisplay.Container*.log*
+FileKey3=%ProgramData%\NVIDIA|*.bak;Resource.old;*.log*|RECURSE
+FileKey4=%ProgramData%\NVIDIA Corporation|*.log*;*.bak;*.old;*.stat|RECURSE
+FileKey5=%ProgramData%\NVIDIA Corporation\CrashDumps|*
+FileKey6=%ProgramData%\NVIDIA Corporation\Downloader|*|RECURSE
+FileKey7=%ProgramData%\NVIDIA Corporation\GeForce Experience\Update|*|RECURSE
+FileKey8=%ProgramData%\NVIDIA Corporation\NV_Cache|*
+FileKey9=%ProgramData%\NVIDIA Corporation\NvFBCPlugin|log*.txt
+FileKey10=%ProgramData%\NVIDIA\NvBackend\Updatus\DownloadManager|*
+FileKey11=%ProgramData%\NVIDIA\Updatus|*.bak;*.log
+FileKey12=%ProgramData%\NVIDIA\Updatus\DownloadManager|*
 FileKey13=%LocalAppData%\NVIDIA Corporation|*.log;*.bak;*.old|RECURSE
 FileKey14=%LocalAppData%\NVIDIA Corporation\*\CefCache|Cookies*;QuotaManager*;Visited Links
 FileKey15=%LocalAppData%\NVIDIA Corporation\*\CefCache\*Cache|*|RECURSE
@@ -14302,8 +14302,8 @@ ExcludeKey1=PATH|%LocalAppData%\NVIDIA Corporation\*\CefCache\IndexedDB\|*.log
 
 [NVIDIA Broadcast *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\NVIDIA Corporation\NVIDIA Broadcast
-FileKey1=%CommonAppData%\NVIDIA Corporation\NVIDIA Broadcast|*.log;*.txt
+DetectFile=%ProgramData%\NVIDIA Corporation\NVIDIA Broadcast
+FileKey1=%ProgramData%\NVIDIA Corporation\NVIDIA Broadcast|*.log;*.txt
 
 [O&O Defrag *]
 LangSecRef=3024
@@ -14369,11 +14369,11 @@ ExcludeKey3=PATH|%LocalAppData%\OEClassic\Prg\Res\|dict-*.license
 
 [OEM Logs *]
 LangSecRef=3021
-DetectFile1=%CommonAppData%\oem
+DetectFile1=%ProgramData%\oem
 DetectFile2=%SystemDrive%\OEM
 DetectFile3=%WinDir%\System32\OEM
 DetectFile4=%WinDir%\SysWOW64\OEM
-FileKey1=%CommonAppData%\oem|*.log|RECURSE
+FileKey1=%ProgramData%\oem|*.log|RECURSE
 FileKey2=%SystemDrive%\OEM|*.log|RECURSE
 FileKey3=%WinDir%\oem|*.log;*.log.txt|RECURSE
 FileKey4=%WinDir%\System32\OEM|*.log
@@ -14495,9 +14495,9 @@ FileKey1=%ProgramFiles%\Openfire\Logs|*.*
 
 [OpenMG *]
 LangSecRef=3023
-DetectFile=%CommonAppData%\Sony Corporation\OpenMG
-FileKey1=%CommonAppData%\Sony Corporation\OpenMG|*.log
-FileKey2=%CommonAppData%\Sony Corporation\OpenMG\CD Walkman\Temp|*.*|REMOVESELF
+DetectFile=%ProgramData%\Sony Corporation\OpenMG
+FileKey1=%ProgramData%\Sony Corporation\OpenMG|*.log
+FileKey2=%ProgramData%\Sony Corporation\OpenMG\CD Walkman\Temp|*.*|REMOVESELF
 
 [OpenMG Jukebox *]
 LangSecRef=3023
@@ -14597,7 +14597,7 @@ ExcludeKey1=FILE|%ProgramFiles%\Oxygen XML Editor 14\.install4j\|files.log
 [PACE Eden *]
 LangSecRef=3021
 DetectFile=%LocalAppData%\PACE\Eden
-FileKey1=%CommonAppData%\PACE\Eden\LdLogs|*.*
+FileKey1=%ProgramData%\PACE\Eden\LdLogs|*.*
 FileKey2=%LocalAppData%\PACE\Eden\Logs|*.*|RECURSE
 FileKey3=%LocalAppData%\PaceAp\iLok License Manager\Cache\Images|*.*|RECURSE
 
@@ -14611,8 +14611,8 @@ FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Pacific Storm*|*.log|RECURSE
 [PageTech PCLReader *]
 LangSecRef=3024
 Detect=HKLM\SOFTWARE\PageTech
-DetectFile=%CommonAppData%\PageTech
-FileKey1=%CommonAppData%\PageTech|*.log
+DetectFile=%ProgramData%\PageTech
+FileKey1=%ProgramData%\PageTech|*.log
 
 [Painkiller Hell & Damnation *]
 Section=Games
@@ -14655,17 +14655,17 @@ FileKey1=%AppData%\Paltalk|*.*|RECURSE
 [Panasonic HD Writer *]
 LangSecRef=3023
 DetectFile=%LocalAppData%\Panasonic\HD Writer*
-FileKey1=%CommonAppData%\Panasonic\HD Writer*|EventLog.evl|RECURSE
+FileKey1=%ProgramData%\Panasonic\HD Writer*|EventLog.evl|RECURSE
 FileKey2=%LocalAppData%\Panasonic\HD Writer*\Log|*.*
 
 [Panda Antivirus *]
 LangSecRef=3024
 Detect=HKLM\Software\Panda Security
-FileKey1=%CommonAppData%\Panda Security\Panda Devices Agent\Logs|*.*
-FileKey2=%CommonAppData%\Panda Security\Panda Security Protection|*.log
-FileKey3=%CommonAppData%\Panda Security\Panda Security Protection\Logs|*.*
-FileKey4=%CommonAppData%\Panda Security\Panda Security Protection\SRFRepository|*.bak
-FileKey5=%CommonAppData%\Panda Security\PSLogs|*.log
+FileKey1=%ProgramData%\Panda Security\Panda Devices Agent\Logs|*.*
+FileKey2=%ProgramData%\Panda Security\Panda Security Protection|*.log
+FileKey3=%ProgramData%\Panda Security\Panda Security Protection\Logs|*.*
+FileKey4=%ProgramData%\Panda Security\Panda Security Protection\SRFRepository|*.bak
+FileKey5=%ProgramData%\Panda Security\PSLogs|*.log
 
 [Pandion *]
 LangSecRef=3022
@@ -14698,20 +14698,20 @@ FileKey12=%LocalAppData%\Paradox Interactive\Launcher*\Logs|*
 [Paragon Partition Manager / Hard Disk Manager Suite *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Paragon Software\*Manager*
-FileKey1=%CommonAppData%\clonehdd|*.log
-FileKey2=%CommonAppData%\converthfs|*.log
-FileKey3=%CommonAppData%\createpart|*.log
-FileKey4=%CommonAppData%\deletepart|*.log
-FileKey5=%CommonAppData%\explauncher|*.log
-FileKey6=%CommonAppData%\formatpart|*.log
-FileKey7=%CommonAppData%\ftw|*.log
-FileKey8=%CommonAppData%\launcher|*.log
-FileKey9=%CommonAppData%\logsaver|*.log
-FileKey10=%CommonAppData%\migrateos|*.log
-FileKey11=%CommonAppData%\redistpart|*.log
-FileKey12=%CommonAppData%\vmadjust|*.log
-FileKey13=%CommonAppData%\vmcreate|*.log
-FileKey14=%CommonAppData%\wipe|*.log
+FileKey1=%ProgramData%\clonehdd|*.log
+FileKey2=%ProgramData%\converthfs|*.log
+FileKey3=%ProgramData%\createpart|*.log
+FileKey4=%ProgramData%\deletepart|*.log
+FileKey5=%ProgramData%\explauncher|*.log
+FileKey6=%ProgramData%\formatpart|*.log
+FileKey7=%ProgramData%\ftw|*.log
+FileKey8=%ProgramData%\launcher|*.log
+FileKey9=%ProgramData%\logsaver|*.log
+FileKey10=%ProgramData%\migrateos|*.log
+FileKey11=%ProgramData%\redistpart|*.log
+FileKey12=%ProgramData%\vmadjust|*.log
+FileKey13=%ProgramData%\vmcreate|*.log
+FileKey14=%ProgramData%\wipe|*.log
 FileKey15=%ProgramFiles%\Paragon Software\Hard Disk Manager * Suite|*.log;*Log.txt;fdisk.txt|RECURSE
 FileKey16=%ProgramFiles%\Paragon Software\Hard Disk Manager 14 Suite\*\symmpi*|*.txt
 FileKey17=%SystemDrive%\Documents and Settings\LocalService|objsrv.log
@@ -14758,8 +14758,8 @@ FileKey1=%AppData%\Parsec|log.txt
 
 [Partner Application *]
 LangSecRef=3022
-DetectFile=%CommonAppData%\Partner
-FileKey1=%CommonAppData%\Partner|*.log
+DetectFile=%ProgramData%\Partner
+FileKey1=%ProgramData%\Partner|*.log
 
 [Passware Encryption Analyzer *]
 LangSecRef=3021
@@ -14805,8 +14805,8 @@ FileKey1=%ProgramFiles%\PC-Doctor For Windows\Logs|*.*
 
 [PC Optimizer Pro *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\PC optimizer pro
-FileKey1=%CommonAppData%\PC Optimizer Pro\Logs|*.*
+DetectFile=%ProgramData%\PC optimizer pro
+FileKey1=%ProgramData%\PC Optimizer Pro\Logs|*.*
 
 [PC TechZone Merlin InstantFeedback *]
 LangSecRef=3024
@@ -14839,8 +14839,8 @@ FileKey1=%AppData%\Soft4Boost\Logs|*.*|RECURSE
 LangSecRef=3021
 Detect1=HKCU\Software\Tracker Software\PDFViewer
 Detect2=HKCU\Software\Tracker Software\PDFXEditor
-FileKey1=%CommonAppData%\Tracker Software\TrackerUpdate|TrackerUpdate.exe.del
-FileKey2=%CommonAppData%\Tracker Software\TrackerUpdate\Download|*.*
+FileKey1=%ProgramData%\Tracker Software\TrackerUpdate|TrackerUpdate.exe.del
+FileKey2=%ProgramData%\Tracker Software\TrackerUpdate\Download|*.*
 FileKey3=%LocalAppData%\Tracker Software\LiveUpdate\Updates|*.*
 RegKey1=HKCU\Software\Tracker Software\PDFViewer\Documents\LastOpened
 RegKey2=HKCU\Software\Tracker Software\PDFViewer\Documents\LatestView\Bars
@@ -14888,11 +14888,11 @@ FileKey1=%ProgramFiles%\PlotSoft\PDFill_PDF_Tools\download|gs.zip
 [PDFsam *]
 LangSecRef=3021
 DetectFile1=%AppData%\PDFsam Enhanced*
-DetectFile2=%CommonAppData%\PDFsam Basic
+DetectFile2=%ProgramData%\PDFsam Basic
 FileKey1=%AppData%\PDFsam Enhanced*\logs|*.htm
-FileKey2=%CommonAppData%\PDFsam Basic|*.msi
-FileKey3=%CommonAppData%\PDFsam Enhanced*\Installation|*.exe;*.msi
-FileKey4=%CommonAppData%\PDFsam Enhanced*\Installation\logs|*.*
+FileKey2=%ProgramData%\PDFsam Basic|*.msi
+FileKey3=%ProgramData%\PDFsam Enhanced*\Installation|*.exe;*.msi
+FileKey4=%ProgramData%\PDFsam Enhanced*\Installation\logs|*.*
 
 [PDFStreamDumper *]
 LangSecRef=3024
@@ -14950,7 +14950,7 @@ FileKey6=%LocalAppData%\Packages\Microsoft.People_*\TempState|*.*|RECURSE
 [PerfectDisk *]
 LangSecRef=3024
 Detect=HKCU\Software\Raxco\PerfectDisk
-FileKey1=%CommonAppData%\Raxco\PerfectDisk\*|*.log;*.txt;PDBootLog
+FileKey1=%ProgramData%\Raxco\PerfectDisk\*|*.log;*.txt;PDBootLog
 
 [PerfectKeyboard *]
 LangSecRef=3021
@@ -15473,7 +15473,7 @@ FileKey3=%ProgramFiles%\PPTX Repair Kit|history.txt
 [Predator *]
 LangSecRef=3021
 Detect=HKLM\Software\Predator-Usb
-FileKey1=%CommonAppData%\Predator-Usb\PredatorACE\data|*.log
+FileKey1=%ProgramData%\Predator-Usb\PredatorACE\data|*.log
 
 [Presto Transfer Ultimate *]
 LangSecRef=3024
@@ -15513,7 +15513,7 @@ FileKey6=%LocalAppData%\Packages\Microsoft.Print3D_*\TempState|*.*|RECURSE
 LangSecRef=3021
 Detect=HKLM\Software\Pelikan Software KFT\priPrinter
 FileKey1=%AppData%\Pelikan Software KFT\priPrinter|cache_*.dat
-FileKey2=%CommonAppData%\priPrinter\dumps|*.*
+FileKey2=%ProgramData%\priPrinter\dumps|*.*
 RegKey1=HKCU\Software\Pelikan Software KFT\priPrinter|lastCleanUp
 
 [Prison Architect *]
@@ -15638,8 +15638,8 @@ ExcludeKey1=FILE|%Documents%\Proteus\logs\|rng.txt
 [Proton VPN *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Proton Technologies\ProtonVPN
-FileKey1=%CommonAppData%\ProtonVPN\Logs|*|REMOVESELF
-FileKey2=%CommonAppData%\ProtonVPN\UpdaterLogs|*|REMOVESELF
+FileKey1=%ProgramData%\ProtonVPN\Logs|*|REMOVESELF
+FileKey2=%ProgramData%\ProtonVPN\UpdaterLogs|*|REMOVESELF
 
 [PS3 Media Server *]
 LangSecRef=3023
@@ -15701,9 +15701,9 @@ RegKey2=HKLM\Software\Wow6432Node\Puran Software\Fix Shortcuts|Drives
 [Pure Networks *]
 LangSecRef=3022
 Detect=HKCU\Software\Pure Networks
-FileKey1=%CommonAppData%\Pure Networks\Log|*.*
-FileKey2=%CommonAppData%\Pure Networks\Platform|*.bak
-FileKey3=%CommonAppData%\Pure Networks\Platform\minidumps|*.*
+FileKey1=%ProgramData%\Pure Networks\Log|*.*
+FileKey2=%ProgramData%\Pure Networks\Platform|*.bak
+FileKey3=%ProgramData%\Pure Networks\Platform\minidumps|*.*
 
 [PureRa *]
 LangSecRef=3024
@@ -15713,7 +15713,7 @@ FileKey1=%SystemDrive%|PureRa.txt
 [Puritan File Destroyer Elite *]
 LangSecRef=3023
 Detect=HKCU\Software\Puritan\File Destroyer Elite
-FileKey1=%CommonAppData%\Puritan\File Destroyer Elite|*.log|RECURSE
+FileKey1=%ProgramData%\Puritan\File Destroyer Elite|*.log|RECURSE
 
 [Pushbullet *]
 LangSecRef=3022
@@ -15892,7 +15892,7 @@ RegKey1=HKCU\Software\QwertyLab\RunAsSystem\mru
 [Qwest QuickCare *]
 LangSecRef=3022
 Detect=HKLM\Software\QuickCare
-FileKey1=%CommonAppData%\Support.com|*.tmp|RECURSE
+FileKey1=%ProgramData%\Support.com|*.tmp|RECURSE
 FileKey2=%LocalAppData%\SupportSoft|*.tmp|RECURSE
 
 [R-Wipe & Clean *]
@@ -15951,7 +15951,7 @@ Detect1=HKLM\Software\Big Fish Games\Persistence\Install\F2580T1L1
 Detect2=HKLM\Software\Big Fish Games\Persistence\Install\F5659T1L1
 Detect3=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Ranch Rush1.0
 DetectFile=%ProgramFiles%\Ranch Rush*
-FileKey1=%CommonAppData%\FreshGames\RanchRush\*|*.log;temp_data.ssp
+FileKey1=%ProgramData%\FreshGames\RanchRush\*|*.log;temp_data.ssp
 FileKey2=%ProgramFiles%\Ranch Rush*|*.html;*.nfo
 
 [Raspberry Pi Imager *]
@@ -15977,11 +15977,11 @@ FileKey1=%ProgramFiles%\Rayman Legends\_CommonRedist|*.*|REMOVESELF
 
 [Razer *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Razer
-FileKey1=%CommonAppData%\Razer\*|DiagnoseReport*.*.txt
-FileKey2=%CommonAppData%\Razer\*\Logs|*.*
-FileKey3=%CommonAppData%\Razer\Synapse\Accounts\*\DataSync|SyncDate.txt
-FileKey4=%CommonAppData%\Razer\Synapse\ProductUpdates\Downloads|*.*
+DetectFile=%ProgramData%\Razer
+FileKey1=%ProgramData%\Razer\*|DiagnoseReport*.*.txt
+FileKey2=%ProgramData%\Razer\*\Logs|*.*
+FileKey3=%ProgramData%\Razer\Synapse\Accounts\*\DataSync|SyncDate.txt
+FileKey4=%ProgramData%\Razer\Synapse\ProductUpdates\Downloads|*.*
 FileKey5=%LocalAppData%\Razer\RzUninstallation\Logs|*.*
 FileKey6=%ProgramFiles%\Razer\*|*.log
 
@@ -16018,11 +16018,11 @@ FileKey7=%AppData%\Real\RealPlayer\WatchFolders|*_scan*;*.log|RECURSE
 FileKey8=%AppData%\Real\RPDS\Cache|*.*|RECURSE
 FileKey9=%AppData%\Real\Update|Update-log.txt
 FileKey10=%AppData%\Real\Update\Temp|*.*|RECURSE
-FileKey11=%CommonAppData%\Real\RealPlayer|*-log.txt;S-*
-FileKey12=%CommonAppData%\Real\RPDS\Content\images|*.jpg
-FileKey13=%CommonAppData%\Real\RPDS\Logs|*.log*
-FileKey14=%CommonAppData%\Real\Update_OB|RealPlayer-log.txt
-FileKey15=%CommonAppData%\RPDS\Content\images|*.jpg
+FileKey11=%ProgramData%\Real\RealPlayer|*-log.txt;S-*
+FileKey12=%ProgramData%\Real\RPDS\Content\images|*.jpg
+FileKey13=%ProgramData%\Real\RPDS\Logs|*.log*
+FileKey14=%ProgramData%\Real\Update_OB|RealPlayer-log.txt
+FileKey15=%ProgramData%\RPDS\Content\images|*.jpg
 FileKey16=%LocalAppData%\Real\RealPlayer|*.db-shm;*.db-wal
 FileKey17=%LocalAppData%\Real\RealPlayer\Content\images|*.jpg
 FileKey18=%LocalAppData%\Real\RealPlayer\EBWebview|*.*
@@ -16037,7 +16037,7 @@ ExcludeKey1=PATH|%AppData%\Real\RealPlayer\WatchFolders\|*scan.out
 [Realtek *]
 LangSecRef=3024
 Detect=HKLM\Software\Realtek
-FileKey1=%CommonAppData%\Realtek|*.log
+FileKey1=%ProgramData%\Realtek|*.log
 FileKey2=%ProgramFiles%\Realtek*|*.*log;*.txt|RECURSE
 FileKey3=%ProgramFiles%\Temp|*.*|REMOVESELF
 FileKey4=%SystemDrive%|RHDSetup.log
@@ -16069,7 +16069,7 @@ FileKey1=%LocalAppData%\Recovery Toolbox for Word|*.log
 [Recuva *]
 LangSecRef=3024
 Detect=HKCU\Software\Piriform\Recuva
-FileKey1=%CommonAppData%\Recuva\BurgerData|ActivityData_*.json
+FileKey1=%ProgramData%\Recuva\BurgerData|ActivityData_*.json
 FileKey2=%ProgramFiles%\Recuva|*.log;Recuva_log*.txt
 FileKey3=%UserProfile%|Recuva_log*.txt
 
@@ -16236,8 +16236,8 @@ FileKey1=%ProgramFiles%\RegScrubVistaXP|*.reg;*.rsf;RegEditX.sav
 
 [RegServo *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\regservo
-FileKey1=%CommonAppData%\regservo\Logs|*.*|RECURSE
+DetectFile=%ProgramData%\regservo
+FileKey1=%ProgramData%\regservo\Logs|*.*|RECURSE
 
 [RegToBat *]
 LangSecRef=3024
@@ -16326,13 +16326,13 @@ RegKey5=HKCU\Software\Bomers\Restorator\Restorator\MRUList
 [Restore Point Creator *]
 LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{CC48DE1C-8EC2-43BC-9201-29701CD9AE13}_is1
-FileKey1=%CommonAppData%|Restore Point Creator.log
+FileKey1=%ProgramData%|Restore Point Creator.log
 FileKey2=%ProgramFiles%\Restore Point Creator|*.log;*.txt
 
 [ResumeMaker *]
 LangSecRef=3021
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{D2E80193-7318-4707-A9DE-49AF663ADA73}
-FileKey1=%CommonAppData%\Individual Software\ResumeMaker\R12|*.log
+FileKey1=%ProgramData%\Individual Software\ResumeMaker\R12|*.log
 
 [Reus *]
 Section=Games
@@ -16383,8 +16383,8 @@ FileKey1=%LocalLowAppData%\Ludeon Studios\RimWorld by Ludeon Studios|player.log
 
 [Ring Central *]
 LangSecRef=3022
-DetectFile=%CommonAppData%\RingCentral
-FileKey1=%CommonAppData%\RingCentral\LogFiles|*.*
+DetectFile=%ProgramData%\RingCentral
+FileKey1=%ProgramData%\RingCentral\LogFiles|*.*
 
 [Riot Client *]
 Section=Games
@@ -16432,7 +16432,7 @@ RegKey2=HKCU\Software\Roadkil|Target_Unstp
 [Roblox *]
 Section=Games
 DetectFile=%LocalAppData%\Roblox
-FileKey1=%CommonAppData%\Roblox\Downloads|*.*|RECURSE
+FileKey1=%ProgramData%\Roblox\Downloads|*.*|RECURSE
 FileKey2=%LocalAppData%\Roblox\Downloads|*.*|RECURSE
 FileKey3=%LocalAppData%\Roblox\Logs|*.*|RECURSE
 FileKey4=%LocalLowAppData%\RbxLogs|*.*|RECURSE
@@ -16539,7 +16539,7 @@ FileKey3=%AppData%\Roxio Log Files|*.*|RECURSE
 FileKey4=%AppData%\Roxio\Dragon\3.x\*Logs|*.log
 FileKey5=%AppData%\Roxio\Dragon\3.x\DiscInfoCache|*.tmp
 FileKey6=%AppData%\Roxio\MediaManager*|ItemThumbnails.dat
-FileKey7=%CommonAppData%\Roxio|*.log;cardinfo.*
+FileKey7=%ProgramData%\Roxio|*.log;cardinfo.*
 FileKey8=%LocalAppData%|rx_audio.Cache;rx_image32.Cache
 FileKey9=%WinDir%\System32\config\systemprofile\AppData\Roaming\Roxio Log Files|*.*|RECURSE
 FileKey10=%WinDir%\SysWOW64\config\systemprofile\AppData\Roaming\Roxio Log Files|*.*|RECURSE
@@ -16609,12 +16609,12 @@ FileKey1=%LocalLowAppData%\Safe-Watch-Updater|*.exe
 [Sage ACT! *]
 LangSecRef=3021
 Detect=HKLM\Software\ACT
-FileKey1=%CommonAppData%\Sage Software, Inc\ACT! by Sage\ActUpdate|*.*|RECURSE
+FileKey1=%ProgramData%\Sage Software, Inc\ACT! by Sage\ActUpdate|*.*|RECURSE
 
 [Sage Simply Accounting *]
 LangSecRef=3021
 Detect=HKLM\Software\Sage Software\Simply Accounting
-FileKey1=%CommonAppData%\Sage Software\Simply Accounting\Download|*.*|RECURSE
+FileKey1=%ProgramData%\Sage Software\Simply Accounting\Download|*.*|RECURSE
 
 [SageThumbs *]
 LangSecRef=3021
@@ -16634,8 +16634,8 @@ Detect2=HKCU\Software\Samsung\Kies3.0
 Detect3=HKLM\Software\SAMSUNG\USB_DRIVER
 FileKey1=%AppData%\Samsung\Kies|*.mlca;*.mlme;*.mlpb;*.mlpgb|RECURSE
 FileKey2=%AppData%\Samsung\Kies*\BackupHistory|BackupHistory.xml
-FileKey3=%CommonAppData%\Samsung\Device Error Recovery|*.*
-FileKey4=%CommonAppData%\Samsung\Kies|Kiesairmessage.log
+FileKey3=%ProgramData%\Samsung\Device Error Recovery|*.*
+FileKey4=%ProgramData%\Samsung\Kies|Kiesairmessage.log
 FileKey5=%Documents%\Samsung\Kies*\Backup|*.*|RECURSE
 FileKey6=%Documents%\SelfMV|*.log
 
@@ -16645,9 +16645,9 @@ Detect=HKLM\Software\Samsung Magician
 FileKey1=%AppData%\Samsung Magician\GPUCache|*.*|REMOVESELF
 FileKey2=%AppData%\Samsung Magician\Local Storage\leveldb|*.old
 FileKey3=%AppData%\Samsung Magician\Session Storage|*.old
-FileKey4=%CommonAppData%\Samsung\Backup|*.exe
-FileKey5=%CommonAppData%\Samsung\Samsung Magician|*.exe;*.mdmp|RECURSE
-FileKey6=%CommonAppData%\Samsung\Samsung Magician\PB|*.txt
+FileKey4=%ProgramData%\Samsung\Backup|*.exe
+FileKey5=%ProgramData%\Samsung\Samsung Magician|*.exe;*.mdmp|RECURSE
+FileKey6=%ProgramData%\Samsung\Samsung Magician\PB|*.txt
 FileKey7=%ProgramFiles%\Samsung Magician\Logs|*.*
 FileKey8=%ProgramFiles%\Samsung\Samsung Magician\Log*|*.*
 FileKey9=%SystemDrive%\MagicianPerf*|*.*|REMOVESELF
@@ -16656,7 +16656,7 @@ RegKey1=HKCU\Software\Local AppWizard-Generated Applications\SamsungMagician
 [Samsung MSSCS *]
 LangSecRef=3024
 Detect=HKLM\SOFTWARE\SAMSUNG
-FileKey1=%CommonAppData%\Samsung\MSSCS|*.log
+FileKey1=%ProgramData%\Samsung\MSSCS|*.log
 
 [Samsung Software Upgrade Assistant *]
 LangSecRef=3024
@@ -16703,9 +16703,9 @@ FileKey1=%WinDir%\System32|SavingsBullFilterService.log
 
 [SBCleaner *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\CzechMex LLC\SBCleaner*
-FileKey1=%CommonAppData%\CzechMex LLC\SBCleaner\Logs|*.LOG
-FileKey2=%CommonAppData%\CzechMex LLC\SBCleanerFree\Logs|*.LOG
+DetectFile=%ProgramData%\CzechMex LLC\SBCleaner*
+FileKey1=%ProgramData%\CzechMex LLC\SBCleaner\Logs|*.LOG
+FileKey2=%ProgramData%\CzechMex LLC\SBCleanerFree\Logs|*.LOG
 
 [SBMAV Disk Cleaner *]
 LangSecRef=3024
@@ -17121,10 +17121,10 @@ FileKey2=%AppData%\Similarity\logs|*.*|RECURSE
 
 [SIMS RACER *]
 Section=Games
-DetectFile1=%CommonAppData%\SIMS\RACER
+DetectFile1=%ProgramData%\SIMS\RACER
 DetectFile2=%ProgramFiles%\SIMS\RACER
 DetectFile3=%SystemDrive%\SIMS\RACER
-FileKey1=%CommonAppData%\SIMS\RACER|QLOG.txt
+FileKey1=%ProgramData%\SIMS\RACER|QLOG.txt
 FileKey2=%ProgramFiles%\SIMS\RACER|QLOG.txt
 FileKey3=%SystemDrive%\SIMS\RACER|QLOG.txt
 
@@ -17150,8 +17150,8 @@ RegKey9=HKCU\Software\BreakPoint\SIP Workbench|file9
 LangSecRef=3021
 DetectFile=%AppData%\SiSense
 FileKey1=%AppData%\SiSense\Prism\logs|*.*
-FileKey2=%CommonAppData%\SiSense|*.*log|RECURSE
-FileKey3=%CommonAppData%\SiSense\Logs|*.*|RECURSE
+FileKey2=%ProgramData%\SiSense|*.*log|RECURSE
+FileKey3=%ProgramData%\SiSense\Logs|*.*|RECURSE
 
 [SketchUp Make *]
 LangSecRef=3021
@@ -17241,7 +17241,7 @@ FileKey2=%AppData%\SlimBrowser\iconcache|*.*|RECURSE
 LangSecRef=3024
 Detect1=HKCU\Software\SlimWare Utilities Inc\SlimCleaner
 Detect2=HKCU\Software\SlimWare Utilities Inc\SlimCleaner Plus
-FileKey1=%CommonAppData%\SlimWare Utilities Inc\Services\SlimService*\Logs|*.log
+FileKey1=%ProgramData%\SlimWare Utilities Inc\Services\SlimService*\Logs|*.log
 FileKey2=%LocalAppData%\SlimWare Utilities Inc\SlimCleaner*\Cache|*.*|RECURSE
 FileKey3=%LocalAppData%\SlimWare Utilities Inc\SlimCleaner*\Logs|*.*|RECURSE
 FileKey4=%ProgramFiles%\SlimCleaner*|*.txt
@@ -17303,7 +17303,7 @@ FileKey1=%UserProfile%\.smplayer\file_settings|*.*|RECURSE
 [Snagit *]
 LangSecRef=3021
 Detect=HKCU\Software\TechSmith\Snagit
-FileKey1=%CommonAppData%\TechSmith\Uploader|*.log
+FileKey1=%ProgramData%\TechSmith\Uploader|*.log
 FileKey2=%Documents%|SnagitDebug.log
 FileKey3=%Documents%\Snagit|*.snagx
 FileKey4=%Documents%\Snagit\.metadata|*.*|RECURSE
@@ -17491,7 +17491,7 @@ FileKey1=%ProgramFiles%\Steam\SteamApps\common\Solarix\UDKGame\Logs|*.*
 [SolarWinds Wake-On-Lan *]
 LangSecRef=3022
 Detect=HKCU\Software\VB and VBA Program Settings\Wake-On-Lan
-FileKey1=%CommonAppData%\SolarWinds\VB\Banners|*.bmp
+FileKey1=%ProgramData%\SolarWinds\VB\Banners|*.bmp
 FileKey2=%ProgramFiles%\SolarWinds\Free Tools\Installs|Wake-On-LAN.LOG
 RegKey1=HKCU\Software\VB and VBA Program Settings\Wake-On-Lan\IP Broadcast
 RegKey2=HKCU\Software\VB and VBA Program Settings\Wake-On-Lan\MAC Address
@@ -17636,7 +17636,7 @@ FileKey1=%AppData%\Sony Corporation\Sound Organizer|*.log
 [Sony VAIO *]
 LangSecRef=3024
 Detect=HKLM\Software\Sony Corporation
-FileKey1=%CommonAppData%\Sony Corporation\VAIO *|*.log;Log.txt
+FileKey1=%ProgramData%\Sony Corporation\VAIO *|*.log;Log.txt
 
 [Sony Xperia Companion *]
 LangSecRef=3024
@@ -17761,7 +17761,7 @@ FileKey1=%ProgramFiles%\SpongeBob Diner Dash|logfile.*
 [Spooky Mall *]
 Section=Games
 Detect=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Spooky Mall1.0
-FileKey1=%CommonAppData%\SpookyMall|*.xml_log
+FileKey1=%ProgramData%\SpookyMall|*.xml_log
 FileKey2=%ProgramFiles%\Foxy Games\Spooky Mall|*.log
 
 [SporTV *]
@@ -17801,9 +17801,9 @@ FileKey1=%LocalAppData%\Safer-Networking Ltd\Spybot*|*.log;Spybot Lab.txt
 LangSecRef=3024
 Detect1=HKCU\Software\Safer Networking Limited\Spybot - Search & Destroy 2
 Detect2=HKLM\Software\Safer Networking Limited\SpybotSnD
-FileKey1=%CommonAppData%\Spybot - Search & Destroy\Logs|*.*|RECURSE
-FileKey2=%CommonAppData%\Spybot - Search & Destroy\Snapshots*|*.*|RECURSE
-FileKey3=%CommonAppData%\Spybot - Search & Destroy\System Configuration Snapshots|*.*|REMOVESELF
+FileKey1=%ProgramData%\Spybot - Search & Destroy\Logs|*.*|RECURSE
+FileKey2=%ProgramData%\Spybot - Search & Destroy\Snapshots*|*.*|RECURSE
+FileKey3=%ProgramData%\Spybot - Search & Destroy\System Configuration Snapshots|*.*|REMOVESELF
 FileKey4=%Documents%\ProcAlyzer Dumps|*.*|REMOVESELF
 FileKey5=%ProgramFiles%\Spybot - Search & Destroy 2\Updates|*.*|RECURSE
 FileKey6=%ProgramFiles%\Spybot - Search & Destroy\Updates|*.zip
@@ -17812,8 +17812,8 @@ ExcludeKey1=FILE|%ProgramFiles%\Spybot - Search & Destroy 2\Updates\Downloads\|u
 [Spybot Search and Destroy Backups *]
 LangSecRef=3024
 Detect=HKLM\Software\Safer Networking Limited\SpybotSnD
-FileKey1=%CommonAppData%\Spybot - Search & Destroy\Backups|*.*|RECURSE
-FileKey2=%CommonAppData%\Spybot - Search & Destroy\Recovery|*.*|RECURSE
+FileKey1=%ProgramData%\Spybot - Search & Destroy\Backups|*.*|RECURSE
+FileKey2=%ProgramData%\Spybot - Search & Destroy\Recovery|*.*|RECURSE
 FileKey3=%WinDir%\System32\drivers\etc|hosts.*.backup
 
 [SpyDefense *]
@@ -17844,8 +17844,8 @@ FileKey1=%ProgramFiles%\SpywareBlaster|spywareblasterupgrade_latest.exe
 
 [SQL Anywhere 11 *]
 LangSecRef=3021
-DetectFile=%CommonAppData%\SQL Anywhere 11
-FileKey1=%CommonAppData%\SQL Anywhere 11\Diagnostics|*.dmp;*.crash_log
+DetectFile=%ProgramData%\SQL Anywhere 11
+FileKey1=%ProgramData%\SQL Anywhere 11\Diagnostics|*.dmp;*.crash_log
 
 [SQL Server *]
 LangSecRef=3021
@@ -17962,7 +17962,7 @@ Detect1=HKLM\Software\Stardock\Misc\Fences
 Detect2=HKLM\Software\Stardock\Misc\Fences2
 DetectFile=%LocalAppData%\Stardock\Fences*
 FileKey1=%AppData%\Stardock\Fences\TroubleshootingLog|*.dat;*.txt
-FileKey2=%CommonAppData%\Stardock\Fences*|Cache.dat
+FileKey2=%ProgramData%\Stardock\Fences*|Cache.dat
 FileKey3=%LocalAppData%\Stardock\Fences*|*Log.txt
 FileKey4=%ProgramFiles%\Stardock\Fences|*.txt
 
@@ -17970,20 +17970,20 @@ FileKey4=%ProgramFiles%\Stardock\Fences|*.txt
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Stardock\ObjectDock Plus
 FileKey1=%AppData%\Stardock|*.*|REMOVESELF
-FileKey2=%CommonAppData%\Stardock|*.*|RECURSE
+FileKey2=%ProgramData%\Stardock|*.*|RECURSE
 FileKey3=%LocalAppData%\ODUI|*.*|REMOVESELF
 FileKey4=%LocalAppData%\Stardock\ObjectDockPlus|*Backup.ini
 
 [Stardock Start11 *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Stardock\Start11
-FileKey1=%CommonAppData%\StarDock\Start11\Update|*.exe
+FileKey1=%ProgramData%\StarDock\Start11\Update|*.exe
 FileKey2=%LocalAppData%\StarDock\Start11|SasLog.txt
 
 [StarMoney *]
 LangSecRef=3021
-DetectFile=%CommonAppData%\StarMoney*
-FileKey1=%CommonAppData%\StarMoney *|*.log|RECURSE
+DetectFile=%ProgramData%\StarMoney*
+FileKey1=%ProgramData%\StarMoney *|*.log|RECURSE
 
 [StarOffice *]
 LangSecRef=3021
@@ -18022,7 +18022,7 @@ FileKey2=%ProgramFiles%\STDU Viewer|browse.cache;FilesViewerState.xml;STDUSessio
 Section=Games
 Detect=HKCU\Software\Valve\Steam
 FileKey1=%AppData%\SteamVR\Logs|*|REMOVESELF
-FileKey2=%CommonAppData%\Steam\RLD!\*|last.txt
+FileKey2=%ProgramData%\Steam\RLD!\*|last.txt
 FileKey3=%CommonProgramFiles%\Steam|*_log.txt
 FileKey4=%LocalAppData%\Steam\htmlcache|*|REMOVESELF
 FileKey5=%ProgramFiles%\Steam|*.old;*.log
@@ -18079,16 +18079,16 @@ FileKey1=%ProgramFiles%\Steam\Steamapps\common\SteamWorld Dig|*.mdmp
 
 [Steed *]
 LangSecRef=3022
-DetectFile=%CommonAppData%\Steed
-FileKey1=%CommonAppData%\Steed\Logs|*.*|REMOVESELF
+DetectFile=%ProgramData%\Steed
+FileKey1=%ProgramData%\Steed\Logs|*.*|REMOVESELF
 
 [SteelSeries *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\SteelSeries
+DetectFile=%ProgramData%\SteelSeries
 FileKey1=%AppData%\SteelSeries-Engine-*-Client|*.old;LOG|RECURSE
 FileKey2=%AppData%\SteelSeries-Engine-*-Client\*Cache|*.*|RECURSE
 FileKey3=%AppData%\SteelSeries-Engine-*-Client\blob_storage|*.*|RECURSE
-FileKey4=%CommonAppData%\SteelSeries\SteelSeries Engine*\Logs|*.*|REMOVESELF
+FileKey4=%ProgramData%\SteelSeries\SteelSeries Engine*\Logs|*.*|REMOVESELF
 FileKey5=%ProgramFiles%\SteelSeries\SteelSeries Engine*|*.log
 
 [Steinberg Cubase *]
@@ -18190,7 +18190,7 @@ FileKey1=%ProgramFiles%\Firefly Studios\Stronghold Crusader\gfx|*log.txt
 LangSecRef=3023
 Detect=HKCU\Software\StudioLine\StudioLine Photo Basic
 DetectFile=%ProgramFiles%\StudioLine Photo Basic
-FileKey1=%CommonAppData%\H&M System Software\StudioLine Photo Basic 3|*.bak;*.dmp;*.log
+FileKey1=%ProgramData%\H&M System Software\StudioLine Photo Basic 3|*.bak;*.dmp;*.log
 RegKey1=HKCU\Software\H&&M System Software\Twain\Recent File List
 RegKey2=HKCU\Software\StudioLine\StudioLine Photo Basic\WindowPositions
 
@@ -18243,8 +18243,8 @@ FileKey1=%ProgramFiles%\Registry Clean Expert|fixlog.ini
 LangSecRef=3024
 Detect1=HKCU\Software\SUPERAntiSpyware.com\SUPERAntiSpyware
 Detect2=HKLM\Software\SUPERAntiSpyware.com\SUPERAntiSpyware
-FileKey1=%CommonAppData%\!SASCORE\AppLogs|*.dmp;*.SDB
-FileKey2=%CommonAppData%\SUPERAntiSpyware.com\SUPERAntiSpyware\Applogs|*.dmp;*.SDB;*.ZIP
+FileKey1=%ProgramData%\!SASCORE\AppLogs|*.dmp;*.SDB
+FileKey2=%ProgramData%\SUPERAntiSpyware.com\SUPERAntiSpyware\Applogs|*.dmp;*.SDB;*.ZIP
 FileKey3=%ProgramFiles%\SUPERAntiSpyware|*.tmp
 
 [SuperEasy Software Driver Updater *]
@@ -18255,8 +18255,8 @@ FileKey1=%AppData%\SuperEasy Software\Driver Updater|*.log
 [SuperMP3Download *]
 LangSecRef=3023
 DetectFile=%ProgramFiles%\SuperMp3Download
-FileKey1=%CommonAppData%\SuperMP3Download|downloadlist.sav
-FileKey2=%CommonAppData%\SuperMP3Download\Downloading|*.*|RECURSE
+FileKey1=%ProgramData%\SuperMP3Download|downloadlist.sav
+FileKey2=%ProgramData%\SuperMP3Download\Downloading|*.*|RECURSE
 
 [Superstar Racing *]
 Section=Games
@@ -18342,7 +18342,7 @@ FileKey7=%SystemDrive%\Temp\Syncios*|*.*|REMOVESELF
 [Syncovery *]
 LangSecRef=3024
 Detect=HKCU\Software\Syncovery
-FileKey1=%CommonAppData%\Syncovery\Logs|*.log|RECURSE
+FileKey1=%ProgramData%\Syncovery\Logs|*.log|RECURSE
 
 [Syncthing *]
 LangSecRef=3022
@@ -18399,7 +18399,7 @@ FileKey1=%SystemDrive%\Drivers|*.*|REMOVESELF
 [System Explorer *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\System Explorer
-FileKey1=%CommonAppData%\SystemExplorer\snapshots|*.ses
+FileKey1=%ProgramData%\SystemExplorer\snapshots|*.ses
 
 [System Mechanic *]
 LangSecRef=3024
@@ -18407,11 +18407,11 @@ Detect=HKCU\Software\iolo\System Mechanic
 FileKey1=%AppData%\iolo\SafetyNet\Temp|*.*
 FileKey2=%AppData%\iolo\System Snapshots Data|*.*
 FileKey3=%AppData%\ioloGovernor\logs|*.*|REMOVESELF
-FileKey4=%CommonAppData%\iolo|*.xml;*.txt
-FileKey5=%CommonAppData%\Iolo Technologies\Logs|*.*
-FileKey6=%CommonAppData%\iolo\ACRSummaryFiles|*.*|REMOVESELF
-FileKey7=%CommonAppData%\iolo\logs|*.*|REMOVESELF
-FileKey8=%CommonAppData%\iolo\TempResources|*.*|REMOVESELF
+FileKey4=%ProgramData%\iolo|*.xml;*.txt
+FileKey5=%ProgramData%\Iolo Technologies\Logs|*.*
+FileKey6=%ProgramData%\iolo\ACRSummaryFiles|*.*|REMOVESELF
+FileKey7=%ProgramData%\iolo\logs|*.*|REMOVESELF
+FileKey8=%ProgramData%\iolo\TempResources|*.*|REMOVESELF
 FileKey9=%ProgramFiles%\iolo\System Mechanic|*.txt;*.xml
 FileKey10=%SystemDrive%\Documents and Settings\LocalService\*\iolo|*.*|REMOVESELF
 FileKey11=%WinDir%\System32\config|iolo App.evt
@@ -18495,9 +18495,9 @@ RegKey7=HKCU\Software\Softpointer\Tag&Rename3\Config|FileListHeader
 
 [Task ForceQuit Pro *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Softorino\Task ForceQuit Pro*
-FileKey1=%CommonAppData%\Softorino\Task ForceQuit Pro*\Logs|*.*
-FileKey2=%CommonAppData%\Softorino\Task ForceQuit Pro*\Update|*.*
+DetectFile=%ProgramData%\Softorino\Task ForceQuit Pro*
+FileKey1=%ProgramData%\Softorino\Task ForceQuit Pro*\Logs|*.*
+FileKey2=%ProgramData%\Softorino\Task ForceQuit Pro*\Update|*.*
 
 [TAudio Converter *]
 LangSecRef=3023
@@ -18596,7 +18596,7 @@ FileKey2=%AppData%\Teeworlds\maps|*.*|REMOVESELF
 [Tele2 Mobile Partner *]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\Tele2 Mobile Partner
-FileKey1=%CommonAppData%\Tele2 Mobile Partner\log|*.*
+FileKey1=%ProgramData%\Tele2 Mobile Partner\log|*.*
 FileKey2=%ProgramFiles%\Tele2 Mobile Partner\Log|*.txt
 
 [Telegram Desktop *]
@@ -18625,7 +18625,7 @@ FileKey1=%AppData%\Tencent\AndroidServer|*.log.xml
 [Tencent QQ *]
 LangSecRef=3022
 DetectFile=%Documents%\Tencent Files
-FileKey1=%CommonAppData%\Tencent Files\QQ\Misc|*.*|RECURSE
+FileKey1=%ProgramData%\Tencent Files\QQ\Misc|*.*|RECURSE
 FileKey2=%Documents%\Tencent Files|*.*|RECURSE
 
 [Tencent WeChat *]
@@ -18762,10 +18762,10 @@ FileKey1=%AppData%\Merscom\The Mystery of the Mary Celeste|logfile.txt
 
 [The Rise of Atlantis *]
 Section=Games
-DetectFile1=%CommonAppData%\Playrix Entertainment\The Rise of Atlantis
-DetectFile2=%CommonAppData%\TERMINAL Studio\The Rise of Atlantis
-FileKey1=%CommonAppData%\Playrix Entertainment\The Rise of Atlantis|log.htm*
-FileKey2=%CommonAppData%\Terminal Studio\The Rise of Atlantis|log.htm*
+DetectFile1=%ProgramData%\Playrix Entertainment\The Rise of Atlantis
+DetectFile2=%ProgramData%\TERMINAL Studio\The Rise of Atlantis
+FileKey1=%ProgramData%\Playrix Entertainment\The Rise of Atlantis|log.htm*
+FileKey2=%ProgramData%\Terminal Studio\The Rise of Atlantis|log.htm*
 
 [The SemWare Editor Professional *]
 LangSecRef=3024
@@ -19031,7 +19031,7 @@ FileKey1=%ProgramFiles%\ToonTown ReWritten\logs|*.*
 [Topaz Photo AI *]
 LangSecRef=3023
 Detect=HKCU\SOFTWARE\Topaz Labs LLC\Topaz Photo AI
-FileKey1=%CommonAppData%\Topaz Labs LLC\Topaz Photo AI\Logs|*|REMOVESELF
+FileKey1=%ProgramData%\Topaz Labs LLC\Topaz Photo AI\Logs|*|REMOVESELF
 
 [Topaz Video AI *]
 LangSecRef=3023
@@ -19119,7 +19119,7 @@ RegKey1=HKCU\Software\ScorpioSoftware\TotalRegistry|LastKey
 LangSecRef=3024
 Detect1=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 5_is1
 Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 6_is1
-FileKey1=%CommonAppData%\Martau\Total Uninstall*|*.Folders;*.cache|RECURSE
+FileKey1=%ProgramData%\Martau\Total Uninstall*|*.Folders;*.cache|RECURSE
 FileKey2=%ProgramFiles%\Total Uninstall*|*.rtf;*.txt;*.GID|RECURSE
 
 [Total Uninstall Backups *]
@@ -19127,10 +19127,10 @@ LangSecRef=3024
 Detect1=HKCU\Software\MartS\Total Uninstall
 Detect2=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 5_is1
 Detect3=HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Total Uninstall 6_is1
-FileKey1=%CommonAppData%\Martau\Total Uninstall*|*.tlg;*.zsns;*.zip|RECURSE
-FileKey2=%CommonAppData%\Martau\Total Uninstall*\Analyzed Programs|*.*
-FileKey3=%CommonAppData%\Martau\Total Uninstall*\Backup|*.zip
-FileKey4=%CommonAppData%\Martau\Total Uninstall*\System Snapshots|*.zsns
+FileKey1=%ProgramData%\Martau\Total Uninstall*|*.tlg;*.zsns;*.zip|RECURSE
+FileKey2=%ProgramData%\Martau\Total Uninstall*\Analyzed Programs|*.*
+FileKey3=%ProgramData%\Martau\Total Uninstall*\Backup|*.zip
+FileKey4=%ProgramData%\Martau\Total Uninstall*\System Snapshots|*.zsns
 
 [Touch *]
 LangSecRef=3024
@@ -19144,8 +19144,8 @@ FileKey1=%ProgramFiles%\Steam\Steamapps\common\towns|*.log
 
 [TP-Link *]
 LangSecRef=3022
-DetectFile=%CommonAppData%\TP-Link
-FileKey1=%CommonAppData%\TP-Link|*.log
+DetectFile=%ProgramData%\TP-Link
+FileKey1=%ProgramData%\TP-Link|*.log
 FileKey2=%LocalAppData%\TP-Link\nsissetup|*.log
 
 [Track Folder Changes *]
@@ -19155,22 +19155,22 @@ RegKey1=HKCU\Software\antiufo\TrackFolderChanges|LastFolder
 
 [TrackMania Forever Cache *]
 Section=Games
-DetectFile=%CommonAppData%\TrackMania
-FileKey1=%CommonAppData%\TrackMania\Cache|*.*
-FileKey2=%CommonAppData%\TrackMania\Cache\ManiaCode|*.*
+DetectFile=%ProgramData%\TrackMania
+FileKey1=%ProgramData%\TrackMania\Cache|*.*
+FileKey2=%ProgramData%\TrackMania\Cache\ManiaCode|*.*
 
 [TrackMania Forever Manialinks *]
 Section=Games
-DetectFile=%CommonAppData%\TrackMania
-FileKey1=%CommonAppData%\TrackMania\Manialinks|*.*
+DetectFile=%ProgramData%\TrackMania
+FileKey1=%ProgramData%\TrackMania\Manialinks|*.*
 
 [TrackMania Forever Scores *]
 Section=Games
-DetectFile=%CommonAppData%\TrackMania
-FileKey1=%CommonAppData%\TrackMania\CampaignsScores|*.*
-FileKey2=%CommonAppData%\TrackMania\CampaignsScores\General|*.*
-FileKey3=%CommonAppData%\TrackMania\CampaignsScores\UnitedRace|*.*
-FileKey4=%CommonAppData%\TrackMania\LadderScores|*.*
+DetectFile=%ProgramData%\TrackMania
+FileKey1=%ProgramData%\TrackMania\CampaignsScores|*.*
+FileKey2=%ProgramData%\TrackMania\CampaignsScores\General|*.*
+FileKey3=%ProgramData%\TrackMania\CampaignsScores\UnitedRace|*.*
+FileKey4=%ProgramData%\TrackMania\LadderScores|*.*
 
 [Tracks Eraser Pro *]
 LangSecRef=3024
@@ -19191,14 +19191,14 @@ FileKey1=%AppData%\JAM Software\TreeSize *|GlobalOptions.bak0.xml
 LangSecRef=3023
 Detect1=HKCU\Software\Trend Micro
 Detect2=HKLM\Software\TrendMicro
-DetectFile=%CommonAppData%\Trend Micro
-FileKey1=%CommonAppData%\Trend Micro|*.log
+DetectFile=%ProgramData%\Trend Micro
+FileKey1=%ProgramData%\Trend Micro|*.log
 FileKey2=%ProgramFiles%\Trend Micro|*.log;URLLog.dat|RECURSE
 
 [Trend Micro AntiRansomware Tool *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\AntiRansomware2.0
-FileKey1=%CommonAppData%\AntiRansomware|*.log
+FileKey1=%ProgramData%\AntiRansomware|*.log
 
 [Trend Micro HijackThis Backups *]
 LangSecRef=3024
@@ -19208,13 +19208,13 @@ FileKey1=%ProgramFiles%\Trend Micro\HijackThis\backups|*.*
 [Trend Micro RUBotted *]
 LangSecRef=3024
 Detect=HKLM\Software\TrendMicro\RUBotted
-FileKey1=%CommonAppData%\Trend Micro\RUBotted\Logs|*.*|REMOVESELF
+FileKey1=%ProgramData%\Trend Micro\RUBotted\Logs|*.*|REMOVESELF
 FileKey2=%ProgramFiles%\Trend Micro\RUBotted\DebugLogs|*.*|REMOVESELF
 
 [Tribes: Ascend *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\17080
-FileKey1=%CommonAppData%\Hi-Rez Studios\BrowserCacheTribes\Default\Cache|*.*|RECURSE
+FileKey1=%ProgramData%\Hi-Rez Studios\BrowserCacheTribes\Default\Cache|*.*|RECURSE
 FileKey2=%Documents%\My Games\Tribes Ascend\TribesGame\Logs|*.*
 FileKey3=%ProgramFiles%\Steam\steamapps\common\tribes\Binaries\Logs|*.*
 
@@ -19429,7 +19429,7 @@ FileKey2=%UserProfile%\.umplayer\file_settings|*.*|RECURSE
 [Unchecky *]
 LangSecRef=3024
 Detect=HKCU\Software\Unchecky
-FileKey1=%CommonAppData%\Unchecky|*.log;uclogfile*.bin
+FileKey1=%ProgramData%\Unchecky|*.log;uclogfile*.bin
 
 [UnHackMe *]
 LangSecRef=3024
@@ -19537,7 +19537,7 @@ LangSecRef=3024
 Detect=HKCU\Software\SafelyRemove
 FileKey1=%AppData%\USBSafelyRemove|*.txt
 FileKey2=%AppData%\USBSRService|*.txt
-FileKey3=%CommonAppData%\USBSRService|*.txt
+FileKey3=%ProgramData%\USBSRService|*.txt
 FileKey4=%ProgramFiles%\USB Safely Remove|*.DIZ;*.rtf;*.url
 
 [UsbFix *]
@@ -19750,7 +19750,7 @@ FileKey1=%UserProfile%|_viminfo
 Section=Games
 Detect=HKLM\Software\Nexon\Vindictus
 DetectFile=%SystemDrive%\Nexon\Vindictus EU\en-EU
-FileKey1=%CommonAppData%\NexonEU\601|*.log
+FileKey1=%ProgramData%\NexonEU\601|*.log
 FileKey2=%Documents%\Vindictus EU\Report Error|*.log;*.mdmp
 FileKey3=%SystemDrive%\Nexon\Vindictus EU\en-EU|*.log;*.tmp
 FileKey4=%SystemDrive%\Nexon\Vindictus EU\en-EU\HShield|*.log
@@ -19768,7 +19768,7 @@ RegKey1=HKLM\Software\Elaborate Bytes\VirtualCloneDrive\0
 [VirtualBox *]
 LangSecRef=3024
 DetectFile=%UserProfile%\.VirtualBox
-FileKey1=%CommonAppData%\VirtualBox|*.log*
+FileKey1=%ProgramData%\VirtualBox|*.log*
 FileKey2=%UserProfile%\.VirtualBox|*.log*
 FileKey3=%UserProfile%\VirtualBox VMs\*\Logs|*.log*
 
@@ -19834,10 +19834,10 @@ LangSecRef=3024
 Detect1=HKLM\Software\VMware, Inc.\VMware Player
 Detect2=HKLM\Software\VMware, Inc.\VMware Workstation
 DetectFile=%Documents%\Virtual Machines
-FileKey1=%CommonAppData%\VMware\hostd|*.log;*.gz|RECURSE
-FileKey2=%CommonAppData%\VMware\Installer|*.*|REMOVESELF
-FileKey3=%CommonAppData%\VMware\logs|*.log|RECURSE
-FileKey4=%CommonAppData%\VMware\VMware vCenter Converter Standalone|*.log;*.gz;*.zip|RECURSE
+FileKey1=%ProgramData%\VMware\hostd|*.log;*.gz|RECURSE
+FileKey2=%ProgramData%\VMware\Installer|*.*|REMOVESELF
+FileKey3=%ProgramData%\VMware\logs|*.log|RECURSE
+FileKey4=%ProgramData%\VMware\VMware vCenter Converter Standalone|*.log;*.gz;*.zip|RECURSE
 FileKey5=%Documents%\*Virtual Machines|*.log|RECURSE
 FileKey6=%LocalAppData%\VMware|*.log
 FileKey7=%LocalAppData%\VMware\VMware vCenter Converter Standalone Client\Logs|*.log;*.gz
@@ -19853,7 +19853,7 @@ LangSecRef=3022
 Detect=HKCU\Software\Vodafone
 FileKey1=%AppData%\Vodafone\Vodafone Mobile*\Log|*.*
 FileKey2=%AppData%\Vodafone\Vodafone Mobile*\Temp|*.*
-FileKey3=%CommonAppData%\Vodafone\Log|*.*
+FileKey3=%ProgramData%\Vodafone\Log|*.*
 FileKey4=%ProgramFiles%\Vodafone\Vodafone Mobile Broadband\Bin|SwiHpAux.log
 FileKey5=%WinDir%|ModemLog_*.txt
 
@@ -19901,8 +19901,8 @@ LangSecRef=3023
 Detect=HKCU\Software\VSO
 FileKey1=%AppData%|pcouffin.log;ezplay.log
 FileKey2=%AppData%\VSO|*.log|REMOVESELF
-FileKey3=%CommonAppData%\VSO|*.cache;*.crashlist;*.log;*.vsothumb|RECURSE
-FileKey4=%CommonAppData%\VSO\vsothumbs|*.*|REMOVESELF
+FileKey3=%ProgramData%\VSO|*.cache;*.crashlist;*.log;*.vsothumb|RECURSE
+FileKey4=%ProgramData%\VSO\vsothumbs|*.*|REMOVESELF
 FileKey5=%Documents%\PcSetup|*.log|REMOVESELF
 FileKey6=%UserProfile%|timestamp.txt
 
@@ -19915,14 +19915,14 @@ RegKey1=HKCU\Software\VSO\VSO Batcher\1|VideoFilesLastFlder
 [VSO Blindwrite *]
 LangSecRef=3021
 Detect=HKCU\Software\VSO\Blindwrite
-FileKey1=%CommonAppData%\VSO\Blindwrite\*|*.log|REMOVESELF
+FileKey1=%ProgramData%\VSO\Blindwrite\*|*.log|REMOVESELF
 
 [VSO Converter *]
 LangSecRef=3023
 Detect1=HKCU\Software\VSO\Blu-ray Converter Ultimate
 Detect2=HKCU\Software\VSO\DVD Converter Ultimate
 Detect3=HKCU\Software\VSO\VSO Video Converter
-FileKey1=%CommonAppData%\VSO\*Converter*\*\Log|*.log;*.crashlist|REMOVESELF
+FileKey1=%ProgramData%\VSO\*Converter*\*\Log|*.log;*.crashlist|REMOVESELF
 FileKey2=%ProgramFiles%\VSO\*Converter*\*|*.txt
 RegKey1=HKCU\Software\VSO\Blu-ray Converter Ultimate\2|BDMVInputFolders
 RegKey2=HKCU\Software\VSO\Blu-ray Converter Ultimate\2|ISOInputFolders
@@ -19958,14 +19958,14 @@ FileKey1=%ProgramFiles%\VSO\ConvertX\5|*.log;*.rtf
 LangSecRef=3023
 Detect=HKCU\Software\VSO\VSO Downloader
 FileKey1=%AppData%\VSO\VSO Downloader\*\items|*.item|RECURSE
-FileKey2=%CommonAppData%\VSO\VSO Downloader\*\items|*.item|RECURSE
-FileKey3=%CommonAppData%\VSO\VSO Downloader\*\log|*.log
+FileKey2=%ProgramData%\VSO\VSO Downloader\*\items|*.item|RECURSE
+FileKey3=%ProgramData%\VSO\VSO Downloader\*\log|*.log
 
 [VSO Media Player 1 *]
 LangSecRef=3023
 Detect=HKCU\Software\VSO\VSO Media Player\1
 FileKey1=%AppData%\VSO\VSO Media Player\1|autoresume.xml
-FileKey2=%CommonAppData%\VSO\VSO Media Player\1\log|*.log;*.crashlist
+FileKey2=%ProgramData%\VSO\VSO Media Player\1\log|*.log;*.crashlist
 RegKey1=HKCU\Software\VSO\VSO Media Player\1\RecentlyOpenedFiles
 
 [VueScan *]
@@ -19987,8 +19987,8 @@ FileKey6=%ProgramFiles%\Vuze|*.log|RECURSE
 
 [W3i *]
 LangSecRef=3022
-DetectFile=%CommonAppData%\W3i
-FileKey1=%CommonAppData%\W3i\InstallQUpdater|*.log
+DetectFile=%ProgramData%\W3i
+FileKey1=%ProgramData%\W3i\InstallQUpdater|*.log
 
 [Wacom *]
 LangSecRef=3023
@@ -20078,7 +20078,7 @@ FileKey4=%ProgramFiles%\Game Extractor\temp|*.*
 LangSecRef=3021
 DetectFile=%AppData%\Wave Systems Corp
 FileKey1=%AppData%\Wave Systems Corp|DSM_AM.*
-FileKey2=%CommonAppData%\Wave Systems Corp|*.log|RECURSE
+FileKey2=%ProgramData%\Wave Systems Corp|*.log|RECURSE
 FileKey3=%LocalAppData%\Wave Systems Corp\WCLIENTDLL|errors.txt
 
 [WavePad Sound Editor *]
@@ -20147,7 +20147,7 @@ LangSecRef=3024
 DetectFile1=%LocalLowAppData%\Webroot
 DetectFile2=%ProgramFiles%\Webroot
 FileKey1=%AppData%\Local\Temp\lptmp*|*.*|REMOVESELF
-FileKey2=%CommonAppData%\WRData|WRLog.log
+FileKey2=%ProgramData%\WRData|WRLog.log
 FileKey3=%LocalAppData%\lptmp*|*.*|REMOVESELF
 
 [Webroot Window Washer Backups *]
@@ -20164,7 +20164,7 @@ FileKey2=%LocalAppData%\WebTorrent|*.log
 [WeFi *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\WeFi
-FileKey1=%CommonAppData%\WeFi\LogFiles|*.*|REMOVESELF
+FileKey1=%ProgramData%\WeFi\LogFiles|*.*|REMOVESELF
 
 [West of Loathing *]
 Section=Games
@@ -20174,12 +20174,12 @@ FileKey2=%LocalLowAppData%\Asymmetric Software\West of Loathing\Crashes|*.*
 
 [Western Digital SmartWare *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Western Digital
+DetectFile=%ProgramData%\Western Digital
 FileKey1=%AppData%\Western Digital\WD SmartWare\Logs|*.*
-FileKey2=%CommonAppData%\Western Digital\Logs\WD *\*|*.log
-FileKey3=%CommonAppData%\Western Digital\Logs\WD Firmware Updater|*.*|REMOVESELF
-FileKey4=%CommonAppData%\Western Digital\WD SmartWare|*.log
-FileKey5=%CommonAppData%\Western Digital\WDFME|*.*
+FileKey2=%ProgramData%\Western Digital\Logs\WD *\*|*.log
+FileKey3=%ProgramData%\Western Digital\Logs\WD Firmware Updater|*.*|REMOVESELF
+FileKey4=%ProgramData%\Western Digital\WD SmartWare|*.log
+FileKey5=%ProgramData%\Western Digital\WDFME|*.*
 FileKey6=%LocalAppData%\Western Digital\WD SmartWare|*log.txt
 FileKey7=%Public%\Documents\Downloads\WD_SmartWare_Installer_*|*.*|REMOVESELF
 
@@ -20431,7 +20431,7 @@ RegKey5=HKU\.DEFAULT\Software\Microsoft\Windows\Windows Error Reporting\Debug|St
 [Windows Event Viewer *]
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\Windows
-FileKey1=%CommonAppData%\Microsoft\Event Viewer\*Logs|*.xml
+FileKey1=%ProgramData%\Microsoft\Event Viewer\*Logs|*.xml
 FileKey2=%LocalAppData%\Microsoft\Event Viewer|RecentViews
 
 [Windows Feedback *]
@@ -20586,9 +20586,9 @@ RegKey3=HKCU\Software\Microsoft\Windows Live\Photo Gallery|galleryscopedfolders
 LangSecRef=3022
 Detect1=HKCU\Software\Microsoft\Windows Live Mail
 Detect2=HKLM\Software\Microsoft\Windows Live
-FileKey1=%CommonAppData%\Microsoft\WLSetup|*.tmp
-FileKey2=%CommonAppData%\Microsoft\WLSetup\*logs|*.*|RECURSE
-FileKey3=%CommonAppData%\WLInstaller|*.log
+FileKey1=%ProgramData%\Microsoft\WLSetup|*.tmp
+FileKey2=%ProgramData%\Microsoft\WLSetup\*logs|*.*|RECURSE
+FileKey3=%ProgramData%\WLInstaller|*.log
 FileKey4=%CommonProgramFiles%\Windows Live\.cache|*.tmp
 FileKey5=%LocalAppData%\Microsoft\WLSetup\*logs|*.*|RECURSE
 
@@ -20626,14 +20626,14 @@ RegKey2=HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager\Su
 [Windows Logs *]
 LangSecRef=3025
 Detect=HKLM\Software\Microsoft\Windows
-FileKey1=%CommonAppData%\Microsoft\Diagnosis\DownloadedSettings|*.json.bk
-FileKey2=%CommonAppData%\Microsoft\Diagnosis\ETLLogs|*.*|RECURSE
-FileKey3=%CommonAppData%\Microsoft\DiagnosticLogCSP|*.*|RECURSE
-FileKey4=%CommonAppData%\Microsoft\Network\Downloader|*.*|RECURSE
-FileKey5=%CommonAppData%\Microsoft\WDF|*.*|RECURSE
-FileKey6=%CommonAppData%\Microsoft\Windows Security Health\Logs|*.*|RECURSE
-FileKey7=%CommonAppData%\Microsoft\Windows\wfp|*.etl
-FileKey8=%CommonAppData%\USOShared\Logs|*.*|RECURSE
+FileKey1=%ProgramData%\Microsoft\Diagnosis\DownloadedSettings|*.json.bk
+FileKey2=%ProgramData%\Microsoft\Diagnosis\ETLLogs|*.*|RECURSE
+FileKey3=%ProgramData%\Microsoft\DiagnosticLogCSP|*.*|RECURSE
+FileKey4=%ProgramData%\Microsoft\Network\Downloader|*.*|RECURSE
+FileKey5=%ProgramData%\Microsoft\WDF|*.*|RECURSE
+FileKey6=%ProgramData%\Microsoft\Windows Security Health\Logs|*.*|RECURSE
+FileKey7=%ProgramData%\Microsoft\Windows\wfp|*.etl
+FileKey8=%ProgramData%\USOShared\Logs|*.*|RECURSE
 FileKey9=%LocalAppData%\ConnectedDevicesPlatform|*.log
 FileKey10=%LocalAppData%\Diagnostics|*.*|RECURSE
 FileKey11=%LocalAppData%\Microsoft\Dialer|*.log.txt
@@ -20700,8 +20700,8 @@ RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 [Windows Maps *]
 LangSecRef=3025
 Detect=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.WindowsMaps_8wekyb3d8bbwe
-FileKey1=%CommonAppData%\Microsoft\MapData|events.log
-FileKey2=%CommonAppData%\Microsoft\MapData\mapscache|*.*|RECURSE
+FileKey1=%ProgramData%\Microsoft\MapData|events.log
+FileKey2=%ProgramData%\Microsoft\MapData\mapscache|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\AppCache|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\INet*|*.*|RECURSE
 FileKey5=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
@@ -20714,7 +20714,7 @@ FileKey10=%LocalAppData%\Packages\Microsoft.WindowsMaps_*\TempState|*.*|RECURSE
 [Windows Media Center *]
 LangSecRef=3023
 Detect=HKCU\Software\Microsoft\Windows\CurrentVersion\Media Center
-FileKey1=%CommonAppData%\Microsoft\eHome\thmb|TVThumb.db
+FileKey1=%ProgramData%\Microsoft\eHome\thmb|TVThumb.db
 FileKey2=%LocalAppData%\Microsoft\ehome|Image.db;Video.db;musicThumbs.db
 FileKey3=%LocalAppData%\Microsoft\eHome\Art Cache|*.*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\CurrentVersion\Media Center\MRU\SettingsMRU
@@ -20810,9 +20810,9 @@ RegKey4=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 
 [Windows Power Efficiency Diagnostics *]
 LangSecRef=3025
-DetectFile=%CommonAppData%\Microsoft\Windows\Power Efficiency Diagnostics
-FileKey1=%CommonAppData%\Microsoft\Windows\Power Efficiency Diagnostics|*.xml
-ExcludeKey1=FILE|%CommonAppData%\Microsoft\Windows\Power Efficiency Diagnostics\|energy-report-latest.xml
+DetectFile=%ProgramData%\Microsoft\Windows\Power Efficiency Diagnostics
+FileKey1=%ProgramData%\Microsoft\Windows\Power Efficiency Diagnostics|*.xml
+ExcludeKey1=FILE|%ProgramData%\Microsoft\Windows\Power Efficiency Diagnostics\|energy-report-latest.xml
 
 [Windows PowerShell *]
 LangSecRef=3024
@@ -20865,8 +20865,8 @@ FileKey1=%Documents%|*.rdp
 
 [Windows Retail Demo *]
 LangSecRef=3025
-DetectFile=%CommonAppData%\Microsoft\Windows\RetailDemo
-FileKey1=%CommonAppData%\Microsoft\Windows\RetailDemo|*.*|REMOVESELF
+DetectFile=%ProgramData%\Microsoft\Windows\RetailDemo
+FileKey1=%ProgramData%\Microsoft\Windows\RetailDemo|*.*|REMOVESELF
 
 [Windows Scan *]
 LangSecRef=3025
@@ -20882,7 +20882,7 @@ RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 [Windows Search *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
-FileKey1=%CommonAppData%\Microsoft\Search\Data\Applications\Windows\GatherLogs\SystemIndex|*.*|RECURSE
+FileKey1=%ProgramData%\Microsoft\Search\Data\Applications\Windows\GatherLogs\SystemIndex|*.*|RECURSE
 FileKey2=%LocalAppData%\Packages\Microsoft.Bing_*\AC\Microsoft\CLR_v4.0\UsageLogs|*.*|RECURSE
 FileKey3=%LocalAppData%\Packages\Microsoft.Windows.Search_*\AC\AppCache|*.*|RECURSE
 FileKey4=%LocalAppData%\Packages\Microsoft.Windows.Search_*\AC\INet*|*.*|RECURSE
@@ -20908,21 +20908,21 @@ Detect2=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentV
 Detect3=HKCU\Software\Microsoft\Microsoft Antimalware
 Detect4=HKLM\Software\Microsoft\Microsoft Antimalware
 Detect5=HKLM\Software\Microsoft\Windows Defender
-DetectFile=%CommonAppData%\Microsoft\Microsoft antimalware
-FileKey1=%CommonAppData%\Microsoft\*\network inspection system\Support|*.txt;*.log;NisLog.txt.bak
-FileKey2=%CommonAppData%\Microsoft\*\Scans\History\Service|*.log|RECURSE
-FileKey3=%CommonAppData%\Microsoft\Microsoft Antimalware\LocalCopy|*.*|RECURSE
-FileKey4=%CommonAppData%\Microsoft\Microsoft antimalware\scans\history\results\Quick|*.*|REMOVESELF
-FileKey5=%CommonAppData%\Microsoft\Microsoft antimalware\scans\history\results\resource|*.*|REMOVESELF
-FileKey6=%CommonAppData%\Microsoft\Microsoft antimalware\scans\history\results\System|*.*|REMOVESELF
-FileKey7=%CommonAppData%\Microsoft\Microsoft antimalware\support|*.log;*.txt
-FileKey8=%CommonAppData%\Microsoft\Microsoft Security Client\Support|MSSecurityClient*.log
-FileKey9=%CommonAppData%\Microsoft\Windows Defender\Scans\BackupStore|*.*|RECURSE
-FileKey10=%CommonAppData%\Microsoft\Windows Defender\Scans\History\CacheManager|*.*|RECURSE
-FileKey11=%CommonAppData%\Microsoft\Windows Defender\Scans\History\Store|*.*
-FileKey12=%CommonAppData%\Microsoft\Windows Defender\Scans\MetaStore|*.*|RECURSE
-FileKey13=%CommonAppData%\Microsoft\Windows Defender\Scans\RtSigs\Data|*.*|RECURSE
-FileKey14=%CommonAppData%\Microsoft\Windows Defender\Support|*.*|RECURSE
+DetectFile=%ProgramData%\Microsoft\Microsoft antimalware
+FileKey1=%ProgramData%\Microsoft\*\network inspection system\Support|*.txt;*.log;NisLog.txt.bak
+FileKey2=%ProgramData%\Microsoft\*\Scans\History\Service|*.log|RECURSE
+FileKey3=%ProgramData%\Microsoft\Microsoft Antimalware\LocalCopy|*.*|RECURSE
+FileKey4=%ProgramData%\Microsoft\Microsoft antimalware\scans\history\results\Quick|*.*|REMOVESELF
+FileKey5=%ProgramData%\Microsoft\Microsoft antimalware\scans\history\results\resource|*.*|REMOVESELF
+FileKey6=%ProgramData%\Microsoft\Microsoft antimalware\scans\history\results\System|*.*|REMOVESELF
+FileKey7=%ProgramData%\Microsoft\Microsoft antimalware\support|*.log;*.txt
+FileKey8=%ProgramData%\Microsoft\Microsoft Security Client\Support|MSSecurityClient*.log
+FileKey9=%ProgramData%\Microsoft\Windows Defender\Scans\BackupStore|*.*|RECURSE
+FileKey10=%ProgramData%\Microsoft\Windows Defender\Scans\History\CacheManager|*.*|RECURSE
+FileKey11=%ProgramData%\Microsoft\Windows Defender\Scans\History\Store|*.*
+FileKey12=%ProgramData%\Microsoft\Windows Defender\Scans\MetaStore|*.*|RECURSE
+FileKey13=%ProgramData%\Microsoft\Windows Defender\Scans\RtSigs\Data|*.*|RECURSE
+FileKey14=%ProgramData%\Microsoft\Windows Defender\Support|*.*|RECURSE
 FileKey15=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\AppCache|*.*|RECURSE
 FileKey16=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\INet*|*.*|RECURSE
 FileKey17=%LocalAppData%\Packages\Microsoft.AccountsControl_*\AC\Microsoft\CryptnetUrlCache\*|*.*|RECURSE
@@ -21024,12 +21024,12 @@ RegKey8=HKU\S-1-5-18\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPag
 [Windows Subsystems *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
-FileKey1=%CommonAppData%\Microsoft\RAC\PublishedData|*.log;*.jrs
-FileKey2=%CommonAppData%\Microsoft\RAC\StateData|*.log;*.jrs
-FileKey3=%CommonAppData%\Microsoft\RAC\Temp|*
-FileKey4=%CommonAppData%\Microsoft\Windows\DeviceMetadataCache\dmrccache.bak|*|REMOVESELF
-FileKey5=%CommonAppData%\Microsoft\Windows\Sqm\Manifest|*.bin
-FileKey6=%CommonAppData%\Microsoft\Windows\Sqm\Sessions|*.psqm;*.sqm
+FileKey1=%ProgramData%\Microsoft\RAC\PublishedData|*.log;*.jrs
+FileKey2=%ProgramData%\Microsoft\RAC\StateData|*.log;*.jrs
+FileKey3=%ProgramData%\Microsoft\RAC\Temp|*
+FileKey4=%ProgramData%\Microsoft\Windows\DeviceMetadataCache\dmrccache.bak|*|REMOVESELF
+FileKey5=%ProgramData%\Microsoft\Windows\Sqm\Manifest|*.bin
+FileKey6=%ProgramData%\Microsoft\Windows\Sqm\Sessions|*.psqm;*.sqm
 FileKey7=%Documents%\Remote Assistance Logs|*.xml
 FileKey8=%LocalAppData%\Microsoft\Windows Sidebar\Cache|*|RECURSE
 FileKey9=%LocalAppData%\Microsoft\Windows\AppCache|*|RECURSE
@@ -21106,7 +21106,7 @@ FileKey9=%WinDir%\TEMP|*|REMOVESELF
 [Windows Update *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows
-FileKey1=%CommonAppData%\USOShared\Logs|*.etl|RECURSE
+FileKey1=%ProgramData%\USOShared\Logs|*.etl|RECURSE
 FileKey2=%LocalAppData%\Microsoft\Windows\Windows Anytime Upgrade|Upgrade.log
 FileKey3=%LocalAppData%\MigWiz|*|REMOVESELF
 FileKey4=%LocalAppData%\Packages\MicrosoftWindows.Client.*\AC\AppCache|*|RECURSE
@@ -21244,8 +21244,8 @@ RegKey3=HKCU\Software\WinRAR\General\Info|CommentFile
 
 [WinRemote *]
 LangSecRef=3021
-DetectFile=%CommonAppData%\Banamalon\WinRemoteService
-FileKey1=%CommonAppData%\Banamalon\WinRemoteService\log|*.*
+DetectFile=%ProgramData%\Banamalon\WinRemoteService
+FileKey1=%ProgramData%\Banamalon\WinRemoteService\log|*.*
 
 [WinSetupFromUSB *]
 LangSecRef=3024
@@ -21408,8 +21408,8 @@ ExcludeKey1=FILE|%ProgramFiles%\WolfQuest\|Help.txt
 LangSecRef=3021
 Detect=HKLM\Software\Wondershare
 FileKey1=%AppData%\se_tmp*|*.*|REMOVESELF
-FileKey2=%CommonAppData%\Wondershare\*\*Log*|*.*|RECURSE
-FileKey3=%CommonAppData%\Wondershare\WAF\ProductFeatures\*Logs|*.*|RECURSE
+FileKey2=%ProgramData%\Wondershare\*\*Log*|*.*|RECURSE
+FileKey3=%ProgramData%\Wondershare\WAF\ProductFeatures\*Logs|*.*|RECURSE
 FileKey4=%Public%\Documents\Wondershare|*.*|REMOVESELF
 FileKey5=%UserProfile%\.cache|*.*|REMOVESELF
 
@@ -21417,22 +21417,22 @@ FileKey5=%UserProfile%\.cache|*.*|REMOVESELF
 LangSecRef=3022
 Detect=HKLM\Software\Wondershare\Wondershare AllMyTube
 FileKey1=%AppData%\Wondershare AllMyTube|*.*|RECURSE
-FileKey2=%CommonAppData%\Wondershare AllMyTube\ConvertedLibPic|*.*|RECURSE
-FileKey3=%CommonAppData%\Wondershare Application Common Data\Download|*.bak;*.xml
-FileKey4=%CommonAppData%\Wondershare Application Common Data\Download\MediaLibPic|*.*|RECURSE
-FileKey5=%CommonAppData%\Wondershare Application Common Data\Download\SiteLogo|*.*|RECURSE
-FileKey6=%CommonAppData%\Wondershare Application Common Data\Download\TempThumbDir|*.*|RECURSE
-FileKey7=%CommonAppData%\Wondershare\AllMyTube|*.bak;*.xml
+FileKey2=%ProgramData%\Wondershare AllMyTube\ConvertedLibPic|*.*|RECURSE
+FileKey3=%ProgramData%\Wondershare Application Common Data\Download|*.bak;*.xml
+FileKey4=%ProgramData%\Wondershare Application Common Data\Download\MediaLibPic|*.*|RECURSE
+FileKey5=%ProgramData%\Wondershare Application Common Data\Download\SiteLogo|*.*|RECURSE
+FileKey6=%ProgramData%\Wondershare Application Common Data\Download\TempThumbDir|*.*|RECURSE
+FileKey7=%ProgramData%\Wondershare\AllMyTube|*.bak;*.xml
 FileKey8=%ProgramFiles%\Wondershare\AllMyTube\Log|*.*|RECURSE
 
 [Wondershare Dr.Fone *]
 LangSecRef=3021
 DetectFile=%ProgramFiles%\Wondershare\Wondershare Dr.Fone
 FileKey1=%AppData%\DataEraser_Temp|*.*|RECURSE
-FileKey2=%CommonAppData%\Wondershare\dr.fone\Wondershare_DataEraser_Clean|*.*|RECURSE
-FileKey3=%CommonAppData%\Wondershare\DriverInstall|*.log
-FileKey4=%CommonAppData%\Wondershare\WSRoot|*.tmp
-FileKey5=%CommonAppData%\WsAppHelper\Dr.Fone|*.log
+FileKey2=%ProgramData%\Wondershare\dr.fone\Wondershare_DataEraser_Clean|*.*|RECURSE
+FileKey3=%ProgramData%\Wondershare\DriverInstall|*.log
+FileKey4=%ProgramData%\Wondershare\WSRoot|*.tmp
+FileKey5=%ProgramData%\WsAppHelper\Dr.Fone|*.log
 FileKey6=%ProgramFiles%\Wondershare\MirrorGo\Log|*.*|RECURSE
 
 [Wondershare DVD Creator *]
@@ -21469,7 +21469,7 @@ FileKey7=%AppData%\Wondershare\MobileGo\iOSTemp|*.*|REMOVESELF
 FileKey8=%AppData%\Wondershare\MobileGo\Logs\DeviceConnection|*.*|RECURSE
 FileKey9=%AppData%\Wondershare\MobileTransTool|*.log
 FileKey10=%AppData%\Wondershare\WsRoot\Logs|*.*|RECURSE
-FileKey11=%CommonAppData%\Wondershare\Dr.FoneTool\Log|*.txt
+FileKey11=%ProgramData%\Wondershare\Dr.FoneTool\Log|*.txt
 FileKey12=%ProgramFiles%\Wondershare\MobileGo|*.log
 
 [Wondershare PDF Editor *]
@@ -21480,14 +21480,14 @@ FileKey2=%AppData%\Wondershare\PDF Editor\Log|*.log
 
 [Wondershare Recoverit *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\Wondershare\Recoverit*
-FileKey1=%CommonAppData%\Wondershare\Recoverit*\dataSDK|tmp;*.bak;*.log
-FileKey2=%CommonAppData%\Wondershare\Recoverit*\WGPSDK|*.log
+DetectFile=%ProgramData%\Wondershare\Recoverit*
+FileKey1=%ProgramData%\Wondershare\Recoverit*\dataSDK|tmp;*.bak;*.log
+FileKey2=%ProgramData%\Wondershare\Recoverit*\WGPSDK|*.log
 
 [Wondershare Repairit *]
 LangSecRef=3024
 DetectFile=%ProgramFiles%\Wondershare\Repairit
-FileKey1=%CommonAppData%\Wondershare\Repairit\*SDK|*.bak;*.log;tmp
+FileKey1=%ProgramData%\Wondershare\Repairit\*SDK|*.bak;*.log;tmp
 FileKey2=%ProgramFiles%\Wondershare\Repairit\log|*.*
 
 [Wondershare SafeEraser *]
@@ -21505,9 +21505,9 @@ FileKey7=%SystemDrive%\se_tmp|*.*|REMOVESELF
 LangSecRef=3023
 Detect1=HKLM\Software\Wondershare\Wondershare UniConverter
 Detect2=HKLM\Software\Wondershare\Wondershare UniConverter 13
-FileKey1=%CommonAppData%\Wondershare\UniConverter*\DataTrack|tmp;*.bak;*.log
-FileKey2=%CommonAppData%\Wondershare\UniConverter*\TempThumbDir|*.*|RECURSE
-FileKey3=%CommonAppData%\Wondershare\UniConverter*\UpdatePackge|*.*|RECURSE
+FileKey1=%ProgramData%\Wondershare\UniConverter*\DataTrack|tmp;*.bak;*.log
+FileKey2=%ProgramData%\Wondershare\UniConverter*\TempThumbDir|*.*|RECURSE
+FileKey3=%ProgramData%\Wondershare\UniConverter*\UpdatePackge|*.*|RECURSE
 FileKey4=%ProgramFiles%\Wondershare\*UniConverter*\Log|*.*|RECURSE
 FileKey5=%SystemDrive%|logWSVCUUpdateHelper.log
 FileKey6=%SystemDrive%\Wondershare UniConverter\Downloaded\temp|*.*|REMOVESELF
@@ -21516,9 +21516,9 @@ FileKey6=%SystemDrive%\Wondershare UniConverter\Downloaded\temp|*.*|REMOVESELF
 LangSecRef=3023
 DetectFile1=%ProgramFiles%\Wondershare Video Converter*
 DetectFile2=%ProgramFiles%\Wondershare\Video Converter*
-FileKey1=%CommonAppData%\Wondershare MediaServer|*.txt
-FileKey2=%CommonAppData%\Wondershare Video Converter*|*.dat.bak
-FileKey3=%CommonAppData%\Wondershare Video Converter*\Temp*Dir|*.*|RECURSE
+FileKey1=%ProgramData%\Wondershare MediaServer|*.txt
+FileKey2=%ProgramData%\Wondershare Video Converter*|*.dat.bak
+FileKey3=%ProgramData%\Wondershare Video Converter*\Temp*Dir|*.*|RECURSE
 FileKey4=%Documents%\Wondershare MediaServer\log|*.*|RECURSE
 FileKey5=%ProgramFiles%\Wondershare Video Converter*\Log|*.*|RECURSE
 FileKey6=%ProgramFiles%\Wondershare Video Converter*\Temp*Dir|*.*|RECURSE
@@ -21529,8 +21529,8 @@ FileKey10=%SystemDrive%|logWSVCUUpdateHelper.log
 
 [Wondershare Video Editor *]
 LangSecRef=3023
-DetectFile=%CommonAppData%\Wondershare Video Editor
-FileKey1=%CommonAppData%\Wondershare Video Editor\Resources|Favorites.xml
+DetectFile=%ProgramData%\Wondershare Video Editor
+FileKey1=%ProgramData%\Wondershare Video Editor\Resources|Favorites.xml
 
 [Wordweb *]
 LangSecRef=3021
@@ -21564,8 +21564,8 @@ FileKey3=%LocalAppData%\Microsoft\WorldWideTelescope\tourcache|*.*|RECURSE
 [Wowhead Client *]
 Section=Games
 Detect=HKCU\Software\Wowhead\WowHead Client
-FileKey1=%CommonAppData%\wowhead\wowhead client\cache|*.*|REMOVESELF
-FileKey2=%CommonAppData%\wowhead\wowhead client\log|*.*|REMOVESELF
+FileKey1=%ProgramData%\wowhead\wowhead client\cache|*.*|REMOVESELF
+FileKey2=%ProgramData%\wowhead\wowhead client\log|*.*|REMOVESELF
 RegKey1=HKCU\Software\Wowhead\WowHead Client|Statistics
 
 [WRAL Desktop Alert *]
@@ -21580,8 +21580,8 @@ FileKey1=%AppData%\Ipswitch\WS_FTP\Logs|*.*
 
 [wufuc *]
 LangSecRef=3024
-DetectFile=%CommonAppData%\wufuc
-FileKey1=%CommonAppData%\wufuc|*.log
+DetectFile=%ProgramData%\wufuc
+FileKey1=%ProgramData%\wufuc|*.log
 
 [X-NetStat *]
 LangSecRef=3024
@@ -21662,8 +21662,8 @@ RegKey1=HKCU\Software\Xenocode\SandboxCache
 
 [Xerox Printer Driver *]
 LangSecRef=3021
-DetectFile=%CommonAppData%\Xerox\PrinterDriver
-FileKey1=%CommonAppData%\Xerox\PrinterDriver|*.tmp|RECURSE
+DetectFile=%ProgramData%\Xerox\PrinterDriver
+FileKey1=%ProgramData%\Xerox\PrinterDriver|*.tmp|RECURSE
 
 [Xiaomi *]
 LangSecRef=3021
@@ -21766,8 +21766,8 @@ LangSecRef=3023
 Detect=HKLM\Software\Splitmedialabs\XSplit
 DetectFile=%ProgramFiles%\SplitmediaLabs\XSplit Broadcaster
 FileKey1=%AppData%\SplitMediaLabs\XSplit*|*.log|RECURSE
-FileKey2=%CommonAppData%\SplitMediaLabs\XSplit\LocalStore\Temp|*.*
-FileKey3=%CommonAppData%\SplitMediaLabs\XSplit\Temp|*.*
+FileKey2=%ProgramData%\SplitMediaLabs\XSplit\LocalStore\Temp|*.*
+FileKey3=%ProgramData%\SplitMediaLabs\XSplit\Temp|*.*
 FileKey4=%LocalAppData%\SplitMediaLabs\XSplit\*|bwtestlogs.txt
 FileKey5=%ProgramFiles%\SplitmediaLabs\XSplit Broadcaster\x*|*Log.txt
 
@@ -23229,8 +23229,8 @@ FileKey3=%LocalLowAppData%\Adobe\Acrobat\DC\Search|*.*
 LangSecRef=3023
 Detect=HKLM\Software\Aimersoft\Aimersoft Video Converter Ultimate
 FileKey1=%AppData%\Aimersoft Video Converter Ultimate\Temp|*.*
-FileKey2=%CommonAppData%\Aimersoft Video Converter Ultimate|*.dat.bak
-FileKey3=%CommonAppData%\Aimersoft Video Converter Ultimate\Temp*Dir|*.*
+FileKey2=%ProgramData%\Aimersoft Video Converter Ultimate|*.dat.bak
+FileKey3=%ProgramData%\Aimersoft Video Converter Ultimate\Temp*Dir|*.*
 FileKey4=%CommonProgramFiles%\Aimersoft\Aimersoft Helper Compact\log|*.*|RECURSE
 FileKey5=%LocalAppData%\Aimersoft\ASHelper|*.exe.tmp
 FileKey6=%ProgramFiles%\Aimersoft\Video Converter Ultimate\Log|*.*
@@ -23264,9 +23264,9 @@ FileKey1=%AppData%\Anonymizer\Anonymizer Universal|*.log
 LangSecRef=3024
 Detect1=HKLM\Software\Avira\Speedup
 Detect2=HKLM\Software\AviraSpeedup
-FileKey1=%CommonAppData%\Avira\Launcher\Logfiles|*.log
-FileKey2=%CommonAppData%\Avira\SystemSpeedup\Errors|*.*
-FileKey3=%CommonAppData%\Avira\SystemSpeedup\Logs|*.*
+FileKey1=%ProgramData%\Avira\Launcher\Logfiles|*.log
+FileKey2=%ProgramData%\Avira\SystemSpeedup\Errors|*.*
+FileKey3=%ProgramData%\Avira\SystemSpeedup\Logs|*.*
 FileKey4=%LocalAppData%\AviraSpeedup\logs|*.*
 
 [Camtasia Studio 8 Extras *]
@@ -23338,8 +23338,8 @@ FileKey1=%LocalAppData%\D3DSCache|*.*|RECURSE
 
 [Dr. Watson Extras *]
 LangSecRef=3025
-DetectFile=%CommonAppData%\Microsoft\Dr Watson
-FileKey1=%CommonAppData%\Microsoft\Dr Watson|*.log;*.dmp
+DetectFile=%ProgramData%\Microsoft\Dr Watson
+FileKey1=%ProgramData%\Microsoft\Dr Watson|*.log;*.dmp
 
 [Explorer MRU Extras *]
 LangSecRef=3025
@@ -23367,7 +23367,7 @@ Detect=HKCU\Software\Foxit Software\Foxit Reader 8.0
 FileKey1=%AppData%\Foxit Software\Foxit Reader\Foxit Cloud|foxitcloud.log
 FileKey2=%AppData%\Foxit Software\Foxit Reader\Foxit Cloud\DownloadCache|*.cache
 FileKey3=%AppData%\Foxit Software\Foxit Reader\Foxit Cloud\FileIDCache|*.fcd
-FileKey4=%CommonAppData%\Foxit Software|*.log|RECURSE
+FileKey4=%ProgramData%\Foxit Software|*.log|RECURSE
 FileKey5=%LocalAppData%\Foxit Reader|*_old.DMP
 RegKey1=HKCU\Software\Foxit Software\Foxit Reader 8.0\MRU\File MRU
 RegKey2=HKCU\Software\Foxit Software\Foxit Reader 8.0\MRU\Place MRU
@@ -23613,14 +23613,14 @@ FileKey1=%SystemDrive%|File*.chk
 [Windows Defender Extras *]
 LangSecRef=3024
 Detect=HKLM\Software\Microsoft\Windows Defender
-FileKey1=%CommonAppData%\Microsoft\Windows Defender\Scans\History\Results\Quick|*.*
-FileKey2=%CommonAppData%\Microsoft\Windows Defender\Scans\History\Results\Resource|*.*
+FileKey1=%ProgramData%\Microsoft\Windows Defender\Scans\History\Results\Quick|*.*
+FileKey2=%ProgramData%\Microsoft\Windows Defender\Scans\History\Results\Resource|*.*
 FileKey3=%ProgramFiles%\Microsoft AntiSpyware|errors.log;tracksEraser.log;cleaner.log
 
 [Windows Error Reporting Extras *]
 LangSecRef=3025
 Detect=HKCU\Software\Microsoft\Windows\Windows Error Reporting
-FileKey1=%CommonAppData%\Microsoft\Windows\WER\Temp|*.*|RECURSE
+FileKey1=%ProgramData%\Microsoft\Windows\WER\Temp|*.*|RECURSE
 RegKey1=HKCU\Software\Microsoft\Windows\Windows Error Reporting\Debug|StoreLocation
 RegKey2=HKLM\Software\Microsoft\Windows\Windows Error Reporting\Debug|StoreLocation
 
@@ -23638,7 +23638,7 @@ Detect1=HKCU\Software\Xilisoft\Video Converter Ultimate
 Detect2=HKLM\Software\Xilisoft\Video Converter Platinum
 Detect3=HKLM\Software\Xilisoft\Video Converter Standard
 Detect4=HKLM\Software\Xilisoft\Video Converter Ultimate
-FileKey1=%CommonAppData%\Xilisoft\Video Converter*\customdata|settings.old
+FileKey1=%ProgramData%\Xilisoft\Video Converter*\customdata|settings.old
 RegKey1=HKCU\Software\Xilisoft\Video Converter Platinum\Settings|last_imported_dir
 RegKey2=HKCU\Software\Xilisoft\Video Converter Platinum\Settings|last_openfile_dir
 RegKey3=HKCU\Software\Xilisoft\Video Converter Platinum\Settings|last_openpicture_dir

--- a/Winapp3/Winapp3.ini
+++ b/Winapp3/Winapp3.ini
@@ -1,4 +1,4 @@
-; Version: 230902
+; Version: 230905
 ; # of entries: 855
 ;
 ; Winapp3.ini is fully licensed under the CC-BY-SA-4.0 license agreement. Please refer to our license agreement before using Winapp3.ini: https://github.com/MoscaDotTo/Winapp2/blob/master/Winapp3/License.md
@@ -115,11 +115,11 @@ ExcludeKey1=FILE|%ProgramFiles%\ABBYY FineReader*Sprint\|Readme_English.htm
 
 [Abelssoft Software Languages *]
 Section=Language Files
-DetectFile=%CommonAppData%\Abelssoft
+DetectFile=%ProgramData%\Abelssoft
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\Abelssoft\*\Program\Assets\Languages|*.lang
-ExcludeKey1=FILE|%CommonAppData%\Abelssoft\*\Program\Assets\Languages\|english.lang
-ExcludeKey2=PATH|%CommonAppData%\Abelssoft\*\Program\Assets\Languages\|*.en.lang
+FileKey1=%ProgramData%\Abelssoft\*\Program\Assets\Languages|*.lang
+ExcludeKey1=FILE|%ProgramData%\Abelssoft\*\Program\Assets\Languages\|english.lang
+ExcludeKey2=PATH|%ProgramData%\Abelssoft\*\Program\Assets\Languages\|*.en.lang
 
 [AbiWord Languages *]
 Section=Language Files
@@ -718,10 +718,10 @@ ExcludeKey28=PATH|%ProgramFiles%\Ashampoo\Ashampoo*\Translation\|en-*.nlang*
 
 [ASUS Languages *]
 Section=Language Files
-DetectFile1=%CommonAppData%\OberonGameConsole\Asus
+DetectFile1=%ProgramData%\OberonGameConsole\Asus
 DetectFile2=%ProgramFiles%\ASUS
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\OberonGameConsole\Asus\*|*.resources.dll;*.xml|REMOVESELF
+FileKey1=%ProgramData%\OberonGameConsole\Asus\*|*.resources.dll;*.xml|REMOVESELF
 FileKey2=%ProgramFiles%\ASUS\ASUSUpdate\LangFiles|*.ini|RECURSE
 FileKey3=%ProgramFiles%\ASUS\ASUSUpdate\UpdateChecker\LangFiles|*.ini|RECURSE
 FileKey4=%ProgramFiles%\ASUS\Disk Unlocker\language|*.ini
@@ -731,8 +731,8 @@ ExcludeKey1=FILE|%ProgramFiles%\ASUS\ASUSUpdate\LangFiles\English\|English.ini
 ExcludeKey2=FILE|%ProgramFiles%\ASUS\ASUSUpdate\UpdateChecker\LangFiles\English\|English.ini
 ExcludeKey3=FILE|%ProgramFiles%\ASUS\Disk Unlocker\language\|1033.ini
 ExcludeKey4=FILE|%ProgramFiles%\ASUS\Turbo Key\LangFiles\English\|English.ini
-ExcludeKey5=PATH|%CommonAppData%\OberonGameConsole\Asus\en\|*.resources.dll
-ExcludeKey6=PATH|%CommonAppData%\OberonGameConsole\Asus\en\|*.xml
+ExcludeKey5=PATH|%ProgramData%\OberonGameConsole\Asus\en\|*.resources.dll
+ExcludeKey6=PATH|%ProgramData%\OberonGameConsole\Asus\en\|*.xml
 
 [Atomic Email Hunter Languages *]
 Section=Language Files
@@ -951,17 +951,17 @@ ExcludeKey1=FILE|%ProgramFiles%\BlueSprig\JetClean\language\|English.lng
 
 [Bluestacks Languages *]
 Section=Language Files
-DetectFile=%CommonAppData%\BlueStacks\Client
+DetectFile=%ProgramData%\BlueStacks\Client
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\BlueStacks\CefData\locales|*.pak;*.pak.info
-FileKey2=%CommonAppData%\BlueStacks\Client\Helper\Locales|i18n.*.txt
-FileKey3=%CommonAppData%\BlueStacks\Locales|i18n.*.txt
-FileKey4=%CommonAppData%\BlueStacks\Locales\ProblemCategories|ReportProblemCategories.*.Json
-ExcludeKey1=FILE|%CommonAppData%\BlueStacks\CefData\locales\|en-US.pak
-ExcludeKey2=FILE|%CommonAppData%\BlueStacks\CefData\locales\|en-US.pak.info
-ExcludeKey3=FILE|%CommonAppData%\BlueStacks\Client\Helper\Locales\|i18n.en-US.txt
-ExcludeKey4=FILE|%CommonAppData%\BlueStacks\Locales\|i18n.en-US.txt
-ExcludeKey5=FILE|%CommonAppData%\BlueStacks\Locales\ProblemCategories\|ReportProblemCategories.en-US.Json
+FileKey1=%ProgramData%\BlueStacks\CefData\locales|*.pak;*.pak.info
+FileKey2=%ProgramData%\BlueStacks\Client\Helper\Locales|i18n.*.txt
+FileKey3=%ProgramData%\BlueStacks\Locales|i18n.*.txt
+FileKey4=%ProgramData%\BlueStacks\Locales\ProblemCategories|ReportProblemCategories.*.Json
+ExcludeKey1=FILE|%ProgramData%\BlueStacks\CefData\locales\|en-US.pak
+ExcludeKey2=FILE|%ProgramData%\BlueStacks\CefData\locales\|en-US.pak.info
+ExcludeKey3=FILE|%ProgramData%\BlueStacks\Client\Helper\Locales\|i18n.en-US.txt
+ExcludeKey4=FILE|%ProgramData%\BlueStacks\Locales\|i18n.en-US.txt
+ExcludeKey5=FILE|%ProgramData%\BlueStacks\Locales\ProblemCategories\|ReportProblemCategories.en-US.Json
 
 [Bonjour Languages *]
 Section=Language Files
@@ -1430,10 +1430,10 @@ ExcludeKey2=FILE|%ProgramFiles%\Shutter\Languages\Flags\|us.png
 
 [Devices and Printers Metadata Languages *]
 Section=Language Files
-DetectFile=%CommonAppData%\Microsoft\Windows\DeviceMetadataStore
+DetectFile=%ProgramData%\Microsoft\Windows\DeviceMetadataStore
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\Microsoft\Windows\DeviceMetadataStore|*.devicemetadata-ms|REMOVESELF
-ExcludeKey1=PATH|%CommonAppData%\Microsoft\Windows\DeviceMetadataStore\en*\|*.devicemetadata-ms
+FileKey1=%ProgramData%\Microsoft\Windows\DeviceMetadataStore|*.devicemetadata-ms|REMOVESELF
+ExcludeKey1=PATH|%ProgramData%\Microsoft\Windows\DeviceMetadataStore\en*\|*.devicemetadata-ms
 
 [DevID Agent Languages *]
 Section=Language Files
@@ -1955,7 +1955,7 @@ ExcludeKey1=PATH|%ProgramFiles%\FreeFileSync\Resources\Languages\|english_*.lng
 Section=Language Files
 DetectFile=%ProgramFiles%\Freemake\Freemake Video Converter
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\Freemake\FreemakeUtilsService\ErrorReporter\FMCommon\*|FreemakeCommon.resources.dll|REMOVESELF
+FileKey1=%ProgramData%\Freemake\FreemakeUtilsService\ErrorReporter\FMCommon\*|FreemakeCommon.resources.dll|REMOVESELF
 FileKey2=%CommonProgramFiles%\Freemake Shared\ProductUpdater\*|*.resources.dll
 FileKey3=%ProgramFiles%\Freemake\Freemake Video Converter\FMCommon\*|FreemakeCommon.resources.dll|REMOVESELF
 FileKey4=%ProgramFiles%\Freemake\Freemake Video Converter\FreemakeVideoConverter\Languages|*.dll|REMOVESELF
@@ -2178,20 +2178,20 @@ ExcludeKey2=FILE|%ProgramFiles%\HotVirtualKeyboard\Lang\|en.txt
 
 [HP Languages *]
 Section=Language Files
-DetectFile1=%CommonAppData%\HP\HP*
+DetectFile1=%ProgramData%\HP\HP*
 DetectFile2=%ProgramFiles%\HP\HP*
 DetectFile3=%SystemDrive%\HP
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\HP\HP*\HPUDC\MoreInfo|*.htm
-FileKey2=%CommonAppData%\HP\HP*\Installer\Help|HP_Setup_Help.chm|REMOVESELF
+FileKey1=%ProgramData%\HP\HP*\HPUDC\MoreInfo|*.htm
+FileKey2=%ProgramData%\HP\HP*\Installer\Help|HP_Setup_Help.chm|REMOVESELF
 FileKey3=%ProgramFiles%\HP\HP*\Bin\UDC_Files|localize_*.json
 FileKey4=%ProgramFiles%\HP\HP*\Bin\UDC_Files\OfflineStatement|*.htm
 FileKey5=%ProgramFiles%\HP\HP*\data\chms|*.chm
 FileKey6=%ProgramFiles%\HP\HP*\data\ini|*.ini
 FileKey7=%SystemDrive%\HP\Diagnostics\PSDR\help|*.chm|REMOVESELF
 FileKey8=%SystemDrive%\HP\Diagnostics\PSDR\Strings|*.xaml
-ExcludeKey1=FILE|%CommonAppData%\HP\HP*\HPUDC\MoreInfo\|1033.htm
-ExcludeKey2=FILE|%CommonAppData%\HP\HP*\Installer\Help\1033\|HP_Setup_Help.chm
+ExcludeKey1=FILE|%ProgramData%\HP\HP*\HPUDC\MoreInfo\|1033.htm
+ExcludeKey2=FILE|%ProgramData%\HP\HP*\Installer\Help\1033\|HP_Setup_Help.chm
 ExcludeKey3=FILE|%ProgramFiles%\HP\HP*\Bin\UDC_Files\|localize_1033.json
 ExcludeKey4=FILE|%ProgramFiles%\HP\HP*\Bin\UDC_Files\OfflineStatement\|1033.htm
 ExcludeKey5=FILE|%SystemDrive%\HP\Diagnostics\PSDR\Strings\|1033.xaml
@@ -2608,17 +2608,17 @@ ExcludeKey6=PATH|%ProgramFiles%\Kaspersky Lab\Kaspersky Password Manager*\resour
 
 [Kerish Doctor Languages *]
 Section=Language Files
-DetectFile=%CommonAppData%\Kerish Products\Kerish Doctor
+DetectFile=%ProgramData%\Kerish Products\Kerish Doctor
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\Kerish Products\Kerish Doctor\Help|*.chm
-FileKey2=%CommonAppData%\Kerish Products\Kerish Doctor\Locale|*.lng
-FileKey3=%CommonAppData%\Kerish Products\Kerish Doctor\Resources\*|*.png;*.wav|REMOVESELF
+FileKey1=%ProgramData%\Kerish Products\Kerish Doctor\Help|*.chm
+FileKey2=%ProgramData%\Kerish Products\Kerish Doctor\Locale|*.lng
+FileKey3=%ProgramData%\Kerish Products\Kerish Doctor\Resources\*|*.png;*.wav|REMOVESELF
 FileKey4=%ProgramFiles%\Kerish Doctor\Help|*.chm
-ExcludeKey1=FILE|%CommonAppData%\Kerish Products\Kerish Doctor\Help\|English.chm
-ExcludeKey2=FILE|%CommonAppData%\Kerish Products\Kerish Doctor\Locale\|English.lng
+ExcludeKey1=FILE|%ProgramData%\Kerish Products\Kerish Doctor\Help\|English.chm
+ExcludeKey2=FILE|%ProgramData%\Kerish Products\Kerish Doctor\Locale\|English.lng
 ExcludeKey3=FILE|%ProgramFiles%\Kerish Doctor\Help\|English.chm
-ExcludeKey4=PATH|%CommonAppData%\Kerish Products\Kerish Doctor\Resources\English\|*.png
-ExcludeKey5=PATH|%CommonAppData%\Kerish Products\Kerish Doctor\Resources\English\|*.wav
+ExcludeKey4=PATH|%ProgramData%\Kerish Products\Kerish Doctor\Resources\English\|*.png
+ExcludeKey5=PATH|%ProgramData%\Kerish Products\Kerish Doctor\Resources\English\|*.wav
 
 [Keynote Languages *]
 Section=Language Files
@@ -3137,7 +3137,7 @@ ExcludeKey1=FILE|%ProgramFiles%\Mz Ultimate Tools\Mz Ultimate Cleaner\Languages\
 Section=Language Files
 DetectFile=%ProgramFiles%\Nero\Nero*
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\Nero\Nero*\OnlineServices\PushMarketingFeeds|offline-*.xml
+FileKey1=%ProgramData%\Nero\Nero*\OnlineServices\PushMarketingFeeds|offline-*.xml
 FileKey2=%CommonProgramFiles%\Nero\AdvrCntr*|Eula_*.rtf
 FileKey3=%CommonProgramFiles%\Nero\Nero BackItUp*|NBRes-*.nls
 FileKey4=%ProgramFiles%\Nero\Nero Common\AdvrCntr*|Eula_Nero_*.rtf
@@ -3147,7 +3147,7 @@ FileKey7=%ProgramFiles%\Nero\Nero*\Nero Burning ROM\ShellRes\*|shellres.dll.mui|
 FileKey8=%ProgramFiles%\Nero\Nero*\Nero BurnLite|NSSModelResources_*.nls;StartSmart_*.nls
 FileKey9=%ProgramFiles%\Nero\Nero*\Nero BurnLite\html|nss_kc_*.html
 FileKey10=%ProgramFiles%\Nero\Nero*\Nero BurnLite\NeroAPIFiles|Nero_*.xml
-ExcludeKey1=FILE|%CommonAppData%\Nero\Nero*\OnlineServices\PushMarketingFeeds\|offline-ENG.xml
+ExcludeKey1=FILE|%ProgramData%\Nero\Nero*\OnlineServices\PushMarketingFeeds\|offline-ENG.xml
 ExcludeKey2=FILE|%ProgramFiles%\Nero\Nero*\Nero Burning ROM\ShellRes\en-*\|shellres.dll.mui
 ExcludeKey3=FILE|%ProgramFiles%\Nero\Nero*\Nero BurnLite\NeroAPIFiles\|nero_dev.xml
 ExcludeKey4=PATH|%CommonProgramFiles%\Nero\AdvrCntr*\|Eula_*_ENG.rtf
@@ -3193,10 +3193,10 @@ ExcludeKey2=PATH|%ProgramFiles%\Nero\Nero Launcher\locales\|en-*.pak
 Section=Language Files
 DetectFile=%ProgramFiles%\Nero\Nero TuneItUp
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\Nero\Nero TuneItUp|usertips_*.xml
+FileKey1=%ProgramData%\Nero\Nero TuneItUp|usertips_*.xml
 FileKey2=%ProgramFiles%\Nero\Nero TuneItUp|product_*.cfg
 FileKey3=%ProgramFiles%\Nero\Nero TuneItUp\language|Texts_*.ini
-ExcludeKey1=FILE|%CommonAppData%\Nero\Nero TuneItUp\|usertips_EN.xml
+ExcludeKey1=FILE|%ProgramData%\Nero\Nero TuneItUp\|usertips_EN.xml
 ExcludeKey2=FILE|%ProgramFiles%\Nero\Nero TuneItUp\|product_en.cfg
 ExcludeKey3=FILE|%ProgramFiles%\Nero\Nero TuneItUp\language\|Texts_EN.ini
 
@@ -3262,17 +3262,17 @@ Section=Language Files
 Detect=HKLM\Software\NVIDIA Corporation\Global\GFEClient
 DetectFile=%ProgramFiles%\NVIDIA Corporation\LED Visualizer
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\NVIDIA Corporation\Downloader\latest\GFExperience|FunctionalConsent_*.txt
-FileKey2=%CommonAppData%\NVIDIA Corporation\Downloader\latest\GFExperience\locales|*.pak
-FileKey3=%CommonAppData%\NVIDIA Corporation\Downloader\latest\GFExperience\PrivacyPolicy|PrivacyPolicy_*.htm
+FileKey1=%ProgramData%\NVIDIA Corporation\Downloader\latest\GFExperience|FunctionalConsent_*.txt
+FileKey2=%ProgramData%\NVIDIA Corporation\Downloader\latest\GFExperience\locales|*.pak
+FileKey3=%ProgramData%\NVIDIA Corporation\Downloader\latest\GFExperience\PrivacyPolicy|PrivacyPolicy_*.htm
 FileKey4=%ProgramFiles%\NVIDIA Corporation\Installer2\Display.GFExperience*\*|GFExperience*.resources.dll|REMOVESELF
 FileKey5=%ProgramFiles%\NVIDIA Corporation\Installer2\GFExperience.LEDVisualizer*\*|NvLedVisualizer*.resources.dll|REMOVESELF
 FileKey6=%ProgramFiles%\NVIDIA Corporation\LED Visualizer\*|NvLedVisualizer*.resources.dll|REMOVESELF
 FileKey7=%ProgramFiles%\NVIDIA Corporation\NVIDIA GeForce Experience\*|GFExperience*.resources.dll|REMOVESELF
 FileKey8=%ProgramFiles%\NVIDIA Corporation\NVIDIA GeForce Experience\locales|*.pak
-ExcludeKey1=PATH|%CommonAppData%\NVIDIA Corporation\Downloader\latest\GFExperience\|FunctionalConsent_en-*.txt
-ExcludeKey2=PATH|%CommonAppData%\NVIDIA Corporation\Downloader\latest\GFExperience\locales\|en-*.pak
-ExcludeKey3=PATH|%CommonAppData%\NVIDIA Corporation\Downloader\latest\GFExperience\PrivacyPolicy\|PrivacyPolicy_en-*.htm
+ExcludeKey1=PATH|%ProgramData%\NVIDIA Corporation\Downloader\latest\GFExperience\|FunctionalConsent_en-*.txt
+ExcludeKey2=PATH|%ProgramData%\NVIDIA Corporation\Downloader\latest\GFExperience\locales\|en-*.pak
+ExcludeKey3=PATH|%ProgramData%\NVIDIA Corporation\Downloader\latest\GFExperience\PrivacyPolicy\|PrivacyPolicy_en-*.htm
 ExcludeKey4=PATH|%ProgramFiles%\NVIDIA Corporation\Installer2\Display.GFExperience*\en-*\|GFExperience*.resources.dll
 ExcludeKey5=PATH|%ProgramFiles%\NVIDIA Corporation\Installer2\GFExperience.LEDVisualizer*\en-*\|NvLedVisualizer*.resources.dll
 ExcludeKey6=PATH|%ProgramFiles%\NVIDIA Corporation\LED Visualizer\en-*\|NvLedVisualizer*.resources.dll
@@ -3362,13 +3362,13 @@ ExcludeKey1=FILE|%ProgramFiles%\Clean Disk Free*\languages\|english.txt
 Section=Language Files
 DetectFile=%ProgramFiles%\Origin
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\Origin\SelfUpdate\Staged\support\Privacy and Cookie Policy|WEBPRIVACY_*.html
-FileKey2=%CommonAppData%\Origin\SelfUpdate\Staged\support\User Agreement|WEBTERMS_*.html
+FileKey1=%ProgramData%\Origin\SelfUpdate\Staged\support\Privacy and Cookie Policy|WEBPRIVACY_*.html
+FileKey2=%ProgramData%\Origin\SelfUpdate\Staged\support\User Agreement|WEBTERMS_*.html
 FileKey3=%ProgramFiles%\Origin\legacyPM\lang|*.xml
 FileKey4=%ProgramFiles%\Origin\support\Privacy and Cookie Policy|WEBPRIVACY_*.html
 FileKey5=%ProgramFiles%\Origin\support\User Agreement|WEBTERMS_*.html
-ExcludeKey1=PATH|%CommonAppData%\Origin\SelfUpdate\Staged\support\Privacy and Cookie Policy\|WEBPRIVACY_*_en_*.html
-ExcludeKey2=PATH|%CommonAppData%\Origin\SelfUpdate\Staged\support\User Agreement\|WEBTERMS_*_en_*.html
+ExcludeKey1=PATH|%ProgramData%\Origin\SelfUpdate\Staged\support\Privacy and Cookie Policy\|WEBPRIVACY_*_en_*.html
+ExcludeKey2=PATH|%ProgramData%\Origin\SelfUpdate\Staged\support\User Agreement\|WEBTERMS_*_en_*.html
 ExcludeKey3=PATH|%ProgramFiles%\Origin\legacyPM\lang\|*Strings_en_*.xml
 ExcludeKey4=PATH|%ProgramFiles%\Origin\support\Privacy and Cookie Policy\|WEBPRIVACY_*_en_*.html
 ExcludeKey5=PATH|%ProgramFiles%\Origin\support\User Agreement\|WEBTERMS_*_en_*.html
@@ -4855,8 +4855,8 @@ ExcludeKey1=PATH|%ProgramFiles%\VMLite\VMLite Workstation\nls\|*_en.qm
 Section=Language Files
 Detect=HKLM\Software\VMware, Inc.
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\VMware\vnckeymap|*
-ExcludeKey1=FILE|%CommonAppData%\VMware\vnckeymap\|us
+FileKey1=%ProgramData%\VMware\vnckeymap|*
+ExcludeKey1=FILE|%ProgramData%\VMware\vnckeymap\|us
 
 [Volume2 Languages *]
 Section=Language Files
@@ -4896,8 +4896,8 @@ FileKey2=%ProgramFiles%\VSDC VideoEditor\Localizations|*.dll
 Section=Language Files
 Detect=HKCU\Software\VSO\ConvertXtoDVD\5
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\VSO\ConvertXToDVD\5\Lang|*.ini;*.png
-ExcludeKey1=PATH|%CommonAppData%\VSO\ConvertXToDVD\5\Lang\|*_English.*
+FileKey1=%ProgramData%\VSO\ConvertXToDVD\5\Lang|*.ini;*.png
+ExcludeKey1=PATH|%ProgramData%\VSO\ConvertXToDVD\5\Lang\|*_English.*
 
 [Wargaming.net GameCenter Languages *]
 Section=Language Files
@@ -5104,10 +5104,10 @@ ExcludeKey6=PATH|%ProgramFiles%\WinZip\en-US\|*.mui
 
 [WinZip Registry Optimizer Languages *]
 Section=Language Files
-DetectFile=%CommonAppData%\WinZip\WinZip Registry Optimizer
+DetectFile=%ProgramData%\WinZip\WinZip Registry Optimizer
 Warning=This will delete all languages excluding English.
-FileKey1=%CommonAppData%\WinZip\WinZip Registry Optimizer\Language|*.xml
-ExcludeKey1=FILE|%CommonAppData%\WinZip\WinZip Registry Optimizer\Language\|English.xml
+FileKey1=%ProgramData%\WinZip\WinZip Registry Optimizer\Language|*.xml
+ExcludeKey1=FILE|%ProgramData%\WinZip\WinZip Registry Optimizer\Language\|English.xml
 
 [Wipe Languages *]
 Section=Language Files
@@ -5388,9 +5388,9 @@ FileKey2=%UserProfile%\Desktop\Adobe Acrobat\Adobe Acrobat|AcrobatDCUpd*.msp
 Section=Dangerous Applications
 Detect=HKLM\Software\Adobe\Acrobat Reader
 Warning=This will prevent a repair installation and successful online updates. You will need to download the installer for a reinstallation.
-FileKey1=%CommonAppData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AA1000000001}|*.*|RECURSE
-FileKey2=%CommonAppData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AB0000000001}|*.*|RECURSE
-FileKey3=%CommonAppData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AC0F074E4100}|*.*|RECURSE
+FileKey1=%ProgramData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AA1000000001}|*.*|RECURSE
+FileKey2=%ProgramData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AB0000000001}|*.*|RECURSE
+FileKey3=%ProgramData%\Adobe\Setup\{AC76BA86-7AD7-*-7B44-AC0F074E4100}|*.*|RECURSE
 FileKey4=%ProgramFiles%\Adobe\*Reader*\Setup Files|*.*|REMOVESELF
 
 [Agent NewsReader *]
@@ -5467,8 +5467,8 @@ FileKey1=%Documents%\Any Video Converter|*.*|RECURSE
 Section=Dangerous Multimedia
 Detect=HKCU\Software\Apple Computer, Inc.
 Warning=You have to reinstall iTunes after adding a new Windows user account.
-FileKey1=%CommonAppData%\Apple Computer\Installer Cache|*.*|REMOVESELF
-FileKey2=%CommonAppData%\Apple\Installer Cache|*.*|REMOVESELF
+FileKey1=%ProgramData%\Apple Computer\Installer Cache|*.*|REMOVESELF
+FileKey2=%ProgramData%\Apple\Installer Cache|*.*|REMOVESELF
 
 [Apple iPhone Updater Logs *]
 Section=Dangerous Multimedia
@@ -5495,8 +5495,8 @@ Detect2=HKCU\Software\The Silicon Realms Toolworks\Armadillo
 Detect3=HKLM\Software\Licenses
 Detect4=HKLM\Software\The Silicon Realms Toolworks\Armadillo
 Warning=This will remove Armadillo software protection. The programs protected by this tool will continue to function as usual.
-FileKey1=%CommonAppData%\Licenses|*.Lic
-FileKey2=%CommonAppData%\Logs|*.license.log
+FileKey1=%ProgramData%\Licenses|*.Lic
+FileKey2=%ProgramData%\Logs|*.license.log
 RegKey1=HKCU\Software\Licenses
 RegKey2=HKCU\Software\The Silicon Realms Toolworks\Armadillo
 RegKey3=HKLM\Software\Licenses
@@ -5541,7 +5541,7 @@ FileKey1=%ProgramFiles%\BleachBit|bleachbit_console.exe
 Section=Dangerous Applications
 Detect1=HKCU\Software\BlueStacks
 Detect2=HKLM\Software\BlueStacks
-FileKey1=%CommonAppData%\BlueStacks\UserData\SharedFolder|*.*
+FileKey1=%ProgramData%\BlueStacks\UserData\SharedFolder|*.*
 
 [Brave Indexed Database Extended *]
 Section=Dangerous Brave
@@ -5849,9 +5849,9 @@ RegKey2=HKLM\System\CurrentControlSet\Services\dam\UserSettings
 
 [DivX License Text Files *]
 Section=Dangerous Multimedia
-DetectFile1=%CommonAppData%\DivX
+DetectFile1=%ProgramData%\DivX
 DetectFile2=%ProgramFiles%\DivX
-FileKey1=%CommonAppData%\DivX\Setup\EULAs|*.*|REMOVESELF
+FileKey1=%ProgramData%\DivX\Setup\EULAs|*.*|REMOVESELF
 FileKey2=%ProgramFiles%\DivX\Licenses|*.txt|REMOVESELF
 
 [Dolphin Emulator Dumps *]
@@ -6125,19 +6125,19 @@ RegKey1=HKCU\Software\Microsoft\Internet Explorer\Main\FeatureControl
 Section=Dangerous Utilities
 Detect=HKLM\Software\IObit\Driver Booster
 Warning=This will delete your Driver Backups. This is just needed, if your current driver is unstable and you have to back it up.
-FileKey1=%CommonAppData%\IObit\Driver Booster\Backups|*.*|RECURSE
+FileKey1=%ProgramData%\IObit\Driver Booster\Backups|*.*|RECURSE
 
 [IObit Driver Booster Download *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\IObit\Driver Booster
 Warning=This will delete your Downloads. You will have to download again.
-FileKey1=%CommonAppData%\IObit\Driver Booster\Download|*.*|RECURSE
+FileKey1=%ProgramData%\IObit\Driver Booster\Download|*.*|RECURSE
 
 [IObit Game Booster Backups *]
 Section=Dangerous Utilities
 DetectFile=%ProgramFiles%\IObit\Game Booster 3
 Warning=This will delete your GameBox applications.
-FileKey1=%CommonAppData%\IObit\Game Booster 3|TweaksBackup.reg
+FileKey1=%ProgramData%\IObit\Game Booster 3|TweaksBackup.reg
 
 [iTunes Previous Libraries *]
 Section=Dangerous Multimedia
@@ -6247,7 +6247,7 @@ FileKey1=%LocalAppData%\Packages\microsoft.windowscommunicationsapps_*\LocalStat
 Section=Dangerous Applications
 Detect=HKLM\Software\Microsoft\Microsoft Antimalware
 Warning=This will make it impossible to rollback to a previous definition file.
-FileKey1=%CommonAppData%\Microsoft\Microsoft Antimalware\Definition Updates\Backup|*.*|RECURSE
+FileKey1=%ProgramData%\Microsoft\Microsoft Antimalware\Definition Updates\Backup|*.*|RECURSE
 
 [Minecraft Screenshots *]
 Section=Dangerous Games
@@ -6275,7 +6275,7 @@ Section=Dangerous Applications
 Detect1=HKCU\Software\Microsoft\Office\15.0
 Detect2=HKCU\Software\Microsoft\Office\16.0
 Warning=This can remove downloaded update files even before they are applied.
-FileKey1=%CommonAppData%\Microsoft\ClickToRun\ProductReleases|*.*|RECURSE
+FileKey1=%ProgramData%\Microsoft\ClickToRun\ProductReleases|*.*|RECURSE
 
 [MS Office License Text Files *]
 Section=Dangerous Applications
@@ -6293,17 +6293,17 @@ FileKey1=%AppData%\Microsoft\Office|ACCESS*.PIP;Excel*.pip;MSOut*.pip;PowerP*.pi
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft\Windows
 Warning=Use only in Windows Safe Mode.
-FileKey1=%CommonAppData%\Microsoft\Search\Data\Applications\Windows|*.chk;*.jrs
-FileKey2=%CommonAppData%\Microsoft\Search\Data\Applications\Windows\Projects\SystemIndex\Indexer\CiFiles|*.*
-FileKey3=%CommonAppData%\Microsoft\Search\Data\Applications\Windows\Projects\SystemIndex\PropMap|*.*|RECURSE
-FileKey4=%CommonAppData%\Microsoft\Search\Data\Applications\Windows\Projects\SystemIndex\SecStore|*.*|RECURSE
+FileKey1=%ProgramData%\Microsoft\Search\Data\Applications\Windows|*.chk;*.jrs
+FileKey2=%ProgramData%\Microsoft\Search\Data\Applications\Windows\Projects\SystemIndex\Indexer\CiFiles|*.*
+FileKey3=%ProgramData%\Microsoft\Search\Data\Applications\Windows\Projects\SystemIndex\PropMap|*.*|RECURSE
+FileKey4=%ProgramData%\Microsoft\Search\Data\Applications\Windows\Projects\SystemIndex\SecStore|*.*|RECURSE
 RegKey1=HKLM\Software\Microsoft\Windows Search\VolumeInfoCache
 
 [MS Search Index *]
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft\Windows
 Warning=Use only in Windows Safe Mode. This forces the search index to be rebuilt.
-FileKey1=%CommonAppData%\Microsoft\Search\Data\Applications\Windows|Windows.edb
+FileKey1=%ProgramData%\Microsoft\Search\Data\Applications\Windows|Windows.edb
 
 [MSConfig *]
 Section=Dangerous Windows
@@ -6755,9 +6755,9 @@ FileKey2=%AppData%\Teeworlds\Screenshots|*.*|REMOVESELF
 
 [Temporary Folder Common *]
 Section=Dangerous Applications
-DetectFile=%CommonAppData%\TEMP
+DetectFile=%ProgramData%\TEMP
 Warning=This will remove all files under "C:\ProgramData\Temp" folder.
-FileKey1=%CommonAppData%\TEMP|*.*|RECURSE
+FileKey1=%ProgramData%\TEMP|*.*|RECURSE
 
 [Temporary Folder Root *]
 Section=Dangerous Applications
@@ -6854,14 +6854,14 @@ FileKey1=%WinDir%\CbsTemp|*.*|REMOVESELF
 Section=Dangerous Utilities
 Detect=HKLM\Software\Microsoft\Windows Defender
 Warning=This will make it impossible to rollback to a previous definition file.
-FileKey1=%CommonAppData%\Microsoft\Windows Defender\Definition Updates\*Backup|*.*|RECURSE
-FileKey2=%CommonAppData%\Microsoft\Windows Defender\LocalCopy|*.*|RECURSE
+FileKey1=%ProgramData%\Microsoft\Windows Defender\Definition Updates\*Backup|*.*|RECURSE
+FileKey2=%ProgramData%\Microsoft\Windows Defender\LocalCopy|*.*|RECURSE
 
 [Windows Defender Extended *]
 Section=Dangerous Utilities
 Detect=HKLM\Software\Microsoft\Windows Defender
-FileKey1=%CommonAppData%\Microsoft\Windows Defender\Scans|*.bin*
-FileKey2=%CommonAppData%\Microsoft\Windows Defender\Scans\History\ReportLatency\Latency|*.*|RECURSE
+FileKey1=%ProgramData%\Microsoft\Windows Defender\Scans|*.bin*
+FileKey2=%ProgramData%\Microsoft\Windows Defender\Scans\History\ReportLatency\Latency|*.*|RECURSE
 
 [Windows Driver Enterprise Library Temps *]
 Section=Dangerous Windows
@@ -6949,7 +6949,7 @@ DetectOS=10.0|
 Section=Dangerous Windows
 Detect=HKCU\Software\Microsoft\Windows
 Warning=Use only in Windows Safe Mode.
-FileKey1=%CommonAppData%\Microsoft\Windows\Caches|*.*|RECURSE
+FileKey1=%ProgramData%\Microsoft\Windows\Caches|*.*|RECURSE
 FileKey2=%LocalAppData%\Microsoft\Windows\Caches|*.*|RECURSE
 
 [Windows System Volume Tracking Logs *]


### PR DESCRIPTION
The environment variable `%CommonAppData%` was apparently replaced by the variable `%ProgramData%` after the big overhaul.

_Originally posted by @APMichael in https://github.com/MoscaDotTo/Winapp2/issues/948#issuecomment-2144679075_

`%CommonAppData%` no longer exists in modern Windows builds. Let's not leave out Winapp3 and Non-CCleaner variants, they haven't been working properly as a result.