### PR TITLE
Update Winapp2.ini

### DIFF
--- a/Non-CCleaner/Winapp2.ini
+++ b/Non-CCleaner/Winapp2.ini
@@ -23493,7 +23493,7 @@ RegKey9=HKCU\Software\Nero\Nero 12\Nero Express\Settings|WorkingDir
 RegKey10=HKCU\Software\Nero\Nero 12\Nero WaveEditor\Recent File List
 
 [NVIDIA Install Files Extras *]
-LangSecRef=3024	
+LangSecRef=3024
 Detect=HKCU\Software\NVIDIA Corporation
 FileKey1=%SystemDrive%\Nvidia|*.*|REMOVESELF
 


### PR DESCRIPTION
Small change, because this made the parser recognize wrong: Instead of:
LangSecRef=3024

It recognized
LangSecRef=3024 (with empty space after).