### PR TITLE
Added cleaning of old files for Composer dependency manager for PHP

### DIFF
--- a/Assembler/Entries/C.ini
+++ b/Assembler/Entries/C.ini
@@ -718,6 +718,14 @@ LangSecRef=3024
 DetectFile=%AppData%\Rizonesoft\ComIntRep
 FileKey1=%AppData%\Rizonesoft\ComIntRep\Logging|*|RECURSE
 
+[Composer Dependency Manager for PHP *]
+LangSecRef=3024
+DetectFile=%ProgramData%\ComposerSetup\bin\composer.phar
+FileKey1=%AppData%\Composer|*-old.phar
+FileKey2=%LocalAppData%\Composer\files|*|REMOVESELF
+FileKey3=%LocalAppData%\Composer\repo|*|REMOVESELF
+FileKey4=%LocalAppData%\Composer\vcs|*|REMOVESELF
+
 [Conceiva Mezzmo *]
 LangSecRef=3023
 Detect=HKLM\Software\Conceiva\Mezzmo


### PR DESCRIPTION
Added cleanup of old files for the Composer dependency manager for PHP:

1. Old PHAR files of Composer (https://getcomposer.org)
2. Caches

<details>
  <summary>Screenshoots</summary>
<img width="1172" height="647" alt="image" src="https://github.com/user-attachments/assets/a4370eff-8d7e-4277-940c-a2c365f6a050" />
<img width="1172" height="648" alt="image" src="https://github.com/user-attachments/assets/4035364f-2e9d-48f7-bae8-d5dda7e06928" />
<img width="1172" height="652" alt="image" src="https://github.com/user-attachments/assets/8f1f4ebc-b94a-4bbc-a51d-0213dfa699bf" />
</details>
